### PR TITLE
execute transaction without waiting for it to be mined.

### DIFF
--- a/src/main/java/org/web3j/abi/Contract.java
+++ b/src/main/java/org/web3j/abi/Contract.java
@@ -129,6 +129,35 @@ public abstract class Contract extends ManagedTransaction {
 
         return signAndSend(rawTransaction);
     }
+    
+    /**
+     * Given the duration required to execute a transaction, asyncronous execution is strongly
+     * recommended via {@link Contract#executeTransactionAsync}.
+     * This executes the transaction and waits for the transaction to be processed by the node, but does not wait for the transaction receipt (i.e. the transaction getting mined) 
+     *
+     * @param function to transact with
+     * @return Transaction hash
+     * @throws ExecutionException if the computation threw an
+     * exception
+     * @throws InterruptedException if the current thread was interrupted
+     * while waiting
+     * @throws TransactionTimeoutException if the transaction was not processed while waiting
+     */
+    protected TransactionReceipt executeTransactionWithoutWaiting(
+            Function function) throws ExecutionException, InterruptedException,
+            TransactionTimeoutException {
+        BigInteger nonce = getNonce(credentials.getAddress());
+        String encodedFunction = FunctionEncoder.encode(function);
+
+        RawTransaction rawTransaction = RawTransaction.createFunctionCallTransaction(
+                nonce,
+                GAS_PRICE,
+                GAS_LIMIT,
+                contractAddress,
+                encodedFunction);
+
+        return signAndSendWithoutReceipt(rawTransaction);
+    }
 
     /**
      * Execute the provided function as a transaction asynchronously.

--- a/src/main/java/org/web3j/abi/Contract.java
+++ b/src/main/java/org/web3j/abi/Contract.java
@@ -143,7 +143,7 @@ public abstract class Contract extends ManagedTransaction {
      * while waiting
      * @throws TransactionTimeoutException if the transaction was not processed while waiting
      */
-    protected TransactionReceipt executeTransactionWithoutWaiting(
+    protected String executeTransactionWithoutWaiting(
             Function function) throws ExecutionException, InterruptedException,
             TransactionTimeoutException {
         BigInteger nonce = getNonce(credentials.getAddress());

--- a/src/main/java/org/web3j/abi/ManagedTransaction.java
+++ b/src/main/java/org/web3j/abi/ManagedTransaction.java
@@ -46,6 +46,20 @@ public abstract class ManagedTransaction {
 
         return waitForTransactionReceipt(transactionHash);
     }
+    
+    protected String signAndSendWithoutReceipt(RawTransaction rawTransaction)
+            throws InterruptedException, ExecutionException, TransactionTimeoutException{
+        byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
+        String hexValue = Numeric.toHexString(signedMessage);
+
+        // This might be a good candidate for using functional composition with CompletableFutures
+        EthSendTransaction transactionResponse = web3j.ethSendRawTransaction(hexValue)
+                .sendAsync().get();
+
+        String transactionHash = transactionResponse.getTransactionHash();
+
+        return transactionHash;
+    }
 
     protected BigInteger getNonce(String address) throws InterruptedException, ExecutionException {
         EthGetTransactionCount ethGetTransactionCount = web3j.ethGetTransactionCount(


### PR DESCRIPTION
Hi Conor,

first of all, I have to say that I am not used to working with github or gradle and dont know the entire web3j code. I couldn't get the fork to properly work in my eclipse workspace, so unfortunately I couldn't test it either. So this pull request is more a crude suggestion, than a proper contribution, please DONT merge it blindly without checking it, sorry about that. 

I am playing around with the live network through infura and it takes forever for transactions to get mined (like several minutes). That itself is not really a problem for me, but I dont want to wait that long to get the transaction hash. Right now Contract.executeTransactionAsync(Function function) seems to be doing two things: (1) it sends the transaction async and waits for the response from the node in the form of a transaction hash and (2) it waits for the transaction to get mined by repeatedly requesting a transaction receipt for that transaction hash.
Basically, I am looking for a way to only do (1). I cant override the function properly, because its using private fields (GAS_PRICE, GAS_LIMIT, and contractAddress). I have already figured out how to do (2) on my own and want to check for the transaction receipt at my own/the users discretion.

Do you think something like that is possible?
Max