### PR TITLE
Allow leading zeros when parsing hex strings.

### DIFF
--- a/src/main/java/org/web3j/utils/Numeric.java
+++ b/src/main/java/org/web3j/utils/Numeric.java
@@ -51,10 +51,6 @@ public final class Numeric {
             return false;
         }
 
-        if (value.length() > 3 && value.charAt(2) == '0') {
-            return false;
-        }
-
         return true;
     }
 

--- a/src/test/java/org/web3j/utils/NumericTest.java
+++ b/src/test/java/org/web3j/utils/NumericTest.java
@@ -44,14 +44,15 @@ public class NumericTest {
                 equalTo(new BigInteger("204516877000845695339750056077105398031")));
     }
 
-    @Test(expected = MessageDecodingException.class)
-    public void testQuantityDecodeMissingPrefix() {
-        Numeric.decodeQuantity("ff");
+    @Test
+    public void testQuantityDecodeLeadingZero() {
+        assertThat(Numeric.decodeQuantity("0x0400"), equalTo(BigInteger.valueOf(1024L)));
+        assertThat(Numeric.decodeQuantity("0x001"), equalTo(BigInteger.valueOf(1L)));
     }
 
     @Test(expected = MessageDecodingException.class)
-    public void testQuantityDecodeLeadingZero() {
-        Numeric.decodeQuantity("0x0400");
+    public void testQuantityDecodeMissingPrefix() {
+        Numeric.decodeQuantity("ff");
     }
 
     @Test(expected = MessageDecodingException.class)


### PR DESCRIPTION
Currently Numeric.decodeQuanitity will fail if called with a hex value with a leading zero, such as "0x01".  This doesn't make sense, leading zeroes are valid for hex numbers, and it's fairly common for a hex number to be padded. Check remove, and tests changed

