### PR TITLE
more robustness to Protocol changes

### DIFF
--- a/src/main/java/org/web3j/protocol/ObjectMapperFactory.java
+++ b/src/main/java/org/web3j/protocol/ObjectMapperFactory.java
@@ -1,7 +1,7 @@
 package org.web3j.protocol;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
@@ -14,6 +14,7 @@ public class ObjectMapperFactory {
 
     static {
         objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     public static ObjectMapper getObjectMapper() {


### PR DESCRIPTION
I had the issue, that the Transaction Receipt had an attribute in the json object called logsBloom. Therefore the object could not be parsed to the Java Class.
Do be a bit more robust, I think we can ignore such mapping errors.