### PR TITLE
Fix bug where retrieving logs by numeric block range fails

### DIFF
--- a/src/main/java/org/web3j/protocol/core/DefaultBlockParameterNumber.java
+++ b/src/main/java/org/web3j/protocol/core/DefaultBlockParameterNumber.java
@@ -1,5 +1,7 @@
 package org.web3j.protocol.core;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.math.BigInteger;
 
 import org.web3j.utils.Numeric;
@@ -16,6 +18,7 @@ public class DefaultBlockParameterNumber implements DefaultBlockParameter {
     }
 
     @Override
+    @JsonValue
     public String getValue() {
         return Numeric.encodeQuantity(blockNumber);
     }

--- a/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -369,6 +369,15 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
+    public void testEthGetLogsWithNumericBlockRange() throws Exception {
+        web3j.ethGetLogs(new EthFilter(DefaultBlockParameter.valueOf(Numeric.toBigInt
+            ("0xe8")), DefaultBlockParameter.valueOf("latest"), "")).send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"eth_getLogs\",\"params\":[{\"topics\":[]," +
+            "\"fromBlock\":\"0xe8\",\"toBlock\":\"latest\",\"address\":[\"\"]}],\"id\":1}");
+    }
+
+    @Test
     public void testEthGetWork() throws Exception {
         web3j.ethGetWork().send();
 


### PR DESCRIPTION
Hi @conor10 

Thanks heaps for building this great library, it has been really helpful!

This PR is an attempt at solving an issue where retrieving logs using a numeric block range parameter fails. This seems to be because the [`DefaultBlockParameterNumber`](https://github.com/web3j/web3j/blob/master/src/main/java/org/web3j/protocol/core/DefaultBlockParameterNumber.java) instance (used internally by [`EthFilter`](https://github.com/web3j/web3j/blob/master/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java) for the range parameters) is serialized to JSON incorrectly. i.e. it is serialized as an object with a `value` attribute instead of as a JSON string. 

Below is a simple example to reproduce this issue. 

```Java
web3j.ethGetLogs(new EthFilter(DefaultBlockParameter.valueOf(Numeric.toBigInt("0xe8")), DefaultBlockParameter.valueOf("latest"), "")).send();
```

*Serialized JSON RPC payload (note the `fromBlock` attribute):* (**Fails**)
```JSON
{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"topics":[],"fromBlock":{"value":"0xe8"},"toBlock":"latest","address":[""]}],"id":1}
```

*Serialized JSON RPC payload generated after this PR fix:*
```JSON
{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"topics":[],"fromBlock":"0xe8","toBlock":"latest","address":[""]}],"id":1}
```

Thanks