### PR TITLE
Remove blank spaces in each element of the list passed to the Collection#join

### DIFF
--- a/src/main/java/org/web3j/utils/Collection.java
+++ b/src/main/java/org/web3j/utils/Collection.java
@@ -24,7 +24,7 @@ public class Collection {
     public static <T> String join(List<T> list, String separator, Function<T, String> function) {
         String result = "";
         for (int i = 0; i < list.size(); i++) {
-            result += function.apply(list.get(i));
+            result += function.apply(list.get(i)).trim();
             if (i + 1 < list.size()) {
                 result += separator;
             }
@@ -35,7 +35,7 @@ public class Collection {
     public static String join(List<String> list, String separator) {
         String result = "";
         for (int i = 0; i < list.size(); i++) {
-            result += list.get(i);
+            result += list.get(i).trim();
             if (i + 1 < list.size()) {
                 result += separator;
             }

--- a/src/test/java/org/web3j/utils/CollectionTest.java
+++ b/src/test/java/org/web3j/utils/CollectionTest.java
@@ -3,6 +3,9 @@ package org.web3j.utils;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.web3j.utils.Collection.*;
@@ -22,5 +25,52 @@ public class CollectionTest {
         assertThat(create("a"), is(new String[] { "a" }));
         assertThat(create(""), is(new String[] { "" }));
         assertThat(create("a", "b"), is(new String[] { "a", "b" }));
+    }
+
+    @Test
+    public void testJoin() {
+        assertThat(join(Arrays.asList("a  ", "b ", " c "), ","), is("a,b,c"));
+        assertThat(join(Arrays.asList("a", "b", "c", "d"), ","), is("a,b,c,d"));
+        assertThat(join(Arrays.asList("a  ", "b ", " c "), ", "), is("a, b, c"));
+        assertThat(join(Arrays.asList("a", "b", "c", "d"), ", "), is("a, b, c, d"));
+
+        final List<FakeSpec> specs1 = Arrays.asList(
+                new FakeSpec("a"),
+                new FakeSpec("b"),
+                new FakeSpec("c"));
+        assertThat(join(specs1, ",", FakeSpec::getName), is("a,b,c"));
+
+        final List<FakeSpec> specs2 = Arrays.asList(
+                new FakeSpec("a"),
+                new FakeSpec("b"),
+                new FakeSpec("c"));
+        assertThat(join(specs2, ", ", FakeSpec::getName), is("a, b, c"));
+
+        final List<FakeSpec> specs3 = Arrays.asList(
+                new FakeSpec(" a"),
+                new FakeSpec("b  "),
+                new FakeSpec(" c "));
+        assertThat(join(specs3, ",", FakeSpec::getName), is("a,b,c"));
+
+        final List<FakeSpec> specs4 = Arrays.asList(
+                new FakeSpec(" a"),
+                new FakeSpec("b  "),
+                new FakeSpec(" c "));
+        assertThat(join(specs4, ", ", FakeSpec::getName), is("a, b, c"));
+    }
+
+    /**
+     * Fake object to test {@link Collection#join(List, String, Function)}
+     */
+    private final class FakeSpec {
+        private final String name;
+
+        private FakeSpec(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 }


### PR DESCRIPTION
The blank spaces are removed from the element of the list in each iteration. Included test