### PR TITLE
Change return type of generated wrapper methods to CompletableFuture<T>

### DIFF
--- a/src/main/java/org/web3j/abi/Contract.java
+++ b/src/main/java/org/web3j/abi/Contract.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
 import org.web3j.abi.datatypes.Event;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Type;
@@ -127,7 +125,7 @@ public abstract class Contract extends ManagedTransaction {
      * Execute the provided function as a transaction asynchronously.
      *
      * @param function to transact with
-     * @return {@link Future} containing executing transaction
+     * @return {@link CompletableFuture} containing executing transaction
      */
     protected CompletableFuture<TransactionReceipt> executeTransactionAsync(Function function) {
         return Async.run(() -> executeTransaction(function));

--- a/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.javapoet.*;
@@ -282,7 +282,8 @@ public class SolidityFunctionWrapperGenerator {
         return MethodSpec.methodBuilder("deploy")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .returns(ParameterizedTypeName.get(
-                        ClassName.get(Future.class), TypeVariableName.get(className, Type.class)))
+                        ClassName.get(CompletableFuture.class), TypeVariableName.get(className, Type
+                        .class)))
                 .addParameter(Web3j.class, WEB3J)
                 .addParameter(Credentials.class, CREDENTIALS)
                 .addParameter(BigInteger.class, GAS_PRICE)
@@ -392,7 +393,7 @@ public class SolidityFunctionWrapperGenerator {
             throw new RuntimeException("Only transactional methods should have void return types");
         } else if (outputParameterTypes.size() == 1) {
             methodBuilder.returns(ParameterizedTypeName.get(
-                    ClassName.get(Future.class), outputParameterTypes.get(0)));
+                    ClassName.get(CompletableFuture.class), outputParameterTypes.get(0)));
 
             TypeName typeName = outputParameterTypes.get(0);
             methodBuilder.addStatement("$T function = " +
@@ -405,7 +406,7 @@ public class SolidityFunctionWrapperGenerator {
 
         } else {
             methodBuilder.returns(ParameterizedTypeName.get(
-                    ClassName.get(Future.class),
+                    ClassName.get(CompletableFuture.class),
                     ParameterizedTypeName.get(
                             ClassName.get(List.class), ClassName.get(Type.class))));
 
@@ -423,7 +424,8 @@ public class SolidityFunctionWrapperGenerator {
 
         String functionName = functionDefinition.getName();
 
-        methodBuilder.returns(ParameterizedTypeName.get(Future.class, TransactionReceipt.class));
+        methodBuilder.returns(ParameterizedTypeName.get(CompletableFuture.class, TransactionReceipt
+            .class));
 
         methodBuilder.addStatement("$T function = new $T($S, $T.<$T>asList($L), $T.<$T<?>>emptyList())",
                 Function.class, Function.class, functionName,

--- a/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -82,7 +82,8 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
 
         MethodSpec methodSpec = buildFunction(functionDefinition);
 
-        String expected = "public java.util.concurrent.Future<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated.Uint8 param) {\n" +
+        String expected = "public java.util.concurrent.CompletableFuture<org.web3j.protocol.core" +
+            ".methods.response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated.Uint8 param) {\n" +
                 "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\"functionName\", java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(param), java.util.Collections.<org.web3j.abi.TypeReference<?>>emptyList());\n" +
                 "  return executeTransactionAsync(function);\n" +
                 "}\n";
@@ -104,7 +105,7 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
 
         MethodSpec methodSpec = buildFunction(functionDefinition);
 
-        String expected = "public java.util.concurrent.Future<org.web3j.abi.datatypes.generated.Int8> functionName(org.web3j.abi.datatypes.generated.Uint8 param) {\n" +
+        String expected = "public java.util.concurrent.CompletableFuture<org.web3j.abi.datatypes.generated.Int8> functionName(org.web3j.abi.datatypes.generated.Uint8 param) {\n" +
                 "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\"functionName\", \n" +
                 "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(param), \n" +
                 "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}));\n" +
@@ -145,7 +146,7 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
 
         MethodSpec methodSpec = buildFunction(functionDefinition);
 
-        String expected = "public java.util.concurrent.Future<java.util.List<org.web3j.abi.datatypes.Type>> functionName(org.web3j.abi.datatypes.generated.Uint8 param1, org.web3j.abi.datatypes.generated.Uint32 param2) {\n" +
+        String expected = "public java.util.concurrent.CompletableFuture<java.util.List<org.web3j.abi.datatypes.Type>> functionName(org.web3j.abi.datatypes.generated.Uint8 param1, org.web3j.abi.datatypes.generated.Uint32 param2) {\n" +
                 "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\"functionName\", \n" +
                 "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(param1, param2), \n" +
                 "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int32>() {}));\n" +


### PR DESCRIPTION
Hi @conor10 

This PR proposes returning `CompletableFuture<T>`s, instead of `Future<T>`, from generated solidity wrapper methods. This would offer better flexibility to the calling client, in terms of composability, pipelining, transforming etc. of asynchronous operations.
Given that the underlying transaction execution methods in the super class `Contract` already use `CompletableFuture<T>`s the change in this PR is primarily to the generator, and associated tests.

Thanks!
