### PR TITLE
Replace Java internal API and make file seprator OS-specific

### DIFF
--- a/src/main/java/org/web3j/abi/TypeReference.java
+++ b/src/main/java/org/web3j/abi/TypeReference.java
@@ -3,8 +3,6 @@ package org.web3j.abi;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
-
 /**
  * <p>Type wrapper to get around limitations of Java's type erasure.<br>
  * This is so that we can pass around Typed {@link org.web3j.abi.datatypes.Array} types.</p>
@@ -49,8 +47,8 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type> impl
     public Class<T> getClassType() throws ClassNotFoundException {
         Type clsType = getType();
 
-        if (getType() instanceof ParameterizedTypeImpl) {
-            return (Class<T>) ((ParameterizedTypeImpl) clsType).getRawType();
+        if (getType() instanceof ParameterizedType) {
+            return (Class<T>) ((ParameterizedType) clsType).getRawType();
         } else {
             return (Class<T>) Class.forName(clsType.getTypeName());
         }

--- a/src/main/java/org/web3j/abi/Utils.java
+++ b/src/main/java/org/web3j/abi/Utils.java
@@ -1,13 +1,19 @@
 package org.web3j.abi;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
-
-import org.web3j.abi.datatypes.*;
+import org.web3j.abi.datatypes.DynamicArray;
+import org.web3j.abi.datatypes.DynamicBytes;
+import org.web3j.abi.datatypes.Fixed;
+import org.web3j.abi.datatypes.Int;
+import org.web3j.abi.datatypes.StaticArray;
 import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.Ufixed;
+import org.web3j.abi.datatypes.Uint;
+import org.web3j.abi.datatypes.Utf8String;
 
 /**
  * Utility functions.
@@ -20,8 +26,8 @@ public class Utils {
             java.lang.reflect.Type reflectedType = typeReference.getType();
 
             Class<?> type;
-            if (reflectedType instanceof ParameterizedTypeImpl) {
-                type = ((ParameterizedTypeImpl) reflectedType).getRawType();
+            if (reflectedType instanceof ParameterizedType) {
+                type = (Class<?>) ((ParameterizedType) reflectedType).getRawType();
                 return getParameterizedTypeName(typeReference, type);
             } else {
                 type = Class.forName(reflectedType.getTypeName());
@@ -75,7 +81,7 @@ public class Utils {
 
         java.lang.reflect.Type type = typeReference.getType();
         java.lang.reflect.Type[] typeArguments =
-                ((ParameterizedTypeImpl) type).getActualTypeArguments();
+                ((ParameterizedType) type).getActualTypeArguments();
 
         String parameterizedTypeName = typeArguments[0].getTypeName();
         return (Class<T>) Class.forName(parameterizedTypeName);

--- a/src/main/java/org/web3j/crypto/WalletUtils.java
+++ b/src/main/java/org/web3j/crypto/WalletUtils.java
@@ -73,20 +73,21 @@ public class WalletUtils {
         String osName = osName1.toLowerCase();
 
         if (osName.startsWith("mac")) {
-            return System.getProperty("user.home") + "/Library/Ethereum";
+            return String.format("%s%sLibrary%sEthereum", 
+            		System.getProperty("user.home"), File.separator, File.separator);
         } else if (osName.startsWith("win")) {
-            return System.getenv("APPDATA") + "/Ethereum";
+            return String.format("%s%sEthereum", System.getenv("APPDATA"), File.separator);
         } else {
-            return System.getProperty("user.home") + "/.ethereum";
+            return String.format("%s%s.ethereum", System.getProperty("user.home"), File.separator);
         }
     }
 
     public static String getTestnetKeyDirectory() {
-        return getDefaultKeyDirectory() + "/testnet/keystore";
+        return String.format("%s%stestnet%skeystore", getDefaultKeyDirectory(), File.separator, File.separator);
     }
 
     public static String getMainnetKeyDirectory() {
-        return getDefaultKeyDirectory() + "/keystore";
+        return String.format("%s%skeystore", getDefaultKeyDirectory(), File.separator);
     }
 
     public static boolean isValidPrivateKey(String privateKey) {

--- a/src/test/java/org/web3j/crypto/WalletUtilsTest.java
+++ b/src/test/java/org/web3j/crypto/WalletUtilsTest.java
@@ -1,6 +1,16 @@
 package org.web3j.crypto;
 
 
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.web3j.crypto.SampleKeys.CREDENTIALS;
+import static org.web3j.crypto.SampleKeys.KEY_PAIR;
+import static org.web3j.crypto.SampleKeys.PASSWORD;
+import static org.web3j.crypto.WalletUtils.isValidAddress;
+import static org.web3j.crypto.WalletUtils.isValidPrivateKey;
+
 import java.io.File;
 import java.nio.file.Files;
 
@@ -8,16 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.web3j.utils.Numeric;
-
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.web3j.crypto.SampleKeys.*;
-import static org.web3j.crypto.WalletUtils.isValidAddress;
-import static org.web3j.crypto.WalletUtils.isValidPrivateKey;
 
 
 public class WalletUtilsTest {
@@ -58,7 +59,8 @@ public class WalletUtilsTest {
     public void testLoadCredentialsFromFile() throws Exception {
         Credentials credentials = WalletUtils.loadCredentials(
                 PASSWORD,
-                new File(WalletUtilsTest.class.getResource("/keyfiles/" +
+                new File(WalletUtilsTest.class.getResource(
+                		"/keyfiles/" +
                         "UTC--2016-11-03T05-55-06." +
                         "340672473Z--ef678007d18427e6022059dbc264f27507cd1ffc").getFile()));
 
@@ -69,7 +71,8 @@ public class WalletUtilsTest {
     public void testLoadCredentialsFromString() throws Exception {
         Credentials credentials = WalletUtils.loadCredentials(
                 PASSWORD,
-                WalletUtilsTest.class.getResource("/keyfiles/" +
+                WalletUtilsTest.class.getResource(
+                		"/keyfiles/" +
                         "UTC--2016-11-03T05-55-06." +
                         "340672473Z--ef678007d18427e6022059dbc264f27507cd1ffc").getFile());
 
@@ -81,7 +84,8 @@ public class WalletUtilsTest {
     public void testLoadCredentialsMyEtherWallet() throws Exception {
         Credentials credentials = WalletUtils.loadCredentials(
                 PASSWORD,
-                new File(WalletUtilsTest.class.getResource("/keyfiles/" +
+                new File(WalletUtilsTest.class.getResource(
+                		"/keyfiles/" +
                         "UTC--2016-11-03T07-47-45." +
                         "988Z--4f9c1a1efaa7d81ba1cabf07f2c3a5ac5cf4f818").getFile()));
 
@@ -92,15 +96,20 @@ public class WalletUtilsTest {
 
     @Test
     public void testGetDefaultKeyDirectory() {
-        assertTrue(WalletUtils.getDefaultKeyDirectory("Mac OS X").endsWith("/Library/Ethereum"));
-        assertTrue(WalletUtils.getDefaultKeyDirectory("Windows").endsWith("/Ethereum"));
-        assertTrue(WalletUtils.getDefaultKeyDirectory("Linux").endsWith("/.ethereum"));
+        assertTrue(WalletUtils.getDefaultKeyDirectory("Mac OS X")
+        		.endsWith(String.format("%sLibrary%sEthereum", File.separator, File.separator)));
+        assertTrue(WalletUtils.getDefaultKeyDirectory("Windows")
+        		.endsWith(String.format("%sEthereum", File.separator)));
+        assertTrue(WalletUtils.getDefaultKeyDirectory("Linux")
+        		.endsWith(String.format("%s.ethereum", File.separator)));
     }
 
     @Test
     public void testGetTestnetKeyDirectory() {
-        assertTrue(WalletUtils.getMainnetKeyDirectory().endsWith("/keystore"));
-        assertTrue(WalletUtils.getTestnetKeyDirectory().endsWith("/testnet/keystore"));
+        assertTrue(WalletUtils.getMainnetKeyDirectory()
+        		.endsWith(String.format("%skeystore", File.separator)));
+        assertTrue(WalletUtils.getTestnetKeyDirectory()
+        		.endsWith(String.format("%stestnet%skeystore", File.separator, File.separator)));
     }
 
     private static File createTempDir() throws Exception {


### PR DESCRIPTION
noticed that path expressions for wallet files on windows include "/" as separators instead of "\". while fixing this, eclipse hinted that the use of ParameterizedTypeImpl is discouraged as this is considered to be Java internal API.