### PR TITLE
Make org.web3j.crypto.Sign.SignatureData public.

### DIFF
--- a/src/main/java/org/web3j/crypto/Sign.java
+++ b/src/main/java/org/web3j/crypto/Sign.java
@@ -264,7 +264,7 @@ public class Sign {
         }
     }
 
-    static class SignatureData {
+    public static class SignatureData {
         private final byte v;
         private final byte[] r;
         private final byte[] s;


### PR DESCRIPTION
This Sign methods that have SignatureData in the method signature are now callable from other packages.