### PR TITLE
Fix problems around size validation of large uint values.

### DIFF
--- a/src/main/java/org/web3j/abi/TypeEncoder.java
+++ b/src/main/java/org/web3j/abi/TypeEncoder.java
@@ -85,7 +85,7 @@ public class TypeEncoder {
     private static byte[] toByteArray(NumericType numericType) {
         BigInteger value = numericType.getValue();
         if (numericType instanceof Ufixed || numericType instanceof Uint) {
-            if (value.bitCount() == MAX_BIT_LENGTH) {
+            if (value.bitLength() == MAX_BIT_LENGTH) {
                 // As BigInteger is signed, if we have a 256 bit value, the resultant byte array will
                 // contain a sign byte in it's MSB, which we should ignore for this unsigned integer type.
                 byte[] byteArray = new byte[MAX_BYTE_LENGTH];

--- a/src/main/java/org/web3j/abi/datatypes/IntType.java
+++ b/src/main/java/org/web3j/abi/datatypes/IntType.java
@@ -27,6 +27,6 @@ public abstract class IntType extends NumericType {
     }
 
     private static boolean isValidBitCount(int bitSize, BigInteger value) {
-        return value.bitCount() <= bitSize;
+        return value.bitLength() <= bitSize;
     }
 }

--- a/src/test/java/org/web3j/abi/TypeEncoderTest.java
+++ b/src/test/java/org/web3j/abi/TypeEncoderTest.java
@@ -52,6 +52,12 @@ public class TypeEncoderTest {
                 16));
         assertThat(TypeEncoder.encodeNumeric(maxValue),
                 is("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+
+        Uint largeValue = new Uint(
+                new BigInteger("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+                16));
+        assertThat(TypeEncoder.encodeNumeric(largeValue),
+                is("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/org/web3j/abi/TypeEncoderTest.java
+++ b/src/test/java/org/web3j/abi/TypeEncoderTest.java
@@ -65,6 +65,14 @@ public class TypeEncoderTest {
         new Uint64(BigInteger.valueOf(-1));
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testTooLargeUintEncode() {
+        // 1 more than "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        new Uint(new BigInteger("10000000000000000000000000000000000000000000000000000000000000000",
+                16));
+
+    }
+
     @Test
     public void testIntEncode() {
         Int zero = new Int64(BigInteger.ZERO);


### PR DESCRIPTION
I found two problems related to large uint values:
 - `ArrayIndexOutOfBoundException` when encoding a large uint value
 - No exception when creating an `IntType` with a >256 bit value

The code was using `BigInteger.bitCount()` but I believe it should be using `BigInteger.bitLength()`.  `bitCount` calculates the number of bits that differ from the sign bit, `bitLength` calculates the minimal number of bits needed to represent the number without the sign bit, which I think is what the intention was here.

I added some tests to TypeEncoderTests that demonstrate the 2 bugs.
