### PR TITLE
FunctionReturnDecoder.decodeIndexedValue always returns `Bytes32`

### DIFF
--- a/src/main/java/org/web3j/abi/FunctionReturnDecoder.java
+++ b/src/main/java/org/web3j/abi/FunctionReturnDecoder.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.web3j.abi.datatypes.Array;
+import org.web3j.abi.datatypes.Bytes;
 import org.web3j.abi.datatypes.BytesType;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
@@ -72,7 +73,9 @@ public class FunctionReturnDecoder {
         try {
             Class<T> type = typeReference.getClassType();
 
-            if (Array.class.isAssignableFrom(type)
+            if (Bytes.class.isAssignableFrom(type)) {
+                return TypeDecoder.decodeBytes(input, (Class<Bytes>) Class.forName(type.getName()));
+            } else if (Array.class.isAssignableFrom(type)
                     || BytesType.class.isAssignableFrom(type)
                     || Utf8String.class.isAssignableFrom(type)) {
                 return TypeDecoder.decodeBytes(input, Bytes32.class);

--- a/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -15,6 +15,7 @@ import org.web3j.abi.datatypes.StaticArray;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Uint;
 import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.generated.Bytes16;
 import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.crypto.Hash;
@@ -179,6 +180,28 @@ public class FunctionReturnDecoderTest {
                 hash,
                 new TypeReference<Utf8String>() {}),
                 equalTo(new Bytes32(Numeric.hexStringToByteArray(hash))));
+    }
+
+    @Test
+    public void testDecodeIndexedBytes32Value() {
+        String rawInput = "0x1234567890123456789012345678901234567890123456789012345678901234";
+        byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput);
+
+        assertThat(FunctionReturnDecoder.decodeIndexedValue(
+                rawInput,
+                new TypeReference<Bytes32>(){}),
+                equalTo(new Bytes32(rawInputBytes)));
+    }
+
+    @Test
+    public void testDecodeIndexedBytes16Value() {
+        String rawInput = "0x1234567890123456789012345678901200000000000000000000000000000000";
+        byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput.substring(0, 34));
+
+        assertThat(FunctionReturnDecoder.decodeIndexedValue(
+                rawInput,
+                new TypeReference<Bytes16>(){}),
+                equalTo(new Bytes16(rawInputBytes)));
     }
 
     @Test


### PR DESCRIPTION
We have some solidity contracts with events containing `Bytes16` values. These generate the correct types in the contract wrappers, but when executed they always arrive as `Bytes32` types instead and result in a cast error. I've adjusted the method responsible slightly to generate the specific `BytesN` class required and added some unit tests. 

I had considered an integration test for this but, it seems more like something that should be covered by a unit test.