### PR TITLE
add deploy contract run out of gas error handler

### DIFF
--- a/src/main/java/org/web3j/protocol/exceptions/TransactionOutOfGasException.java
+++ b/src/main/java/org/web3j/protocol/exceptions/TransactionOutOfGasException.java
@@ -1,0 +1,16 @@
+package org.web3j.protocol.exceptions;
+
+/**
+ * Transaction out of gas exception indicates that we have run out of gas when deploy a contract
+ * or send transaction .
+ */
+public class TransactionOutOfGasException extends RuntimeException{
+    public TransactionOutOfGasException(String message) {
+        super(message);
+    }
+
+    public TransactionOutOfGasException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/web3j/protocol/exceptions/TransactionOutOfGasException.java
+++ b/src/main/java/org/web3j/protocol/exceptions/TransactionOutOfGasException.java
@@ -4,7 +4,7 @@ package org.web3j.protocol.exceptions;
  * Transaction out of gas exception indicates that we have run out of gas when deploy a contract
  * or send transaction .
  */
-public class TransactionOutOfGasException extends RuntimeException{
+public class TransactionOutOfGasException extends RuntimeException {
     public TransactionOutOfGasException(String message) {
         super(message);
     }

--- a/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/src/main/java/org/web3j/tx/TransactionManager.java
@@ -1,17 +1,18 @@
 package org.web3j.tx;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Optional;
+
 import org.web3j.protocol.Web3j;
+
 import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionOutOfGasException;
 import org.web3j.protocol.exceptions.TransactionTimeoutException;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Optional;
 
-import static org.web3j.tx.Contract.GAS_LIMIT;
 
 
 /**
@@ -105,9 +106,9 @@ public abstract class TransactionManager {
                     + transactionReceipt.getError().getMessage());
         } else if (transactionReceipt.getTransactionReceipt().isPresent()) {
             TransactionReceipt receipt = transactionReceipt.getTransactionReceipt().get();
-            if (receipt.getGasUsed().compareTo(GAS_LIMIT) == 0) {
-                throw new TransactionOutOfGasException("Transaction run out of gas : gas used " +
-                        GAS_LIMIT);
+            if (receipt.getGasUsed().compareTo(Contract.GAS_LIMIT) == 0) {
+                throw new TransactionOutOfGasException("Transaction run out of gas : gas used "
+                        + Contract.GAS_LIMIT);
             }
         }
 

--- a/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/src/main/java/org/web3j/tx/TransactionManager.java
@@ -1,15 +1,18 @@
 package org.web3j.tx;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.TransactionOutOfGasException;
 import org.web3j.protocol.exceptions.TransactionTimeoutException;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.web3j.tx.Contract.GAS_LIMIT;
+
 
 /**
  * Transaction manager abstraction for executing transactions with Ethereum client via
@@ -100,6 +103,12 @@ public abstract class TransactionManager {
         if (transactionReceipt.hasError()) {
             throw new RuntimeException("Error processing request: "
                     + transactionReceipt.getError().getMessage());
+        } else if (transactionReceipt.getTransactionReceipt().isPresent()) {
+            TransactionReceipt receipt = transactionReceipt.getTransactionReceipt().get();
+            if (receipt.getGasUsed().compareTo(GAS_LIMIT) == 0) {
+                throw new TransactionOutOfGasException("Transaction run out of gas : gas used " +
+                        GAS_LIMIT);
+            }
         }
 
         return transactionReceipt.getTransactionReceipt();

--- a/src/test/java/org/web3j/tx/ContractTest.java
+++ b/src/test/java/org/web3j/tx/ContractTest.java
@@ -1,7 +1,16 @@
 package org.web3j.tx;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import org.web3j.abi.EventValues;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.TypeReference;
@@ -28,14 +37,6 @@ import org.web3j.protocol.exceptions.TransactionOutOfGasException;
 import org.web3j.protocol.exceptions.TransactionTimeoutException;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;


### PR DESCRIPTION
I don't understand what's  meaning of the issue #62 in last PR. Sorry for that bad commit.

What I confusing is  when call a contract method , and the contract throw error, but this error transaction is still on the blockchain and I can't find a way to tell the state is success or fail . No matter the error is 'out of gas' or 'Bad instruction'. 

I know if I run a geth node and print detail logs can find state, but there is no other way to resolve this problem lightly? or I can only call etherscan's api?