### PR TITLE
Adding value as an option for a Smart Contract transactional function call

### DIFF
--- a/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
+++ b/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
@@ -26,7 +26,7 @@ public class AbiDefinition {
         this.name = name;
         this.outputs = outputs;
         this.type = type;
-        this.payable = false;
+        this.payable = payable;
     }
 
     public boolean isConstant() {

--- a/src/main/java/org/web3j/tx/Contract.java
+++ b/src/main/java/org/web3j/tx/Contract.java
@@ -187,6 +187,10 @@ public abstract class Contract extends ManagedTransaction {
         return executeTransaction(FunctionEncoder.encode(function), BigInteger.ZERO);
     }
 
+    protected TransactionReceipt executeTransaction(Function function, BigInteger weiValue)
+            throws InterruptedException, IOException, TransactionTimeoutException {
+        return executeTransaction(FunctionEncoder.encode(function), weiValue);
+    }
 
     /**
      * Given the duration required to execute a transaction, asyncronous execution is strongly

--- a/src/main/java/org/web3j/tx/Contract.java
+++ b/src/main/java/org/web3j/tx/Contract.java
@@ -182,11 +182,6 @@ public abstract class Contract extends ManagedTransaction {
         return executeCall(function);
     }
 
-    protected TransactionReceipt executeTransaction(Function function) throws InterruptedException,
-            IOException, TransactionTimeoutException {
-        return executeTransaction(FunctionEncoder.encode(function), BigInteger.ZERO);
-    }
-
     protected TransactionReceipt executeTransaction(Function function, BigInteger weiValue)
             throws InterruptedException, IOException, TransactionTimeoutException {
         return executeTransaction(FunctionEncoder.encode(function), weiValue);
@@ -218,7 +213,19 @@ public abstract class Contract extends ManagedTransaction {
      * @return {@link Future} containing executing transaction
      */
     protected CompletableFuture<TransactionReceipt> executeTransactionAsync(Function function) {
-        return Async.run(() -> executeTransaction(function));
+        return Async.run(() -> executeTransaction(function, BigInteger.ZERO));
+    }
+
+    /**
+     * Execute the provided function as a transaction asynchronously.
+     *
+     * @param function to transact with
+     * @param weiValue to send in transaction to send to smart contract
+     * @return {@link Future} containing executing transaction
+     */
+    protected CompletableFuture<TransactionReceipt> executeTransactionAsync(Function function,
+                                                                            BigInteger weiValue) {
+        return Async.run(() -> executeTransaction(function,weiValue));
     }
 
     protected EventValues extractEventParameters(

--- a/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -3,6 +3,7 @@ package org.web3j.codegen;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
@@ -73,9 +74,19 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 "type",
                 false);
 
-        MethodSpec methodSpec = buildFunction(functionDefinition);
+        List<MethodSpec> methodSpec = buildFunction(functionDefinition);
 
-        String expected = "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
+        String[] expected = {
+                "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
+                + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
+                + ".Uint8 param, java.math.BigInteger weiValue) {\n"
+                + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
+                + ".Function(\"functionName\", java.util.Arrays.<org.web3j.abi.datatypes"
+                + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
+                + ".TypeReference<?>>emptyList());\n"
+                + "  return executeTransactionAsync(function, weiValue);\n"
+                + "}\n",
+                "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
                 + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
                 + ".Uint8 param) {\n"
                 + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
@@ -83,9 +94,10 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
                 + ".TypeReference<?>>emptyList());\n"
                 + "  return executeTransactionAsync(function);\n"
-                + "}\n";
+                + "}\n"};
 
-        assertThat(methodSpec.toString(), is(expected));
+        assertThat(methodSpec.get(0).toString(), is(expected[0]));
+        assertThat(methodSpec.get(1).toString(), is(expected[1]));
     }
 
     @Test
@@ -100,7 +112,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 "type",
                 false);
 
-        MethodSpec methodSpec = buildFunction(functionDefinition);
+        List<MethodSpec> methodSpec = buildFunction(functionDefinition);
 
         String expected = "public java.util.concurrent.Future<org.web3j.abi.datatypes.generated"
                 + ".Int8> functionName(org.web3j.abi.datatypes.generated.Uint8 param) {\n"
@@ -112,7 +124,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 + "  return executeCallSingleValueReturnAsync(function);\n"
                 + "}\n";
 
-        assertThat(methodSpec.toString(), is(expected));
+        assertThat(methodSpec.get(0).toString(), is(expected));
     }
 
     @Test(expected = RuntimeException.class)
@@ -144,7 +156,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 "type",
                 false);
 
-        MethodSpec methodSpec = buildFunction(functionDefinition);
+        List<MethodSpec> methodSpec = buildFunction(functionDefinition);
 
         String expected = "public java.util.concurrent.Future<java.util.List<org.web3j.abi"
                 + ".datatypes.Type>> functionName(org.web3j.abi.datatypes.generated.Uint8 param1, "
@@ -158,7 +170,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 + "  return executeCallMultipleValueReturnAsync(function);\n"
                 + "}\n";
 
-        assertThat(methodSpec.toString(), is(expected));
+        assertThat(methodSpec.get(0).toString(), is(expected));
     }
 
     @Test

--- a/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -103,8 +103,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
         List<MethodSpec> methodSpec = buildFunction(functionDefinition);
 
-        String[] expected = {
-                "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
+        String expected = "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
                 + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
                 + ".Uint8 param, java.math.BigInteger weiValue) {\n"
                 + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
@@ -112,19 +111,9 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
                 + ".TypeReference<?>>emptyList());\n"
                 + "  return executeTransactionAsync(function, weiValue);\n"
-                + "}\n",
-                "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
-                + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
-                + ".Uint8 param) {\n"
-                + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
-                + ".Function(\"functionName\", java.util.Arrays.<org.web3j.abi.datatypes"
-                + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
-                + ".TypeReference<?>>emptyList());\n"
-                + "  return executeTransactionAsync(function);\n"
-                + "}\n"};
+                + "}\n";
 
-        assertThat(methodSpec.get(0).toString(), is(expected[0]));
-        assertThat(methodSpec.get(1).toString(), is(expected[1]));
+        assertThat(methodSpec.get(0).toString(), is(expected));
     }
 
     @Test

--- a/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -76,6 +76,33 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
         List<MethodSpec> methodSpec = buildFunction(functionDefinition);
 
+        String expected = "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
+                + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
+                + ".Uint8 param) {\n"
+                + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
+                + ".Function(\"functionName\", java.util.Arrays.<org.web3j.abi.datatypes"
+                + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
+                + ".TypeReference<?>>emptyList());\n"
+                + "  return executeTransactionAsync(function);\n"
+                + "}\n";
+
+        assertThat(methodSpec.get(0).toString(), is(expected));
+    }
+
+
+    @Test
+    public void testBuildFunctionPayableTransaction() throws Exception {
+        AbiDefinition functionDefinition = new AbiDefinition(
+                false,
+                Arrays.asList(
+                        new AbiDefinition.NamedType("param", "uint8")),
+                "functionName",
+                Collections.emptyList(),
+                "type",
+                true);
+
+        List<MethodSpec> methodSpec = buildFunction(functionDefinition);
+
         String[] expected = {
                 "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
                 + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"


### PR DESCRIPTION
I needed to include ether as value when calling transactional functions from my generated smart contract. The only way to do that was to modify the auto-generated smart contract java file, then manually encode and send the transaction with a value attached so the smart contract on the blockchain would contain value. 

I decided modifying some transaction functions in Contract.java, and generating overloaded transactional functions in the smart contract wrapper would be a cleaner solution. It works, and I think it will be a good addition to the current features since there are many use cases that involve a smart contract handling ether. 

Please let me know if there are any problems and I will gladly fix them.