### PR TITLE
JsonMappingException fix when compiling a solidity contract with eth_compileSolidity

### DIFF
--- a/src/main/java/org/web3j/protocol/core/methods/response/EthCompileSolidity.java
+++ b/src/main/java/org/web3j/protocol/core/methods/response/EthCompileSolidity.java
@@ -22,6 +22,10 @@ public class EthCompileSolidity extends Response<Map<String, EthCompileSolidity.
         public Code() {
         }
 
+        public Code(String code) {
+            this.code = code;
+        }
+
         public Code(String code, SolidityInfo info) {
             this.code = code;
             this.info = info;


### PR DESCRIPTION
fixes an exception
com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of org.web3j.protocol.core.methods.response.EthCompileSolidity$Code: no String-argument constructor/factory method to deserialize from String value ('0x6060604052346000575b60458060156000396000f3606060405260e060020a6000350463c6888fa18114601c575b6000565b346000576029600435603b565b60408051918252519081900360200190f35b600781025b91905056')

when compiling a solidity code
web3j.ethCompileSolidity("pragma solidity ^0.4.2; contract test { function multiply(uint a) returns(uint d) {   return a * 7;   } }").send()