### PR TITLE
Support payable functions in wrapper generator

### DIFF
--- a/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -63,6 +63,7 @@ public class SolidityFunctionWrapper {
     private static final String GAS_LIMIT = "gasLimit";
     private static final String START_BLOCK = "startBlock";
     private static final String END_BLOCK = "endBlock";
+    private static final String WEI_VALUE = "weiValue";
 
     private static final String CODEGEN_WARNING = "Auto generated code.<br>\n"
             + "<strong>Do not modify!</strong><br>\n"
@@ -355,6 +356,10 @@ public class SolidityFunctionWrapper {
             MethodSpec.Builder methodBuilder,
             String inputParams) throws ClassNotFoundException {
 
+        if (functionDefinition.isPayable()) {
+            methodBuilder.addParameter(BigInteger.class, WEI_VALUE);
+        }
+
         String functionName = functionDefinition.getName();
 
         methodBuilder.returns(ParameterizedTypeName.get(Future.class, TransactionReceipt.class));
@@ -364,7 +369,11 @@ public class SolidityFunctionWrapper {
                 Function.class, Function.class, functionName,
                 Arrays.class, Type.class, inputParams, Collections.class,
                 TypeReference.class);
-        methodBuilder.addStatement("return executeTransactionAsync(function)");
+        if (functionDefinition.isPayable()) {
+            methodBuilder.addStatement("return executeTransactionAsync(function, $N)", WEI_VALUE);
+        } else {
+            methodBuilder.addStatement("return executeTransactionAsync(function)");
+        }
     }
 
     static TypeSpec buildEventResponseObject(String className,

--- a/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
+++ b/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
@@ -26,7 +26,7 @@ public class AbiDefinition {
         this.name = name;
         this.outputs = outputs;
         this.type = type;
-        this.payable = false;
+        this.payable = payable;
     }
 
     public boolean isConstant() {

--- a/src/main/java/org/web3j/tx/Contract.java
+++ b/src/main/java/org/web3j/tx/Contract.java
@@ -217,6 +217,18 @@ public abstract class Contract extends ManagedTransaction {
         return Async.run(() -> executeTransaction(function));
     }
 
+    /**
+     * Execute the provided payable function as a transaction asynchronously.
+     *
+     * @param function to transact with
+     * @param weiValue in Wei to send in transaction
+     * @return {@link Future} containing executing transaction
+     */
+    protected CompletableFuture<TransactionReceipt> executeTransactionAsync(
+            Function function, BigInteger weiValue) {
+        return Async.run(() -> executeTransaction(FunctionEncoder.encode(function), weiValue));
+    }
+
     protected EventValues extractEventParameters(
             Event event, Log log) {
 

--- a/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -89,6 +89,32 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
+    public void testBuildPayabelFunctionTransaction() throws Exception {
+        AbiDefinition functionDefinition = new AbiDefinition(
+                false,
+                Arrays.asList(
+                        new AbiDefinition.NamedType("param", "uint8")),
+                "functionName",
+                Collections.emptyList(),
+                "type",
+                true);
+
+        MethodSpec methodSpec = buildFunction(functionDefinition);
+
+        String expected = "public java.util.concurrent.Future<org.web3j.protocol.core.methods"
+                + ".response.TransactionReceipt> functionName(org.web3j.abi.datatypes.generated"
+                + ".Uint8 param, java.math.BigInteger weiValue) {\n"
+                + "  org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes"
+                + ".Function(\"functionName\", java.util.Arrays.<org.web3j.abi.datatypes"
+                + ".Type>asList(param), java.util.Collections.<org.web3j.abi"
+                + ".TypeReference<?>>emptyList());\n"
+                + "  return executeTransactionAsync(function, weiValue);\n"
+                + "}\n";
+
+        assertThat(methodSpec.toString(), is(expected));
+    }
+
+    @Test
     public void testBuildFunctionConstantSingleValueReturn() throws Exception {
         AbiDefinition functionDefinition = new AbiDefinition(
                 true,


### PR DESCRIPTION
This adds ability to send some ether along with a function call.

The generated code for payable function accepts one extra argument `weiValue`. E.g. such a wrapper 
```
    public Future<TransactionReceipt> pay(Utf8String name, BigInteger weiValue) {
        Function function = new Function("pay", Arrays.<Type>asList(name), Collections.<TypeReference<?>>emptyList());
        return executeTransactionAsync(function, weiValue);
    }
```
is generated for this Sloidity function:

```
function pay(string name) payable public {}
```

Ref. https://ethereum.stackexchange.com/questions/21481