### PR TITLE
Fix web3j#152. Filters create requests based on type

### DIFF
--- a/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
@@ -3,6 +3,7 @@ package org.web3j.protocol.core.filters;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
@@ -37,9 +38,17 @@ public class BlockFilter extends Filter<String> {
         }
     }
 
+    /**
+     * Since the block filter does not support historic filters, the filterId is ignored
+     * and an empty optional is returned
+     * @param filterId
+     * Id of the filter for which the historic log should be retrieved
+     * @return
+     * Optional.empty()
+     */
     @Override
-    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
-        return this.web3j.ethGetFilterChanges(filterId);
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.empty();
     }
 }
 

--- a/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
@@ -1,10 +1,12 @@
 package org.web3j.protocol.core.filters;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthLog;
 
@@ -33,6 +35,11 @@ public class BlockFilter extends Filter<String> {
                         "Unexpected result type: " + logResult.get() + ", required Hash");
             }
         }
+    }
+
+    @Override
+    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
+        return this.web3j.ethGetFilterChanges(filterId);
     }
 }
 

--- a/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthLog;
@@ -39,7 +40,7 @@ public abstract class Filter<T> {
             }
 
             filterId = ethFilter.getFilterId();
-            EthLog ethLogInit = web3j.ethGetFilterLogs(filterId).send();
+            EthLog ethLogInit = this.createFilterRequest(this.filterId).send();
             process(ethLogInit.getLogs());
 
             schedule = scheduledExecutorService.scheduleAtFixedRate(() -> {
@@ -84,6 +85,8 @@ public abstract class Filter<T> {
             throwException(ethUninstallFilter.getError());
         }
     }
+
+    protected abstract Request<?, EthLog> createFilterRequest(BigInteger filterId);
 
     void throwException(Response.Error error) {
         throw new FilterException("Invalid request: " + error.getMessage());

--- a/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -1,18 +1,20 @@
 package org.web3j.protocol.core.filters;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthLog;
 import org.web3j.protocol.core.methods.response.EthUninstallFilter;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -40,27 +42,45 @@ public abstract class Filter<T> {
             }
 
             filterId = ethFilter.getFilterId();
-            EthLog ethLogInit = this.createFilterRequest(this.filterId).send();
-            process(ethLogInit.getLogs());
 
-            schedule = scheduledExecutorService.scheduleAtFixedRate(() -> {
-                EthLog ethLog = null;
-                try {
-                    ethLog = web3j.ethGetFilterChanges(filterId).send();
-                } catch (IOException e) {
-                    throwException(e);
-                }
-                if (ethLog.hasError()) {
-                    throwException(ethFilter.getError());
-                }
+            scheduledExecutorService.submit(this::getInitialFilterLogs);
 
-                process(ethLog.getLogs());
-            }, 0, blockTime, TimeUnit.MILLISECONDS);
-
+            schedule = scheduledExecutorService.scheduleAtFixedRate(
+                    () -> this.pollFilter(ethFilter),
+                    0, blockTime, TimeUnit.MILLISECONDS);
 
         } catch (IOException e) {
             throwException(e);
         }
+    }
+
+    private void getInitialFilterLogs() {
+        try {
+            Optional<Request<?, EthLog>> maybeRequest = this.getFilterLogs(this.filterId);
+            EthLog ethLog = null;
+            if(maybeRequest.isPresent()) {
+                ethLog = maybeRequest.get().send();
+            } else {
+                ethLog = new EthLog();
+                ethLog.setResult(Collections.emptyList());
+            }
+            process(ethLog.getLogs());
+        } catch(IOException e) {
+            throwException(e);
+        }
+    }
+
+    private void pollFilter(EthFilter ethFilter) {
+        EthLog ethLog = null;
+        try {
+            ethLog = web3j.ethGetFilterChanges(filterId).send();
+        } catch (IOException e) {
+            throwException(e);
+        }
+        if (ethLog.hasError()) {
+            throwException(ethFilter.getError());
+        }
+        process(ethLog.getLogs());
     }
 
     abstract EthFilter sendRequest() throws IOException;
@@ -86,7 +106,15 @@ public abstract class Filter<T> {
         }
     }
 
-    protected abstract Request<?, EthLog> createFilterRequest(BigInteger filterId);
+    /**
+     * Retrieves historic filters for the filter with the given id.
+     * Getting historic logs is not supported by all filters. If not the method should return an empty EthLog object
+     * @param filterId
+     * Id of the filter for which the historic log should be retrieved
+     * @return
+     * Historic logs, or an empty optional if the filter cannot retrieve historic logs
+     */
+    protected abstract Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId);
 
     void throwException(Response.Error error) {
         throw new FilterException("Invalid request: " + error.getMessage());

--- a/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -1,12 +1,5 @@
 package org.web3j.protocol.core.filters;
 
-import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.Request;
-import org.web3j.protocol.core.Response;
-import org.web3j.protocol.core.methods.response.EthFilter;
-import org.web3j.protocol.core.methods.response.EthLog;
-import org.web3j.protocol.core.methods.response.EthUninstallFilter;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collections;
@@ -15,6 +8,14 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import org.web3j.protocol.Web3j;
+
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthUninstallFilter;
 
 
 /**
@@ -58,14 +59,14 @@ public abstract class Filter<T> {
         try {
             Optional<Request<?, EthLog>> maybeRequest = this.getFilterLogs(this.filterId);
             EthLog ethLog = null;
-            if(maybeRequest.isPresent()) {
+            if (maybeRequest.isPresent()) {
                 ethLog = maybeRequest.get().send();
             } else {
                 ethLog = new EthLog();
                 ethLog.setResult(Collections.emptyList());
             }
             process(ethLog.getLogs());
-        } catch(IOException e) {
+        } catch (IOException e) {
             throwException(e);
         }
     }
@@ -108,11 +109,11 @@ public abstract class Filter<T> {
 
     /**
      * Retrieves historic filters for the filter with the given id.
-     * Getting historic logs is not supported by all filters. If not the method should return an empty EthLog object
-     * @param filterId
-     * Id of the filter for which the historic log should be retrieved
-     * @return
-     * Historic logs, or an empty optional if the filter cannot retrieve historic logs
+     * Getting historic logs is not supported by all filters.
+     * If not the method should return an empty EthLog object
+     *
+     * @param filterId Id of the filter for which the historic log should be retrieved
+     * @return Historic logs, or an empty optional if the filter cannot retrieve historic logs
      */
     protected abstract Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId);
 

--- a/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
@@ -3,6 +3,7 @@ package org.web3j.protocol.core.filters;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
@@ -26,7 +27,6 @@ public class LogFilter extends Filter<Log> {
     }
 
 
-
     @Override
     EthFilter sendRequest() throws IOException {
         return web3j.ethNewFilter(ethFilter).send();
@@ -46,7 +46,7 @@ public class LogFilter extends Filter<Log> {
     }
 
     @Override
-    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
-        return this.web3j.ethGetFilterLogs(filterId);
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
@@ -1,10 +1,12 @@
 package org.web3j.protocol.core.filters;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthLog;
 import org.web3j.protocol.core.methods.response.Log;
@@ -23,6 +25,8 @@ public class LogFilter extends Filter<Log> {
         this.ethFilter = ethFilter;
     }
 
+
+
     @Override
     EthFilter sendRequest() throws IOException {
         return web3j.ethNewFilter(ethFilter).send();
@@ -39,5 +43,10 @@ public class LogFilter extends Filter<Log> {
                         "Unexpected result type: " + logResult.get() + " required LogObject");
             }
         }
+    }
+
+    @Override
+    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
+        return this.web3j.ethGetFilterLogs(filterId);
     }
 }

--- a/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
@@ -3,6 +3,7 @@ package org.web3j.protocol.core.filters;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
@@ -37,9 +38,17 @@ public class PendingTransactionFilter extends Filter<String> {
         }
     }
 
+    /**
+     * Since the pending transaction filter does not support historic filters, the filterId is ignored
+     * and an empty optional is returned
+     * @param filterId
+     * Id of the filter for which the historic log should be retrieved
+     * @return
+     * Optional.empty()
+     */
     @Override
-    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
-        return this.web3j.ethGetFilterChanges(filterId);
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.empty();
     }
 }
 

--- a/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
@@ -39,8 +39,8 @@ public class PendingTransactionFilter extends Filter<String> {
     }
 
     /**
-     * Since the pending transaction filter does not support historic filters, the filterId is ignored
-     * and an empty optional is returned
+     * Since the pending transaction filter does not support historic filters,
+     * the filterId is ignored and an empty optional is returned
      * @param filterId
      * Id of the filter for which the historic log should be retrieved
      * @return

--- a/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
+++ b/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
@@ -1,10 +1,12 @@
 package org.web3j.protocol.core.filters;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthLog;
 
@@ -33,6 +35,11 @@ public class PendingTransactionFilter extends Filter<String> {
                         "Unexpected result type: " + logResult.get() + ", required Hash");
             }
         }
+    }
+
+    @Override
+    protected Request<?, EthLog> createFilterRequest(BigInteger filterId) {
+        return this.web3j.ethGetFilterChanges(filterId);
     }
 }
 

--- a/src/test/java/org/web3j/protocol/rx/JsonRpc2_0RxTest.java
+++ b/src/test/java/org/web3j/protocol/rx/JsonRpc2_0RxTest.java
@@ -145,7 +145,7 @@ public class JsonRpc2_0RxTest {
                 throwable -> fail(throwable.getMessage()),
                 () -> completedLatch.countDown());
 
-        transactionLatch.await(1, TimeUnit.SECONDS);
+        transactionLatch.await(1250, TimeUnit.MILLISECONDS);
         assertThat(results, equalTo(expected));
 
         subscription.unsubscribe();


### PR DESCRIPTION
Not all filters can provide historic data. In fact only the LogFilter can. Thus all other filters (i.e. BlockFilter and PendingTransactionFilter) must use the ethGetFilterChanges method instead of ethGetFilterLogs