### PR TITLE
Integrate Parity traces API

### DIFF
--- a/core/src/main/java/org/web3j/protocol/parity/JsonRpc2_0Parity.java
+++ b/core/src/main/java/org/web3j/protocol/parity/JsonRpc2_0Parity.java
@@ -1,25 +1,34 @@
 package org.web3j.protocol.parity;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.web3j.crypto.WalletFile;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.JsonRpc2_0Personal;
 import org.web3j.protocol.admin.methods.response.NewAccountIdentifier;
 import org.web3j.protocol.admin.methods.response.PersonalSign;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.parity.methods.request.Derivation;
+import org.web3j.protocol.parity.methods.request.TraceFilter;
 import org.web3j.protocol.parity.methods.response.BooleanResponse;
 import org.web3j.protocol.parity.methods.response.ParityAddressesResponse;
 import org.web3j.protocol.parity.methods.response.ParityAllAccountsInfo;
 import org.web3j.protocol.parity.methods.response.ParityDefaultAddressResponse;
 import org.web3j.protocol.parity.methods.response.ParityDeriveAddress;
 import org.web3j.protocol.parity.methods.response.ParityExportAccount;
+import org.web3j.protocol.parity.methods.response.ParityFullTraceResponse;
 import org.web3j.protocol.parity.methods.response.ParityListRecentDapps;
+import org.web3j.protocol.parity.methods.response.ParityTraceGet;
+import org.web3j.protocol.parity.methods.response.ParityTracesResponse;
+import org.web3j.utils.Numeric;
 
 /**
  * JSON-RPC 2.0 factory implementation for Parity.
@@ -293,5 +302,83 @@ public class JsonRpc2_0Parity extends JsonRpc2_0Personal implements Parity {
                 ID,
                 web3jService,
                 PersonalSign.class);
+    }
+    
+    // TRACE API
+    
+    @Override
+    public Request<?, ParityFullTraceResponse> traceCall(
+            Transaction transaction, List<String> traces, DefaultBlockParameter blockParameter) {
+        return new Request<>(
+            "trace_call",
+            Arrays.asList(transaction, traces, blockParameter),
+            ID,
+            web3jService,
+            ParityFullTraceResponse.class);
+    }
+    
+    @Override
+    public Request<?, ParityFullTraceResponse> traceRawTransaction(
+            String data, List<String> traceTypes) {
+        return new Request<>(
+            "trace_rawTransaction",
+            Arrays.asList(data, traceTypes),
+            ID,
+            web3jService,
+            ParityFullTraceResponse.class);
+    }
+    
+    @Override
+    public Request<?, ParityFullTraceResponse> traceReplayTransaction(
+            String hash, List<String> traceTypes) {
+        return new Request<>(
+            "trace_replayTransaction",
+            Arrays.asList(hash, traceTypes),
+            ID,
+            web3jService,
+            ParityFullTraceResponse.class);
+    }
+    
+    @Override
+    public Request<?, ParityTracesResponse> traceBlock(DefaultBlockParameter blockParameter) {
+        return new Request<>(
+            "trace_block",
+            Arrays.asList(blockParameter),
+            ID,
+            web3jService,
+            ParityTracesResponse.class);
+    }
+    
+    @Override
+    public Request<?, ParityTracesResponse> traceFilter(TraceFilter traceFilter) {
+        return new Request<>(
+            "trace_filter",
+            Arrays.asList(traceFilter),
+            ID,
+            web3jService,
+            ParityTracesResponse.class);
+    }
+    
+    @Override
+    public Request<?, ParityTraceGet> traceGet(String hash, List<BigInteger> indices) {
+        List<String> encodedIndices = indices.stream()
+                .map(Numeric::encodeQuantity)
+                .collect(Collectors.toList());
+        return new Request<>(
+            "trace_get",
+            Arrays.asList(hash, encodedIndices),
+            ID,
+            web3jService,
+            ParityTraceGet.class);
+    }
+
+    @Override
+    public Request<?, ParityTracesResponse> traceTransaction(String hash) {
+        return new Request<>(
+            "trace_transaction",
+            Arrays.asList(hash),
+            ID,
+            web3jService,
+            ParityTracesResponse.class);
     }
 }

--- a/core/src/main/java/org/web3j/protocol/parity/Parity.java
+++ b/core/src/main/java/org/web3j/protocol/parity/Parity.java
@@ -22,7 +22,7 @@ import org.web3j.protocol.parity.methods.response.ParityListRecentDapps;
 /**
  * JSON-RPC Request object building factory for Parity.
  */
-public interface Parity extends Personal {
+public interface Parity extends Personal, Trace {
     static Parity build(Web3jService web3jService) {
         return new JsonRpc2_0Parity(web3jService);
     }
@@ -82,5 +82,5 @@ public interface Parity extends Personal {
     Request<?, BooleanResponse> parityTestPassword(String accountId, String password);
     
     Request<?, PersonalSign> paritySignMessage(
-            String accountId, String password, String hexMessage);    
+            String accountId, String password, String hexMessage);
 }

--- a/core/src/main/java/org/web3j/protocol/parity/Trace.java
+++ b/core/src/main/java/org/web3j/protocol/parity/Trace.java
@@ -1,0 +1,35 @@
+package org.web3j.protocol.parity;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.parity.methods.request.TraceFilter;
+import org.web3j.protocol.parity.methods.response.ParityFullTraceResponse;
+import org.web3j.protocol.parity.methods.response.ParityTraceGet;
+import org.web3j.protocol.parity.methods.response.ParityTracesResponse;
+
+/**
+ * * JSON-RPC Parity traces API request object building factory.
+ */
+public interface Trace {
+    Request<?, ParityFullTraceResponse> traceCall(
+            Transaction transaction,
+            List<String> traceTypes,
+            DefaultBlockParameter blockParameter);
+
+    Request<?, ParityFullTraceResponse> traceRawTransaction(String data, List<String> traceTypes);
+
+    Request<?, ParityFullTraceResponse> traceReplayTransaction(
+            String hash, List<String> traceTypes);
+
+    Request<?, ParityTracesResponse> traceBlock(DefaultBlockParameter blockParameter);
+
+    Request<?, ParityTracesResponse> traceFilter(TraceFilter traceFilter);
+
+    Request<?, ParityTraceGet> traceGet(String hash, List<BigInteger> indices);
+
+    Request<?, ParityTracesResponse> traceTransaction(String hash);
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/request/TraceFilter.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/request/TraceFilter.java
@@ -1,0 +1,43 @@
+package org.web3j.protocol.parity.methods.request;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.web3j.protocol.core.DefaultBlockParameter;
+
+/**
+ * TraceFilter used in trace_filter.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TraceFilter {
+
+    private DefaultBlockParameter fromBlock;
+    private DefaultBlockParameter toBlock;
+    private List<String> fromAddress;
+    private List<String> toAddress;
+
+    public TraceFilter(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock,
+            List<String> fromAddress, List<String> toAddress) {
+        this.fromBlock = fromBlock;
+        this.toBlock = toBlock;
+        this.fromAddress = fromAddress;
+        this.toAddress = toAddress;
+    }
+
+    public DefaultBlockParameter getFromBlock() {
+        return fromBlock;
+    }
+
+    public DefaultBlockParameter getToBlock() {
+        return toBlock;
+    }
+
+    public List<String> getFromAddress() {
+        return fromAddress;
+    }
+
+    public List<String> getToAddress() {
+        return toAddress;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/FullTraceInfo.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/FullTraceInfo.java
@@ -1,0 +1,100 @@
+package org.web3j.protocol.parity.methods.response;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FullTraceInfo used in following methods.
+ * <ol>
+ *     <li>trace_call</li>
+ *     <li>trace_rawTransaction</li>
+ *     <li>trace_replayTransaction</li>
+ * </ol>
+ */
+public class FullTraceInfo {
+
+    private String output;
+    private Map<String, StateDiff> stateDiff;
+    private List<Trace> trace;
+    private VMTrace vmTrace;
+
+    public FullTraceInfo() {
+    }
+
+    public FullTraceInfo(String output, Map<String, StateDiff> stateDiff,
+            List<Trace> trace, VMTrace vmTrace) {
+        this.output = output;
+        this.stateDiff = stateDiff;
+        this.trace = trace;
+        this.vmTrace = vmTrace;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public Map<String, StateDiff> getStateDiff() {
+        return stateDiff;
+    }
+
+    public void setStateDiff(Map<String, StateDiff> stateDiff) {
+        this.stateDiff = stateDiff;
+    }
+
+    public List<Trace> getTrace() {
+        return trace;
+    }
+
+    public void setTrace(List<Trace> trace) {
+        this.trace = trace;
+    }
+
+    public VMTrace getVmTrace() {
+        return vmTrace;
+    }
+
+    public void setVmTrace(VMTrace vmTrace) {
+        this.vmTrace = vmTrace;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof FullTraceInfo)) {
+            return false;
+        }
+
+        FullTraceInfo that = (FullTraceInfo) o;
+
+        if (getOutput() != null ? !getOutput().equals(that.getOutput())
+                : that.getOutput() != null) {
+            return false;
+        }
+        if (getStateDiff() != null ? !getStateDiff().equals(that.getStateDiff())
+                : that.getStateDiff() != null) {
+            return false;
+        }
+        if (getTrace() != null ? !getTrace().equals(that.getTrace())
+                : that.getTrace() != null) {
+            return false;
+        }
+        return getVmTrace() != null ? getVmTrace().equals(that.getVmTrace())
+                : that.getVmTrace() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getOutput() != null ? getOutput().hashCode() : 0;
+        result = 31 * result + (getStateDiff() != null ? getStateDiff().hashCode() : 0);
+        result = 31 * result + (getTrace() != null ? getTrace().hashCode() : 0);
+        result = 31 * result + (getVmTrace() != null ? getVmTrace().hashCode() : 0);
+        return result;
+    }
+
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityFullTraceResponse.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityFullTraceResponse.java
@@ -1,0 +1,13 @@
+package org.web3j.protocol.parity.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+/**
+ * trace_rawTransaction
+ * trace_replayTransaction.
+ */
+public class ParityFullTraceResponse extends Response<FullTraceInfo> {
+    public FullTraceInfo getFullTraceInfo() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityTraceGet.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityTraceGet.java
@@ -1,0 +1,12 @@
+package org.web3j.protocol.parity.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+/**
+ * trace_get.
+ */
+public class ParityTraceGet extends Response<Trace> {
+    public Trace getTrace() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityTracesResponse.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/ParityTracesResponse.java
@@ -1,0 +1,16 @@
+package org.web3j.protocol.parity.methods.response;
+
+import java.util.List;
+
+import org.web3j.protocol.core.Response;
+
+/**
+ * trace_block
+ * trace_filter
+ * trace_transaction.
+ */
+public class ParityTracesResponse extends Response<List<Trace>> {
+    public List<Trace> getTraces() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/StateDiff.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/StateDiff.java
@@ -1,0 +1,308 @@
+package org.web3j.protocol.parity.methods.response;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * StateDiff used in following methods.
+ * <ol>
+ *     <li>trace_call</li>
+ *     <li>trace_rawTransaction</li>
+ *     <li>trace_replayTransaction</li>
+ * </ol>
+ */
+public class StateDiff {
+
+    private State balance;
+    private State code;
+    private State nonce;
+    private Map<String, State> storage;
+
+    public interface State {
+
+        boolean isChanged();
+
+        String getFrom();
+
+        String getTo();
+
+    }
+
+    public static class ChangedState implements State {
+
+        private String from;
+        private String to;
+
+        public ChangedState() {
+        }
+
+        public ChangedState(String from, String to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        public void setFrom(String from) {
+            this.from = from;
+        }
+
+        public void setTo(String to) {
+            this.to = to;
+        }
+
+        @Override
+        public boolean isChanged() {
+            return true;
+        }
+
+        @Override
+        public String getFrom() {
+            return from;
+        }
+
+        @Override
+        public String getTo() {
+            return to;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof ChangedState)) {
+                return false;
+            }
+
+            ChangedState that = (ChangedState) o;
+
+            if (getFrom() != null ? !getFrom().equals(that.getFrom()) : that.getFrom() != null) {
+                return false;
+            }
+            return getTo() != null ? getTo().equals(that.getTo()) : that.getTo() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getFrom() != null ? getFrom().hashCode() : 0;
+            result = 31 * result + (getTo() != null ? getTo().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ChangedState{"
+                    + "from='" + from + '\''
+                    + ", to='" + to + '\''
+                    + '}';
+        }
+
+    }
+
+    public static class UnchangedState implements State {
+
+        public UnchangedState(String jsonString) {}
+
+        public UnchangedState() {
+        }
+
+        @Override
+        public boolean isChanged() {
+            return false;
+        }
+
+        @Override
+        public String getFrom() {
+            return null;
+        }
+
+        @Override
+        public String getTo() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o != null && (this == o || (o instanceof UnchangedState));
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+    }
+
+    public static class AddedState implements State {
+
+        private String value;
+
+        public AddedState() {
+
+        }
+
+        public AddedState(String value) {
+            this.value = value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getFrom() {
+            return null;
+        }
+
+        @Override
+        public String getTo() {
+            return value;
+        }
+
+        @Override
+        public boolean isChanged() {
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof AddedState)) {
+                return false;
+            }
+
+            AddedState that = (AddedState) o;
+
+            return value != null ? value.equals(that.value) : that.value == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "AddedState{"
+                    + "value='" + value + '\''
+                    + '}';
+        }
+
+    }
+
+    public StateDiff() {
+    }
+
+    public StateDiff(State balance, State code, State nonce, Map<String, State> storage) {
+        this.balance = balance;
+        this.code = code;
+        this.nonce = nonce;
+        this.storage = storage;
+    }
+
+    public State getBalance() {
+        return balance;
+    }
+
+    public void setBalance(JsonNode balance) {
+        this.balance = deserializeState(balance);
+    }
+
+    public State getCode() {
+        return code;
+    }
+
+    public void setCode(JsonNode code) {
+        this.code = deserializeState(code);
+    }
+
+    public State getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(JsonNode nonce) {
+        this.nonce = deserializeState(nonce);
+    }
+
+    public Map<String, State> getStorage() {
+        return storage;
+    }
+
+    public void setStorage(Map<String, JsonNode> storage) {
+        this.storage = storage.entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> deserializeState(entry.getValue()))
+            );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof StateDiff)) {
+            return false;
+        }
+
+        StateDiff that = (StateDiff) o;
+
+        if (getBalance() != null ? !getBalance().equals(that.getBalance())
+                : that.getBalance() != null) {
+            return false;
+        }
+        if (getCode() != null ? !getCode().equals(that.getCode())
+                : that.getCode() != null) {
+            return false;
+        }
+        if (getNonce() != null ? !getNonce().equals(that.getNonce())
+                : that.getNonce() != null) {
+            return false;
+        }
+        return getStorage() != null ? getStorage().equals(that.getStorage())
+                : that.getStorage() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getBalance() != null ? getBalance().hashCode() : 0;
+        result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+        result = 31 * result + (getNonce() != null ? getNonce().hashCode() : 0);
+        result = 31 * result + (getStorage() != null ? getStorage().hashCode() : 0);
+        return result;
+    }
+
+    private State deserializeState(JsonNode node) {
+        State state = null;
+        if (node.isTextual() && node.asText().equals("=")) {
+            state = new UnchangedState();
+        } else if (node.isObject() && node.has("*")) {
+            JsonNode subNode = node.get("*");
+            if (subNode.isObject() && subNode.has("from") && subNode.has("to")) {
+                state = new ChangedState(
+                    subNode.get("from").asText(),
+                    subNode.get("to").asText()
+                );
+            }
+        } else if (node.isObject() && node.has("+")) {
+            JsonNode subNode = node.get("+");
+            if (subNode.isTextual()) {
+                state = new AddedState(subNode.asText());
+            }
+        }
+        return state;
+    }
+
+    @Override
+    public String toString() {
+        return "StateDiff{"
+                + "balance=" + getBalance()
+                + ", code=" + getCode()
+                + ", nonce=" + getNonce()
+                + ", storage=" + getStorage()
+                + '}';
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/Trace.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/Trace.java
@@ -1,0 +1,684 @@
+package org.web3j.protocol.parity.methods.response;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.web3j.utils.Numeric;
+
+/**
+ * Trace used in following methods.
+ * <ol>
+ *     <li>trace_call</li>
+ *     <li>trace_rawTransaction</li>
+ *     <li>trace_replayTransaction</li>
+ *     <li>trace_block</li>
+ *     <li>trace_filter</li>
+ *     <li>trace_get</li>
+ * </ol>
+ */
+public class Trace {
+
+    private Action action;
+    private String error;
+    private Result result;
+    private BigInteger subtraces;
+    private List<BigInteger> traceAddress;
+    private String type;
+    private String blockHash;
+    private BigInteger blockNumber;
+    private String transactionHash;
+    private BigInteger transactionPosition;
+
+    @JsonDeserialize(using = ActionDeserializer.class)
+    public interface Action {
+
+    }
+
+    @JsonDeserialize()
+    public static class SuicideAction implements Action {
+
+        private String address;
+        private String balance;
+        private String refundAddress;
+
+        public SuicideAction() {
+        }
+
+        public SuicideAction(String address, String balance, String refundAddress) {
+            this.address = address;
+            this.balance = balance;
+            this.refundAddress = refundAddress;
+        }
+
+        public String getAddress() {
+            return address;
+        }
+
+        public void setAddress(String address) {
+            this.address = address;
+        }
+
+        public BigInteger getBalance() {
+            return Numeric.decodeQuantity(balance);
+        }
+
+        public String getBalanceRaw() {
+            return balance;
+        }
+
+        public void setBalance(String balance) {
+            this.balance = balance;
+        }
+
+        public String getRefundAddress() {
+            return refundAddress;
+        }
+
+        public void setRefundAddress(String refundAddress) {
+            this.refundAddress = refundAddress;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof SuicideAction)) {
+                return false;
+            }
+
+            SuicideAction that = (SuicideAction) o;
+
+            if (getAddress() != null ? !getAddress().equals(that.getAddress())
+                    : that.getAddress() != null) {
+                return false;
+            }
+            if (getBalanceRaw() != null ? !getBalanceRaw().equals(that.getBalanceRaw())
+                    : that.getBalanceRaw() != null) {
+                return false;
+            }
+            return getRefundAddress() != null ? getRefundAddress().equals(that.getRefundAddress())
+                    : that.getRefundAddress() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getAddress() != null ? getAddress().hashCode() : 0;
+            result = 31 * result + (getBalanceRaw() != null ? getBalanceRaw().hashCode() : 0);
+            result = 31 * result + (getRefundAddress() != null ? getRefundAddress().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "SuicideAction{"
+                    + "address='" + getAddress() + '\''
+                    + ", balance='" + getBalanceRaw() + '\''
+                    + ", refundAddress='" + getRefundAddress() + '\''
+                    + '}';
+        }
+    }
+
+    @JsonDeserialize()
+    public static class CallAction implements Action {
+
+        private String callType;
+        private String from;
+        private String to;
+        private String gas;
+        private String input;
+        private String value;
+
+        public CallAction() {
+        }
+
+        public CallAction(String callType, String from, String to, String gas, String input,
+                String value) {
+            this.callType = callType;
+            this.from = from;
+            this.to = to;
+            this.gas = gas;
+            this.input = input;
+            this.value = value;
+        }
+
+        public String getCallType() {
+            return callType;
+        }
+
+        public void setCallType(String callType) {
+            this.callType = callType;
+        }
+
+        public String getFrom() {
+            return from;
+        }
+
+        public void setFrom(String from) {
+            this.from = from;
+        }
+
+        public String getTo() {
+            return to;
+        }
+
+        public void setTo(String to) {
+            this.to = to;
+        }
+
+        public BigInteger getGas() {
+            return Numeric.decodeQuantity(gas);
+        }
+
+        public String getGasRaw() {
+            return gas;
+        }
+
+        public void setGas(String gas) {
+            this.gas = gas;
+        }
+
+        public String getInput() {
+            return input;
+        }
+
+        public void setInput(String input) {
+            this.input = input;
+        }
+
+        public BigInteger getValue() {
+            return Numeric.decodeQuantity(value);
+        }
+
+        public String getValueRaw() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CallAction)) {
+                return false;
+            }
+
+            CallAction that = (CallAction) o;
+
+            if (getCallType() != null ? !getCallType().equals(that.getCallType())
+                    : that.getCallType() != null) {
+                return false;
+            }
+            if (getFrom() != null ? !getFrom().equals(that.getFrom())
+                    : that.getFrom() != null) {
+                return false;
+            }
+            if (getTo() != null ? !getTo().equals(that.getTo())
+                    : that.getTo() != null) {
+                return false;
+            }
+            if (getGasRaw() != null ? !getGasRaw().equals(that.getGasRaw())
+                    : that.getGasRaw() != null) {
+                return false;
+            }
+            if (getInput() != null ? !getInput().equals(that.getInput())
+                    : that.getInput() != null) {
+                return false;
+            }
+            return getValueRaw() != null ? getValueRaw().equals(that.getValueRaw())
+                    : that.getValueRaw() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getCallType() != null ? getCallType().hashCode() : 0;
+            result = 31 * result + (getFrom() != null ? getFrom().hashCode() : 0);
+            result = 31 * result + (getTo() != null ? getTo().hashCode() : 0);
+            result = 31 * result + (getGasRaw() != null ? getGasRaw().hashCode() : 0);
+            result = 31 * result + (getInput() != null ? getInput().hashCode() : 0);
+            result = 31 * result + (getValueRaw() != null ? getValueRaw().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "CallAction{"
+                    + "callType='" + getCallType() + '\''
+                    + ", from='" + getFrom() + '\''
+                    + ", to='" + getTo() + '\''
+                    + ", gas='" + getGasRaw() + '\''
+                    + ", input='" + getInput() + '\''
+                    + ", value='" + getValueRaw() + '\''
+                    + '}';
+        }
+    }
+
+    @JsonDeserialize()
+    public static class CreateAction implements Action {
+
+        private String from;
+        private String gas;
+        private String value;
+        private String init;
+
+        public CreateAction() {
+        }
+
+        public CreateAction(String from, String gas, String value, String init) {
+            this.from = from;
+            this.gas = gas;
+            this.value = value;
+            this.init = init;
+        }
+
+        public BigInteger getValue() {
+            return Numeric.decodeQuantity(value);
+        }
+
+        public String getValueRaw() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        public BigInteger getGas() {
+            return Numeric.decodeQuantity(gas);
+        }
+
+        public String getGasRaw() {
+            return gas;
+        }
+
+        public void setGas(String gas) {
+            this.gas = gas;
+        }
+
+        public String getFrom() {
+            return from;
+        }
+
+        public void setFrom(String from) {
+            this.from = from;
+        }
+
+        public String getInit() {
+            return init;
+        }
+
+        public void setInit(String init) {
+            this.init = init;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CreateAction)) {
+                return false;
+            }
+
+            CreateAction that = (CreateAction) o;
+
+            if (getFrom() != null ? !getFrom().equals(that.getFrom())
+                    : that.getFrom() != null) {
+                return false;
+            }
+            if (getGasRaw() != null ? !getGasRaw().equals(that.getGasRaw())
+                    : that.getGasRaw() != null) {
+                return false;
+            }
+            if (getValueRaw() != null ? !getValueRaw().equals(that.getValueRaw())
+                    : that.getValueRaw() != null) {
+                return false;
+            }
+            return getInit() != null ? getInit().equals(that.getInit())
+                    : that.getInit() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getFrom() != null ? getFrom().hashCode() : 0;
+            result = 31 * result + (getGasRaw() != null ? getGasRaw().hashCode() : 0);
+            result = 31 * result + (getValueRaw() != null ? getValueRaw().hashCode() : 0);
+            result = 31 * result + (getInit() != null ? getInit().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "CreateAction{"
+                    + "from='" + getFrom() + '\''
+                    + ", gas='" + getGasRaw() + '\''
+                    + ", value='" + getValueRaw() + '\''
+                    + ", init='" + getInit() + '\''
+                    + '}';
+        }
+    }
+
+    public static class Result {
+
+        private String address;
+        private String code;
+        private String gasUsed;
+        private String output;
+
+        public Result() {
+        }
+
+        public Result(String address, String code, String gasUsed, String output) {
+            this.address = address;
+            this.code = code;
+            this.gasUsed = gasUsed;
+            this.output = output;
+        }
+
+        public String getAddress() {
+            return address;
+        }
+
+        public void setAddress(String address) {
+            this.address = address;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public BigInteger getGasUsed() {
+            return Numeric.decodeQuantity(gasUsed);
+        }
+
+        public String getGasUsedRaw() {
+            return gasUsed;
+        }
+
+        public void setGasUsed(String gasUsed) {
+            this.gasUsed = gasUsed;
+        }
+
+        public String getOutput() {
+            return output;
+        }
+
+        public void setOutput(String output) {
+            this.output = output;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof Result)) {
+                return false;
+            }
+
+            Result result = (Result) o;
+
+            if (getAddress() != null ? !getAddress().equals(result.getAddress())
+                    : result.getAddress() != null) {
+                return false;
+            }
+            if (getCode() != null ? !getCode().equals(result.getCode())
+                    : result.getCode() != null) {
+                return false;
+            }
+            if (getGasUsedRaw() != null ? !getGasUsedRaw().equals(result.getGasUsedRaw())
+                    : result.getGasUsedRaw() != null) {
+                return false;
+            }
+            return getOutput() != null ? getOutput().equals(result.getOutput())
+                    : result.getOutput() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getAddress() != null ? getAddress().hashCode() : 0;
+            result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+            result = 31 * result + (getGasUsedRaw() != null ? getGasUsedRaw().hashCode() : 0);
+            result = 31 * result + (getOutput() != null ? getOutput().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Result{"
+                    + "address='" + getAddress() + '\''
+                    + ", code='" + getCode() + '\''
+                    + ", gasUsed='" + getGasUsedRaw() + '\''
+                    + ", output='" + getOutput() + '\''
+                    + '}';
+        }
+    }
+
+    public Trace() {
+    }
+
+    public Trace(Action action, String error, Result result, BigInteger subtraces,
+                 List<BigInteger> traceAddress, String type, String blockHash,
+                 BigInteger blockNumber, String transactionHash, BigInteger transactionPosition) {
+        this.action = action;
+        this.error = error;
+        this.result = result;
+        this.subtraces = subtraces;
+        this.traceAddress = traceAddress;
+        this.type = type;
+        this.blockHash = blockHash;
+        this.blockNumber = blockNumber;
+        this.transactionHash = transactionHash;
+        this.transactionPosition = transactionPosition;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    public BigInteger getSubtraces() {
+        return subtraces;
+    }
+
+    public void setSubtraces(BigInteger subtraces) {
+        this.subtraces = subtraces;
+    }
+
+    public List<BigInteger> getTraceAddress() {
+        return traceAddress;
+    }
+
+    public void setTraceAddress(List<BigInteger> traceAddress) {
+        this.traceAddress = traceAddress;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public BigInteger getBlockNumber() {
+        return blockNumber;
+    }
+
+    public void setBlockNumber(BigInteger blockNumber) {
+        this.blockNumber = blockNumber;
+    }
+
+    public String getTransactionHash() {
+        return transactionHash;
+    }
+
+    public void setTransactionHash(String transactionHash) {
+        this.transactionHash = transactionHash;
+    }
+
+    public BigInteger getTransactionPosition() {
+        return transactionPosition;
+    }
+
+    public void setTransactionPosition(BigInteger transactionPosition) {
+        this.transactionPosition = transactionPosition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof Trace)) {
+            return false;
+        }
+
+        Trace trace = (Trace) o;
+
+        if (getAction() != null ? !getAction().equals(trace.getAction())
+                : trace.getAction() != null) {
+            return false;
+        }
+        if (getError() != null ? !getError().equals(trace.getError())
+                : trace.getError() != null) {
+            return false;
+        }
+        if (getResult() != null ? !getResult().equals(trace.getResult())
+                : trace.getResult() != null) {
+            return false;
+        }
+        if (getSubtraces() != null ? !getSubtraces().equals(trace.getSubtraces())
+                : trace.getSubtraces() != null) {
+            return false;
+        }
+        if (getTraceAddress() != null ? !getTraceAddress().equals(trace.getTraceAddress())
+                : trace.getTraceAddress() != null) {
+            return false;
+        }
+        if (getType() != null ? !getType().equals(trace.getType())
+                : trace.getType() != null) {
+            return false;
+        }
+        if (getBlockHash() != null ? !getBlockHash().equals(trace.getBlockHash())
+                : trace.getBlockHash() != null) {
+            return false;
+        }
+        if (getBlockNumber() != null ? !getBlockNumber().equals(trace.getBlockNumber())
+                : trace.getBlockNumber() != null) {
+            return false;
+        }
+        if (getTransactionHash() != null ? !getTransactionHash().equals(trace.getTransactionHash())
+                : trace.getTransactionHash() != null) {
+            return false;
+        }
+        return getTransactionPosition() != null
+                ? getTransactionPosition().equals(trace.getTransactionPosition())
+                : trace.getTransactionPosition() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result1 = getAction() != null
+                ? getAction().hashCode() : 0;
+        result1 = 31 * result1 + (getError() != null
+                ? getError().hashCode() : 0);
+        result1 = 31 * result1 + (getResult() != null
+                ? getResult().hashCode() : 0);
+        result1 = 31 * result1 + (getSubtraces() != null
+                ? getSubtraces().hashCode() : 0);
+        result1 = 31 * result1 + (getTraceAddress() != null
+                ? getTraceAddress().hashCode() : 0);
+        result1 = 31 * result1 + (getType() != null
+                ? getType().hashCode() : 0);
+        result1 = 31 * result1 + (getBlockHash() != null
+                ? getBlockHash().hashCode() : 0);
+        result1 = 31 * result1 + (getBlockNumber() != null
+                ? getBlockNumber().hashCode() : 0);
+        result1 = 31 * result1 + (getTransactionHash() != null
+                ? getTransactionHash().hashCode() : 0);
+        result1 = 31 * result1 + (getTransactionPosition() != null
+                ? getTransactionPosition().hashCode() : 0);
+        return result1;
+    }
+
+    @Override
+    public String toString() {
+        return "Trace{"
+                + "action=" + getAction()
+                + ", error='" + getError() + '\''
+                + ", result=" + getResult()
+                + ", subtraces=" + getSubtraces()
+                + ", traceAddress=" + getTraceAddress()
+                + ", type='" + getType() + '\''
+                + ", blockHash='" + getBlockHash() + '\''
+                + ", blockNumber=" + getBlockNumber()
+                + ", transactionHash='" + getTransactionHash() + '\''
+                + ", transactionPosition=" + getTransactionPosition()
+                + '}';
+    }
+
+    public static class ActionDeserializer extends JsonDeserializer<Action> {
+
+        @Override
+        public Action deserialize(JsonParser jsonParser, DeserializationContext context)
+                throws IOException {
+            ObjectMapper objectMapper = (ObjectMapper) jsonParser.getCodec();
+            ObjectNode root = objectMapper.readTree(jsonParser);
+
+            if (root.has("callType")) {
+                return objectMapper.convertValue(root, CallAction.class);
+            } else if (root.has("init")) {
+                return objectMapper.convertValue(root, CreateAction.class);
+            } else if (root.has("refundAddress")) {
+                return objectMapper.convertValue(root, SuicideAction.class);
+            }
+
+            return null;
+        }
+
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/parity/methods/response/VMTrace.java
+++ b/core/src/main/java/org/web3j/protocol/parity/methods/response/VMTrace.java
@@ -1,0 +1,390 @@
+package org.web3j.protocol.parity.methods.response;
+
+import java.math.BigInteger;
+import java.util.List;
+
+/**
+ * VMTrace used in following methods.
+ * <ol>
+ *     <li>trace_call</li>
+ *     <li>trace_rawTransaction</li>
+ *     <li>trace_replayTransaction</li>
+ * </ol>
+ */
+public class VMTrace {
+
+    private String code;
+    private List<VMOperation> ops;
+
+    public static class VMOperation {
+
+        private VMTrace sub;
+        private BigInteger cost;
+        private Ex ex;
+        private BigInteger pc;
+
+        public static class Ex {
+
+            private Mem mem;
+            private List<String> push;
+            private Store store;
+            private BigInteger used;
+
+            public static class Mem {
+
+                private String data;
+                private BigInteger off;
+
+                public Mem() {
+                }
+
+                public Mem(String data, BigInteger off) {
+                    this.data = data;
+                    this.off = off;
+                }
+
+                public String getData() {
+                    return data;
+                }
+
+                public void setData(String data) {
+                    this.data = data;
+                }
+
+                public BigInteger getOff() {
+                    return off;
+                }
+
+                public void setOff(BigInteger off) {
+                    this.off = off;
+                }
+
+                @Override
+                public boolean equals(Object o) {
+                    if (this == o) {
+                        return true;
+                    }
+                    if (o == null || !(o instanceof Mem)) {
+                        return false;
+                    }
+
+                    Mem mem = (Mem) o;
+
+                    if (getData() != null ? !getData().equals(mem.getData())
+                            : mem.getData() != null) {
+                        return false;
+                    }
+                    return getOff() != null ? getOff().equals(mem.getOff())
+                            : mem.getOff() == null;
+                }
+
+                @Override
+                public int hashCode() {
+                    int result = getData() != null ? getData().hashCode() : 0;
+                    result = 31 * result + (getOff() != null ? getOff().hashCode() : 0);
+                    return result;
+                }
+
+                @Override
+                public String toString() {
+                    return "Mem{"
+                            + "data='" + getData() + '\''
+                            + ", off=" + getOff()
+                            + '}';
+                }
+            }
+
+            public static class Store {
+
+                String key;
+                String val;
+
+                public Store() {
+                }
+
+                public Store(String key, String val) {
+                    this.key = key;
+                    this.val = val;
+                }
+
+                public String getKey() {
+                    return key;
+                }
+
+                public void setKey(String key) {
+                    this.key = key;
+                }
+
+                public String getVal() {
+                    return val;
+                }
+
+                public void setVal(String val) {
+                    this.val = val;
+                }
+
+                @Override
+                public boolean equals(Object o) {
+                    if (this == o) {
+                        return true;
+                    }
+                    if (o == null || !(o instanceof Store)) {
+                        return false;
+                    }
+
+                    Store store = (Store) o;
+
+                    if (getKey() != null ? !getKey().equals(store.getKey())
+                            : store.getKey() != null) {
+                        return false;
+                    }
+                    return getVal() != null ? getVal().equals(store.getVal())
+                            : store.getVal() == null;
+                }
+
+                @Override
+                public int hashCode() {
+                    int result = getKey() != null ? getKey().hashCode() : 0;
+                    result = 31 * result + (getVal() != null ? getVal().hashCode() : 0);
+                    return result;
+                }
+
+                @Override
+                public String toString() {
+                    return "Store{"
+                            + "key='" + getKey() + '\''
+                            + ", val='" + getVal() + '\''
+                            + '}';
+                }
+            }
+
+            public Ex() {
+            }
+
+            public Ex(Mem mem, List<String> push, Store store, BigInteger used) {
+                this.mem = mem;
+                this.push = push;
+                this.store = store;
+                this.used = used;
+            }
+
+            public Mem getMem() {
+                return mem;
+            }
+
+            public void setMem(Mem mem) {
+                this.mem = mem;
+            }
+
+            public List<String> getPush() {
+                return push;
+            }
+
+            public void setPush(List<String> push) {
+                this.push = push;
+            }
+
+            public Store getStore() {
+                return store;
+            }
+
+            public void setStore(Store store) {
+                this.store = store;
+            }
+
+            public BigInteger getUsed() {
+                return used;
+            }
+
+            public void setUsed(BigInteger used) {
+                this.used = used;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || !(o instanceof Ex)) {
+                    return false;
+                }
+
+                Ex ex = (Ex) o;
+
+                if (getMem() != null ? !getMem().equals(ex.getMem())
+                        : ex.getMem() != null) {
+                    return false;
+                }
+                if (getPush() != null ? !getPush().equals(ex.getPush())
+                        : ex.getPush() != null) {
+                    return false;
+                }
+                if (getStore() != null ? !getStore().equals(ex.getStore())
+                        : ex.getStore() != null) {
+                    return false;
+                }
+                return getUsed() != null ? getUsed().equals(ex.getUsed())
+                        : ex.getUsed() == null;
+            }
+
+            @Override
+            public int hashCode() {
+                int result = getMem() != null ? getMem().hashCode() : 0;
+                result = 31 * result + (getPush() != null ? getPush().hashCode() : 0);
+                result = 31 * result + (getStore() != null ? getStore().hashCode() : 0);
+                result = 31 * result + (getUsed() != null ? getUsed().hashCode() : 0);
+                return result;
+            }
+
+            @Override
+            public String toString() {
+                return "Ex{"
+                        + "mem=" + getMem()
+                        + ", push=" + getPush()
+                        + ", store=" + getStore()
+                        + ", used=" + getUsed()
+                        + '}';
+            }
+        }
+
+        public VMOperation() {
+        }
+
+        public VMOperation(VMTrace sub, BigInteger cost, Ex ex, BigInteger pc) {
+            this.sub = sub;
+            this.cost = cost;
+            this.ex = ex;
+            this.pc = pc;
+        }
+
+        public VMTrace getSub() {
+            return sub;
+        }
+
+        public void setSub(VMTrace sub) {
+            this.sub = sub;
+        }
+
+        public BigInteger getCost() {
+            return cost;
+        }
+
+        public void setCost(BigInteger cost) {
+            this.cost = cost;
+        }
+
+        public Ex getEx() {
+            return ex;
+        }
+
+        public void setEx(Ex ex) {
+            this.ex = ex;
+        }
+
+        public BigInteger getPc() {
+            return pc;
+        }
+
+        public void setPc(BigInteger pc) {
+            this.pc = pc;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof VMOperation)) {
+                return false;
+            }
+
+            VMOperation that = (VMOperation) o;
+
+            if (getSub() != null ? !getSub().equals(that.getSub()) : that.getSub() != null) {
+                return false;
+            }
+            if (getCost() != null ? !getCost().equals(that.getCost()) : that.getCost() != null) {
+                return false;
+            }
+            if (getEx() != null ? !getEx().equals(that.getEx()) : that.getEx() != null) {
+                return false;
+            }
+            return getPc() != null ? getPc().equals(that.getPc()) : that.getPc() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getSub() != null ? getSub().hashCode() : 0;
+            result = 31 * result + (getCost() != null ? getCost().hashCode() : 0);
+            result = 31 * result + (getEx() != null ? getEx().hashCode() : 0);
+            result = 31 * result + (getPc() != null ? getPc().hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "VMOperation{"
+                    + "sub=" + getSub()
+                    + ", cost=" + getCost()
+                    + ", ex=" + getEx()
+                    + ", pc=" + getPc()
+                    + '}';
+        }
+    }
+
+    public VMTrace() {
+    }
+
+    public VMTrace(String code, List<VMOperation> ops) {
+        this.code = code;
+        this.ops = ops;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public List<VMOperation> getOps() {
+        return ops;
+    }
+
+    public void setOps(List<VMOperation> ops) {
+        this.ops = ops;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof VMTrace)) {
+            return false;
+        }
+
+        VMTrace vmTrace = (VMTrace) o;
+
+        if (getCode() != null ? !getCode().equals(vmTrace.getCode()) : vmTrace.getCode() != null) {
+            return false;
+        }
+        return getOps() != null ? getOps().equals(vmTrace.getOps()) : vmTrace.getOps() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getCode() != null ? getCode().hashCode() : 0;
+        result = 31 * result + (getOps() != null ? getOps().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "VMTrace{"
+                + "code='" + getCode() + '\''
+                + ", ops=" + getOps()
+                + '}';
+    }
+}

--- a/core/src/test/java/org/web3j/protocol/core/EqualsVerifierResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/EqualsVerifierResponseTest.java
@@ -4,7 +4,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
-import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthCompileSolidity;

--- a/core/src/test/java/org/web3j/protocol/parity/EqualsVerifierParityResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/parity/EqualsVerifierParityResponseTest.java
@@ -1,10 +1,17 @@
 package org.web3j.protocol.parity;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
+import org.web3j.protocol.parity.methods.response.FullTraceInfo;
 import org.web3j.protocol.parity.methods.response.ParityAllAccountsInfo;
+import org.web3j.protocol.parity.methods.response.StateDiff;
+import org.web3j.protocol.parity.methods.response.Trace;
+import org.web3j.protocol.parity.methods.response.VMTrace;
 
 public class EqualsVerifierParityResponseTest {
 
@@ -15,4 +22,140 @@ public class EqualsVerifierParityResponseTest {
                 .suppress(Warning.STRICT_INHERITANCE)
                 .verify();
     }
+
+
+    @Test
+    public void testFullTraceInfo() {
+        VMTrace vmTrace1 = new VMTrace("one", new ArrayList<>());
+        VMTrace vmTrace2 = new VMTrace("two", new ArrayList<>());
+
+        EqualsVerifier.forClass(FullTraceInfo.class)
+                .withPrefabValues(VMTrace.class, vmTrace1, vmTrace2)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testStateDiff() {
+        EqualsVerifier.forClass(StateDiff.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testChangedState() {
+        EqualsVerifier.forClass(StateDiff.ChangedState.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testUnchangedState() {
+        EqualsVerifier.forClass(StateDiff.UnchangedState.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testAddedState() {
+        EqualsVerifier.forClass(StateDiff.AddedState.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testVMTrace() {
+        VMTrace.VMOperation op1 = new VMTrace.VMOperation(
+                null, BigInteger.ZERO, null, null);
+        VMTrace.VMOperation op2 = new VMTrace.VMOperation(
+                null, BigInteger.ONE, null, null);
+
+        EqualsVerifier.forClass(VMTrace.class)
+                .withPrefabValues(VMTrace.VMOperation.class, op1, op2)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testVMTraceVMOperation() {
+        VMTrace vmTrace1 = new VMTrace("one", new ArrayList<>());
+        VMTrace vmTrace2 = new VMTrace("two", new ArrayList<>());
+
+        EqualsVerifier.forClass(VMTrace.VMOperation.class)
+                .withPrefabValues(VMTrace.class, vmTrace1, vmTrace2)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testVMTraceVMOperationEx() {
+        EqualsVerifier.forClass(VMTrace.VMOperation.Ex.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testVMTraceVMOperationExMem() {
+        EqualsVerifier.forClass(VMTrace.VMOperation.Ex.Mem.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testVMTraceVMOperationExStore() {
+        EqualsVerifier.forClass(VMTrace.VMOperation.Ex.Store.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testTrace() {
+        EqualsVerifier.forClass(Trace.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testTraceSuicideAction() {
+        EqualsVerifier.forClass(Trace.SuicideAction.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testTraceCallAction() {
+        EqualsVerifier.forClass(Trace.CallAction.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testTraceCreateAction() {
+        EqualsVerifier.forClass(Trace.CreateAction.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    public void testTraceResult() {
+        EqualsVerifier.forClass(Trace.Result.class)
+                .suppress(Warning.NONFINAL_FIELDS)
+                .suppress(Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
 }

--- a/core/src/test/java/org/web3j/protocol/parity/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/parity/ResponseTest.java
@@ -1,8 +1,12 @@
 package org.web3j.protocol.parity;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -10,15 +14,21 @@ import org.junit.Test;
 import org.web3j.crypto.WalletFile;
 import org.web3j.protocol.ResponseTester;
 import org.web3j.protocol.core.methods.response.VoidResponse;
+import org.web3j.protocol.parity.methods.response.FullTraceInfo;
 import org.web3j.protocol.parity.methods.response.ParityAddressesResponse;
 import org.web3j.protocol.parity.methods.response.ParityAllAccountsInfo;
 import org.web3j.protocol.parity.methods.response.ParityDefaultAddressResponse;
 import org.web3j.protocol.parity.methods.response.ParityDeriveAddress;
 import org.web3j.protocol.parity.methods.response.ParityExportAccount;
+import org.web3j.protocol.parity.methods.response.ParityFullTraceResponse;
 import org.web3j.protocol.parity.methods.response.ParityListRecentDapps;
+import org.web3j.protocol.parity.methods.response.StateDiff;
+import org.web3j.protocol.parity.methods.response.Trace;
+import org.web3j.protocol.parity.methods.response.VMTrace;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -186,4 +196,338 @@ public class ResponseTest extends ResponseTester {
         VoidResponse voidResponse = deserialiseResponse(VoidResponse.class);
         assertTrue(voidResponse.isValid());
     }
+
+    @Test
+    public void testParityFullTraceResponseStateDiff() {
+        //CHECKSTYLE:OFF
+        buildResponse("{\n"
+                + "    \"jsonrpc\": \"2.0\",\n"
+                + "    \"id\":22,\n"
+                + "    \"result\": {\n"
+                + "        \"output\": \"0x\",\n"
+                + "        \"stateDiff\": {\n"
+                + "            \"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de\": {\n"
+                + "                \"balance\": {\n"
+                + "                    \"*\": {\n"
+                + "                        \"from\": \"0x2067ee238a4648bed5797\",\n"
+                + "                        \"to\": \"0x2067ee23f5d09db3d0397\"\n"
+                + "                    }\n"
+                + "                },\n"
+                + "                \"code\": \"=\",\n"
+                + "                \"nonce\": \"=\",\n"
+                + "                \"storage\": {}\n"
+                + "            },\n"
+                + "            \"0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a\": {\n"
+                + "                \"balance\": {\n"
+                + "                    \"*\": {\n"
+                + "                        \"from\": \"0xf85a746b58c1fee\",\n"
+                + "                        \"to\": \"0xf7eeea1663c73ee\"\n"
+                + "                    }\n"
+                + "                },\n"
+                + "                \"code\": \"=\",\n"
+                + "                \"nonce\": {\n"
+                + "                    \"*\": {\n"
+                + "                        \"from\": \"0x15\",\n"
+                + "                        \"to\": \"0x16\"\n"
+                + "                    }\n"
+                + "                },\n"
+                + "                \"storage\": {}\n"
+                + "            },\n"
+                + "            \"0x1a4298d0edc00618310e4c26f6479e5cccdfeaf8\": {\n"
+                + "                \"balance\": {\n"
+                + "                    \"+\": \"0x0\"\n"
+                + "                },\n"
+                + "                \"code\": {\n"
+                + "                    \"+\": \"0x6060604052361561004a576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806341c0e1b51461004e578063b46300ec14610063575b5b5b005b341561005957600080fd5b61006161006d565b005b61006b6100ff565b005b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156100fc576000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16ff5b5b565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f19350505050151561017757600080fd5b5b5600a165627a7a72305820a6f301a38f55ea4c326a17bb26afad4aad7ed9dd49e1954d2b8995595e0ffceb0029\"\n"
+                + "                },\n"
+                + "                \"nonce\": {\n"
+                + "                    \"+\": \"0x1\"\n"
+                + "                },\n"
+                + "                \"storage\": {\n"
+                + "                    \"0x0000000000000000000000000000000000000000000000000000000000000000\": {\n"
+                + "                        \"+\": \"0x00000000000000000000000014772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a\"\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            }\n"
+                + "        }"
+                + "    },\n"
+                + "    \"id\": 1\n"
+                + "}"
+        );
+        //CHECKSTYLE:ON
+
+        ParityFullTraceResponse response = deserialiseResponse(ParityFullTraceResponse.class);
+        assertNotNull(response);
+
+        Map<String, StateDiff> stateDiffMap = new LinkedHashMap<>();
+        stateDiffMap.put("0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de", new StateDiff(
+                new StateDiff.ChangedState("0x2067ee238a4648bed5797", "0x2067ee23f5d09db3d0397"),
+                new StateDiff.UnchangedState(),
+                new StateDiff.UnchangedState(),
+                new HashMap<>()
+        ));
+        stateDiffMap.put("0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a", new StateDiff(
+                new StateDiff.ChangedState("0xf85a746b58c1fee", "0xf7eeea1663c73ee"),
+                new StateDiff.UnchangedState(),
+                new StateDiff.ChangedState("0x15", "0x16"),
+                new HashMap<>()
+        ));
+        //CHECKSTYLE:OFF
+        stateDiffMap.put("0x1a4298d0edc00618310e4c26f6479e5cccdfeaf8", new StateDiff(
+                new StateDiff.AddedState("0x0"),
+                new StateDiff.AddedState("0x6060604052361561004a576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806341c0e1b51461004e578063b46300ec14610063575b5b5b005b341561005957600080fd5b61006161006d565b005b61006b6100ff565b005b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156100fc576000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16ff5b5b565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f19350505050151561017757600080fd5b5b5600a165627a7a72305820a6f301a38f55ea4c326a17bb26afad4aad7ed9dd49e1954d2b8995595e0ffceb0029"),
+                new StateDiff.AddedState("0x1"),
+                new HashMap<>(Collections.singletonMap(
+                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        new StateDiff.AddedState("0x00000000000000000000000014772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a"))
+                )
+        ));
+        //CHECKSTYLE:ON
+        FullTraceInfo info = new FullTraceInfo("0x", stateDiffMap, null, null);
+        assertThat(response.getFullTraceInfo(), equalTo(info));
+    }
+
+    @Test
+    public void testParityFullTraceResponseTraces() {
+        //CHECKSTYLE:OFF
+        // hacked together from multiple requests and the code shortened
+        buildResponse("{\n"
+                + "    \"jsonrpc\": \"2.0\",\n"
+                + "    \"id\":22,\n"
+                + "    \"result\": {\n"
+                + "        \"output\": \"0x\",\n"
+                + "        \"stateDiff\": null,\n"
+                + "        \"trace\": [{\n"
+                + "                \"action\": {\n"
+                + "                    \"from\": \"0x6c24f4387b31251fd7b6d7a1269d880b2108bf3a\",\n"
+                + "                    \"gas\": \"0x4bc1f5\",\n"
+                + "                    \"init\": \"0x606060405234156200000d57fe5b60405162004e4038038062004e40833981016040908152815\",\n"
+                + "                    \"value\": \"0x0\"\n"
+                + "                },\n"
+                + "                \"blockHash\": \"0xf831abfdc67fb2ea3d16b6510b8e37d3d3e52ce3c25ed345053cb9503a430dd8\",\n"
+                + "                \"blockNumber\": 4019912,\n"
+                + "                \"result\": {\n"
+                + "                    \"address\": \"0x1c9997559f6f1ae2ece8525eab68709f50865165\",\n"
+                + "                    \"code\": \"0x606060405236156102b95763ffffffff60e060020a600035041663095ea7b381146102bb578063\",\n"
+                + "                    \"gasUsed\": \"0x3ef6fe\"\n"
+                + "                },\n"
+                + "                \"subtraces\": 0,\n"
+                + "                \"traceAddress\": [\n"
+                + "\n"
+                + "                ],\n"
+                + "                \"transactionHash\": \"0x3d30d01a470dc4ae92e87f4c0068d640f880ce27e8b863780cbcb748f1654939\",\n"
+                + "                \"transactionPosition\": 1,\n"
+                + "                \"type\": \"create\"\n"
+                + "            }, {\n"
+                + "                \"action\": {\n"
+                + "                    \"callType\": \"call\",\n"
+                + "                    \"from\": \"0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a\",\n"
+                + "                    \"gas\": \"0x4f6c5\",\n"
+                + "                    \"input\": \"0xb46300ec\",\n"
+                + "                    \"to\": \"0x781ab1a38837e351bfe1e318c6587766848abffa\",\n"
+                + "                    \"value\": \"0x0\"\n"
+                + "                },\n"
+                + "                \"error\": \"Bad instruction\",\n"
+                + "                \"subtraces\": 1,\n"
+                + "                \"traceAddress\": [\n"
+                + "\n"
+                + "                ],\n"
+                + "                \"type\": \"call\"\n"
+                + "            }, {\n"
+                + "                \"action\": {\n"
+                + "                    \"address\": \"0xb8d2ac822f3d0445f5b83d32b0b176c2cb3d0e60\",\n"
+                + "                    \"balance\": \"0x0\",\n"
+                + "                    \"refundAddress\": \"0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a\"\n"
+                + "                },\n"
+                + "                \"blockHash\": \"0xf263b9364434a781057c467004e8d398d915529bdffa6f600d6d17fe733d3210\",\n"
+                + "                \"blockNumber\": 3740614,\n"
+                + "                \"result\": null,\n"
+                + "                \"subtraces\": 0,\n"
+                + "                \"traceAddress\": [\n"
+                + "                    0\n"
+                + "                ],\n"
+                + "                \"transactionHash\": \"0xea6649db0f88d5400159853bf2c5b752ce724435dfb85b35f8725cf4cdc1ad6d\",\n"
+                + "                \"transactionPosition\": 2,\n"
+                + "                \"type\": \"suicide\"\n"
+                + "            }\n"
+                + "        ]\n"
+                + "    },\n"
+                + "    \"id\": 1\n"
+                + "}"
+        );
+        //CHECKSTYLE:ON
+
+        ParityFullTraceResponse response = deserialiseResponse(ParityFullTraceResponse.class);
+        assertNotNull(response);
+
+        //CHECKSTYLE:OFF
+        org.web3j.protocol.parity.methods.response.Trace trace1 = new org.web3j.protocol.parity.methods.response.Trace();
+        Trace.CreateAction action1 = new Trace.CreateAction();
+        action1.setFrom("0x6c24f4387b31251fd7b6d7a1269d880b2108bf3a");
+        action1.setGas("0x4bc1f5");
+        action1.setInit("0x606060405234156200000d57fe5b60405162004e4038038062004e40833981016040908152815");
+        action1.setValue("0x0");
+        trace1.setAction(action1);
+        trace1.setBlockHash("0xf831abfdc67fb2ea3d16b6510b8e37d3d3e52ce3c25ed345053cb9503a430dd8");
+        trace1.setBlockNumber(BigInteger.valueOf(4019912));
+        trace1.setResult(new Trace.Result(
+                "0x1c9997559f6f1ae2ece8525eab68709f50865165",
+                "0x606060405236156102b95763ffffffff60e060020a600035041663095ea7b381146102bb578063",
+                "0x3ef6fe",
+                null
+        ));
+        trace1.setSubtraces(BigInteger.ZERO);
+        trace1.setTraceAddress(Collections.emptyList());
+        trace1.setTransactionHash("0x3d30d01a470dc4ae92e87f4c0068d640f880ce27e8b863780cbcb748f1654939");
+        trace1.setTransactionPosition(BigInteger.ONE);
+        trace1.setType("create");
+
+        org.web3j.protocol.parity.methods.response.Trace trace2 = new org.web3j.protocol.parity.methods.response.Trace();
+        Trace.CallAction action2 = new Trace.CallAction();
+        action2.setCallType("call");
+        action2.setFrom("0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a");
+        action2.setTo("0x781ab1a38837e351bfe1e318c6587766848abffa");
+        action2.setGas("0x4f6c5");
+        action2.setInput("0xb46300ec");
+        action2.setValue("0x0");
+        trace2.setAction(action2);
+        trace2.setError("Bad instruction");
+        trace2.setSubtraces(BigInteger.ONE);
+        trace2.setTraceAddress(Collections.emptyList());
+        trace2.setType("call");
+
+        org.web3j.protocol.parity.methods.response.Trace trace3 = new org.web3j.protocol.parity.methods.response.Trace();
+        Trace.SuicideAction action3 = new Trace.SuicideAction();
+        action3.setAddress("0xb8d2ac822f3d0445f5b83d32b0b176c2cb3d0e60");
+        action3.setBalance("0x0");
+        action3.setRefundAddress("0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a");
+        trace3.setAction(action3);
+        trace3.setBlockHash("0xf263b9364434a781057c467004e8d398d915529bdffa6f600d6d17fe733d3210");
+        trace3.setBlockNumber(BigInteger.valueOf(3740614));
+        trace3.setSubtraces(BigInteger.ZERO);
+        trace3.setTraceAddress(Collections.singletonList(BigInteger.ZERO));
+        trace3.setTransactionHash("0xea6649db0f88d5400159853bf2c5b752ce724435dfb85b35f8725cf4cdc1ad6d");
+        trace3.setTransactionPosition(BigInteger.valueOf(2));
+        trace3.setType("suicide");
+        //CHECKSTYLE:ON
+
+        List<org.web3j.protocol.parity.methods.response.Trace> traces = new ArrayList<>();
+        traces.add(trace1);
+        traces.add(trace2);
+        traces.add(trace3);
+        FullTraceInfo info = new FullTraceInfo("0x", null, traces, null);
+        assertThat(response.getFullTraceInfo(), equalTo(info));
+    }
+
+    @Test
+    public void testParityFullTraceResponseVMTrace() {
+        // hacked together from multiple requests and the code shortened
+        //CHECKSTYLE:OFF
+        buildResponse("{\n"
+                + "    \"jsonrpc\": \"2.0\",\n"
+                + "    \"result\": {\n"
+                + "        \"output\": \"0x\",\n"
+                + "        \"vmTrace\": {\n"
+                + "            \"code\": \"0x6060604052361561004a576000357c01\",\n"
+                + "            \"ops\": [{\n"
+                + "                    \"cost\": 20000,\n"
+                + "                    \"ex\": {\n"
+                + "                        \"mem\": null,\n"
+                + "                        \"push\": [\n"
+                + "\n"
+                + "                        ],\n"
+                + "                        \"store\": {\n"
+                + "                            \"key\": \"0x0\",\n"
+                + "                            \"val\": \"0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a\"\n"
+                + "                        },\n"
+                + "                        \"used\": 241835\n"
+                + "                    },\n"
+                + "                    \"pc\": 79,\n"
+                + "                    \"sub\": null\n"
+                + "                }, {\n"
+                + "                    \"cost\": 9700,\n"
+                + "                    \"ex\": {\n"
+                + "                        \"mem\": {\n"
+                + "                            \"data\": \"0x\",\n"
+                + "                            \"off\": 96\n"
+                + "                        },\n"
+                + "                        \"push\": [\n"
+                + "                            \"0x1\"\n"
+                + "                        ],\n"
+                + "                        \"store\": null,\n"
+                + "                        \"used\": 317494\n"
+                + "                    },\n"
+                + "                    \"pc\": 337,\n"
+                + "                    \"sub\": {\n"
+                + "                        \"code\": \"0x606060405236156100b75763ffffffff\",\n"
+                + "                        \"ops\": [{\n"
+                + "                                \"cost\": 3,\n"
+                + "                                \"ex\": {\n"
+                + "                                    \"mem\": null,\n"
+                + "                                    \"push\": [\n"
+                + "                                        \"0x60\"\n"
+                + "                                    ],\n"
+                + "                                    \"store\": null,\n"
+                + "                                    \"used\": 5753235\n"
+                + "                                },\n"
+                + "                                \"pc\": 0,\n"
+                + "                                \"sub\": null\n"
+                + "                            }\n"
+                + "                        ]\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            ]\n"
+                + "        }\n"
+                + "    },\n"
+                + "    \"id\": 1\n"
+                + "}"
+        );
+        //CHECKSTYLE:ON
+
+        ParityFullTraceResponse response = deserialiseResponse(ParityFullTraceResponse.class);
+        assertNotNull(response);
+
+        VMTrace.VMOperation operation1 = new VMTrace.VMOperation(
+                null,
+                BigInteger.valueOf(20000),
+                new VMTrace.VMOperation.Ex(
+                        null,
+                        Collections.emptyList(),
+                        new VMTrace.VMOperation.Ex.Store(
+                                "0x0",
+                                "0x14772e4f805b4dd2e69bd6d3f9b5edf0dfa5385a"),
+                        BigInteger.valueOf(241835)),
+                BigInteger.valueOf(79));
+
+        VMTrace.VMOperation subOperation = new VMTrace.VMOperation(
+                null,
+                BigInteger.valueOf(3),
+                new VMTrace.VMOperation.Ex(
+                        null,
+                        Collections.singletonList("0x60"),
+                        null,
+                        BigInteger.valueOf(5753235)),
+                BigInteger.ZERO);
+
+        VMTrace.VMOperation operation2 = new VMTrace.VMOperation(
+                new VMTrace(
+                        "0x606060405236156100b75763ffffffff",
+                        Collections.singletonList(subOperation)),
+                BigInteger.valueOf(9700),
+                new VMTrace.VMOperation.Ex(
+                        new VMTrace.VMOperation.Ex.Mem(
+                                "0x",
+                                BigInteger.valueOf(96)),
+                        Collections.singletonList("0x1"),
+                        null,
+                        BigInteger.valueOf(317494)),
+                BigInteger.valueOf(337));
+
+        VMTrace trace = new VMTrace(
+                "0x6060604052361561004a576000357c01",
+                Arrays.asList(operation1, operation2));
+        FullTraceInfo info = new FullTraceInfo("0x", null, null, trace);
+        assertThat(response.getFullTraceInfo(), equalTo(info));
+    }
+
 }


### PR DESCRIPTION
Integration of Parity traces API.

The API is very useful to track transaction calls to contracts or check for value received in internal contract transactions (value transfers).

To use: run Parity with `--tracing on` and add `traces` to JSON-RPC API list (will require resync of chain to build full DB).

**Any feedback / critique / complaints are welcome.**

If preferred, I can squash it all into a single commit as well.