### PR TITLE
Refactor addHeaders() in HttpService allowing customize headers.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -39,6 +39,8 @@ public class HttpService extends Service {
     private final String url;
 
     private final boolean includeRawResponse;
+    
+    private HashMap<String, String> headersMap = new HashMap<>();
 
     public HttpService(String url, OkHttpClient httpClient, boolean includeRawResponses) {
         super(includeRawResponses);
@@ -145,10 +147,14 @@ public class HttpService extends Service {
     }
 
     private Headers buildHeaders() {
-        Map<String, String> headers = new HashMap<>();
-        addHeaders(headers);
-        return Headers.of(headers);
+        return Headers.of(headersMap);
     }
-
-    protected void addHeaders(Map<String, String> headers) { }
+    
+    public void addHeader(String key, String value) {
+        headersMap.put(key, value);
+    }
+    
+    public void addHeaders(Map<String, String> headers) {
+        headersMap.putAll(headers);
+    }
 }

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -40,7 +40,7 @@ public class HttpService extends Service {
 
     private final boolean includeRawResponse;
     
-    private HashMap<String, String> headersMap = new HashMap<>();
+    private HashMap<String, String> headers = new HashMap<>();
 
     public HttpService(String url, OkHttpClient httpClient, boolean includeRawResponses) {
         super(includeRawResponses);
@@ -147,14 +147,18 @@ public class HttpService extends Service {
     }
 
     private Headers buildHeaders() {
-        return Headers.of(headersMap);
+        return Headers.of(headers);
     }
     
     public void addHeader(String key, String value) {
-        headersMap.put(key, value);
+        headers.put(key, value);
     }
     
-    public void addHeaders(Map<String, String> headers) {
-        headersMap.putAll(headers);
+    public void addHeaders(Map<String, String> headersToAdd) {
+        headers.putAll(headersToAdd);
+    }
+    
+    public HashMap<String, String> getHeaders() {
+        return headers;
     }
 }

--- a/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
@@ -1,0 +1,39 @@
+package org.web3j.protocol.http;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class HttpServiceTest {
+    
+    private HttpService httpService = new HttpService();
+    
+    @Test
+    public void testAddHeader() {
+        String headerName = "customized_header0";
+        String headerValue = "customized_value0";
+        httpService.addHeader(headerName, headerValue);
+        assertTrue(httpService.getHeaders().get(headerName).equals(headerValue));
+    }
+    
+    @Test
+    public void testAddHeaders() {
+        String headerName1 = "customized_header1";
+        String headerValue1 = "customized_value1";
+        
+        String headerName2 = "customized_header2";
+        String headerValue2 = "customized_value2";
+        
+        HashMap<String, String> headersToAdd = new HashMap<>();
+        headersToAdd.put(headerName1, headerValue1);
+        headersToAdd.put(headerName2, headerValue2);
+        
+        httpService.addHeaders(headersToAdd);
+        
+        assertTrue(httpService.getHeaders().get(headerName1).equals(headerValue1));
+        assertTrue(httpService.getHeaders().get(headerName2).equals(headerValue2));
+    }
+    
+}

--- a/infura/src/main/java/org/web3j/protocol/infura/InfuraHttpService.java
+++ b/infura/src/main/java/org/web3j/protocol/infura/InfuraHttpService.java
@@ -18,6 +18,7 @@ public class InfuraHttpService extends HttpService {
     public InfuraHttpService(String url, String clientVersion, boolean required) {
         super(url);
         clientVersionHeader = buildClientVersionHeader(clientVersion, required);
+        addHeaders(clientVersionHeader);
     }
 
     public InfuraHttpService(String url, String clientVersion) {
@@ -26,11 +27,6 @@ public class InfuraHttpService extends HttpService {
 
     public InfuraHttpService(String url) {
         this(url, "", false);
-    }
-
-    @Override
-    protected void addHeaders(Map<String, String> headers) {
-        headers.putAll(clientVersionHeader);
     }
 
     static Map<String, String> buildClientVersionHeader(String clientVersion, boolean required) {


### PR DESCRIPTION
Users may need customized headers if they access Ethereum via a reverse proxy or a gateway.
The customized headers may be used for authentication or give some other info to the reverse proxy or gateway.

I refactored the code to allow users to customize headers.