### PR TITLE
Refactoring - move Sign.sign method into ECKeyPair so it can be overridden.

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
+++ b/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
@@ -1,0 +1,48 @@
+package org.web3j.crypto;
+
+import java.math.BigInteger;
+
+/**
+ * An ECDSA Signature.
+ */
+public class ECDSASignature {
+    public final BigInteger r;
+    public final BigInteger s;
+
+    public ECDSASignature(BigInteger r, BigInteger s) {
+        this.r = r;
+        this.s = s;
+    }
+
+    /**
+     * Returns true if the S component is "low", that means it is below
+     * {@link Sign#HALF_CURVE_ORDER}. See
+     * <a href="https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures">
+     * BIP62</a>.
+     */
+    public boolean isCanonical() {
+        return s.compareTo(Sign.HALF_CURVE_ORDER) <= 0;
+    }
+
+    /**
+     * Will automatically adjust the S component to be less than or equal to half the curve
+     * order, if necessary. This is required because for every signature (r,s) the signature
+     * (r, -s (mod N)) is a valid signature of the same message. However, we dislike the
+     * ability to modify the bits of a Bitcoin transaction after it's been signed, as that
+     * violates various assumed invariants. Thus in future only one of those forms will be
+     * considered legal and the other will be banned.
+     */
+    public ECDSASignature toCanonicalised() {
+        if (!isCanonical()) {
+            // The order of the curve is the number of valid points that exist on that curve.
+            // If S is in the upper half of the number of valid points, then bring it back to
+            // the lower half. Otherwise, imagine that
+            //    N = 10
+            //    s = 8, so (-8 % 10 == 2) thus both (r, 8) and (r, 2) are valid solutions.
+            //    10 - 8 == 2, giving us always the latter solution, which is canonical.
+            return new ECDSASignature(r, Sign.CURVE.getN().subtract(s));
+        } else {
+            return this;
+        }
+    }
+}

--- a/crypto/src/main/java/org/web3j/crypto/ECKeyPair.java
+++ b/crypto/src/main/java/org/web3j/crypto/ECKeyPair.java
@@ -4,6 +4,10 @@ import java.math.BigInteger;
 import java.security.KeyPair;
 import java.util.Arrays;
 
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
+import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 
@@ -29,6 +33,20 @@ public class ECKeyPair {
         return publicKey;
     }
 
+    /**
+     * Sign a hash with the private key of this key pair.
+     * @param transactionHash   the hash to sign
+     * @return  An {@link ECDSASignature} of the hash
+     */
+    public ECDSASignature sign(byte[] transactionHash) {
+        ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
+
+        ECPrivateKeyParameters privKey = new ECPrivateKeyParameters(privateKey, Sign.CURVE);
+        signer.init(true, privKey);
+        BigInteger[] components = signer.generateSignature(transactionHash);
+
+        return new ECDSASignature(components[0], components[1]).toCanonicalised();
+    }
 
     public static ECKeyPair create(KeyPair keyPair) {
         BCECPrivateKey privateKey = (BCECPrivateKey) keyPair.getPrivate();


### PR DESCRIPTION
This will make it easier to override the default signing behavior, such as implementing an ECKeyPair that does out of process signing.

This is for issue #195 