### PR TITLE
Removing the duplicated calls for installing and uninstalling the filter

### DIFF
--- a/core/src/main/java/org/web3j/protocol/rx/JsonRpc2_0Rx.java
+++ b/core/src/main/java/org/web3j/protocol/rx/JsonRpc2_0Rx.java
@@ -108,18 +108,6 @@ public class JsonRpc2_0Rx {
                 filter.cancel();
             }
         }));
-        scheduledExecutorService.submit(new Runnable() {
-            @Override
-            public void run() {
-                filter.run(scheduledExecutorService, pollingInterval);
-            }
-        });
-        subscriber.add(Subscriptions.create(new Action0() {
-            @Override
-            public void call() {
-                filter.cancel();
-            }
-        }));
     }
 
     public Observable<Transaction>  transactionObservable(final long pollingInterval) {


### PR DESCRIPTION
Investigating the #211 issue, I found out that `eth_uninstallFilter` method is called twice. The first call is successful, but the second call causes an exception as its result is false:
`{"jsonrpc":"2.0","id":1,"result":false}`.

This pull request fixes the issue.