### PR TITLE
Added the field 'status' to the transaction receipts

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceipt.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceipt.java
@@ -17,6 +17,7 @@ public class TransactionReceipt {
     private String gasUsed;
     private String contractAddress;  // this is present in the spec
     private String root;
+    private String status;
     private String from;
     private String to;
     private List<Log> logs;
@@ -27,8 +28,8 @@ public class TransactionReceipt {
 
     public TransactionReceipt(String transactionHash, String transactionIndex,
                               String blockHash, String blockNumber, String cumulativeGasUsed,
-                              String gasUsed, String contractAddress, String root, String from,
-                              String to, List<Log> logs, String logsBloom) {
+                              String gasUsed, String contractAddress, String root, String status,
+                              String from, String to, List<Log> logs, String logsBloom) {
         this.transactionHash = transactionHash;
         this.transactionIndex = transactionIndex;
         this.blockHash = blockHash;
@@ -37,6 +38,7 @@ public class TransactionReceipt {
         this.gasUsed = gasUsed;
         this.contractAddress = contractAddress;
         this.root = root;
+        this.status = status;
         this.from = from;
         this.to = to;
         this.logs = logs;
@@ -123,6 +125,14 @@ public class TransactionReceipt {
         this.root = root;
     }
 
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
     public String getFrom() {
         return from;
     }
@@ -202,6 +212,10 @@ public class TransactionReceipt {
                 ? !getRoot().equals(that.getRoot()) : that.getRoot() != null) {
             return false;
         }
+        if (getStatus() != null
+                ? !getStatus().equals(that.getStatus()) : that.getStatus() != null) {
+            return false;
+        }
         if (getFrom() != null ? !getFrom().equals(that.getFrom()) : that.getFrom() != null) {
             return false;
         }
@@ -225,6 +239,7 @@ public class TransactionReceipt {
         result = 31 * result + (gasUsed != null ? gasUsed.hashCode() : 0);
         result = 31 * result + (getContractAddress() != null ? getContractAddress().hashCode() : 0);
         result = 31 * result + (getRoot() != null ? getRoot().hashCode() : 0);
+        result = 31 * result + (getStatus() != null ? getStatus().hashCode() : 0);
         result = 31 * result + (getFrom() != null ? getFrom().hashCode() : 0);
         result = 31 * result + (getTo() != null ? getTo().hashCode() : 0);
         result = 31 * result + (getLogs() != null ? getLogs().hashCode() : 0);

--- a/core/src/main/java/org/web3j/tx/response/EmptyTransactionReceipt.java
+++ b/core/src/main/java/org/web3j/tx/response/EmptyTransactionReceipt.java
@@ -123,6 +123,16 @@ public class EmptyTransactionReceipt extends TransactionReceipt {
     }
 
     @Override
+    public String getStatus() {
+        throw unsupportedOperation();
+    }
+
+    @Override
+    public void setStatus(String status) {
+        throw unsupportedOperation();
+    }
+
+    @Override
     public String getFrom() {
         throw unsupportedOperation();
     }

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -893,7 +893,7 @@ public class ResponseTest extends ResponseTester {
     }
 
     @Test
-    public void testeEthGetTransactionReceipt() {
+    public void testeEthGetTransactionReceiptBeforeByzantium() {
         //CHECKSTYLE:OFF
         buildResponse(
                 "{\n"
@@ -937,6 +937,82 @@ public class ResponseTest extends ResponseTester {
                         "0x4dc",
                         "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
                         "9307ba10e41ecf3d40507fc908655fe72fc129d46f6d99baf7605d0e29184911",
+                        null,
+                        "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+                        "0x85h43d8a49eeb85d32cf465507dd71d507100c1",
+                        Arrays.asList(
+                                new Log(
+                                        false,
+                                        "0x1",
+                                        "0x0",
+                                        "0xdf829c5a142f1fccd7d8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcf",
+                                        "0x8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+                                        "0x1b4",
+                                        "0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d",
+                                        "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                        "mined",
+                                        Arrays.asList(
+                                                "0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"
+                                        )
+                                )
+                        ),
+                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+                );
+        //CHECKSTYLE:ON
+
+        EthGetTransactionReceipt ethGetTransactionReceipt = deserialiseResponse(
+                EthGetTransactionReceipt.class);
+        assertThat(ethGetTransactionReceipt.getTransactionReceipt().get(),
+                equalTo(transactionReceipt));
+    }
+
+    @Test
+    public void testeEthGetTransactionReceiptAfterByzantium() {
+        //CHECKSTYLE:OFF
+        buildResponse(
+                "{\n"
+                        + "    \"id\":1,\n"
+                        + "    \"jsonrpc\":\"2.0\",\n"
+                        + "    \"result\": {\n"
+                        + "        \"transactionHash\": \"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238\",\n"
+                        + "        \"transactionIndex\":  \"0x1\",\n"
+                        + "        \"blockHash\": \"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b\",\n"
+                        + "        \"blockNumber\": \"0xb\",\n"
+                        + "        \"cumulativeGasUsed\": \"0x33bc\",\n"
+                        + "        \"gasUsed\": \"0x4dc\",\n"
+                        + "        \"contractAddress\": \"0xb60e8dd61c5d32be8058bb8eb970870f07233155\",\n"
+                        + "        \"status\": \"0x1\",\n"
+                        + "        \"from\":\"0x407d73d8a49eeb85d32cf465507dd71d507100c1\",\n"
+                        + "        \"to\":\"0x85h43d8a49eeb85d32cf465507dd71d507100c1\",\n"
+                        + "        \"logs\": [{\n"
+                        + "            \"removed\": false,\n"
+                        + "            \"logIndex\": \"0x1\",\n"
+                        + "            \"transactionIndex\": \"0x0\",\n"
+                        + "            \"transactionHash\": \"0xdf829c5a142f1fccd7d8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcf\",\n"
+                        + "            \"blockHash\": \"0x8216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d\",\n"
+                        + "            \"blockNumber\":\"0x1b4\",\n"
+                        + "            \"address\": \"0x16c5785ac562ff41e2dcfdf829c5a142f1fccd7d\",\n"
+                        + "            \"data\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\n"
+                        + "            \"type\":\"mined\",\n"
+                        + "            \"topics\": [\"0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5\"]"
+                        + "        }],\n"
+                        + "        \"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n"
+                        + "  }\n"
+                        + "}"
+        );
+
+        TransactionReceipt transactionReceipt =
+                new TransactionReceipt(
+                        "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238",
+                        "0x1",
+                        "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+                        "0xb",
+                        "0x33bc",
+                        "0x4dc",
+                        "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+                        null,
+                        "0x1",
                         "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
                         "0x85h43d8a49eeb85d32cf465507dd71d507100c1",
                         Arrays.asList(

--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -102,7 +102,7 @@ public class Sign {
         //        routine specified in Section 2.3.7, where mlen = ⌈(log2 p)/8⌉ or mlen = ⌈m/8⌉.
         //   1.3. Convert the octet string (16 set binary digits)||X to an elliptic curve point R
         //        using the conversion routine specified in Section 2.3.4. If this conversion
-        //        routine outputs “invalid”, then do another iteration of Step 1.
+        //        routine outputs "invalid", then do another iteration of Step 1.
         //
         // More concisely, what these points mean is to use X as a compressed public key.
         BigInteger prime = SecP256K1Curve.q;


### PR DESCRIPTION
Added the status field in the transaction receipts, which was introduced in the Byzantium fork.  It is supposed to indicate the status of the transaction (0=failed, 1=success).

The field 'status' was introduced in the Byzantium fork, and it is supposed to replace the field 'root', meaning:
  - receipts prior to the fork have the field 'root', but do not have the field 'status'
  - receipts after the fork do not have the field 'root', but they have the field 'status'

For example:
<pre>
> eth.getTransactionReceipt("0x5788e90d4a85d91673f8863614294e03a80724f6f503cd3f5005bab4552e74b5")
{
  blockHash: "0x83952d392f9b0059eea94b10d1a095eefb1943ea91595a16c6698757127d4e1c",
  blockNumber: 1500000,
  contractAddress: null,
  cumulativeGasUsed: 128091,
  from: "0xcd88e0e0c455345833ce31c5452c1c37f4b4c438",
  gasUsed: 21000,
  logs: [],
  logsBloom: "0x...",
  root: "0x1e7eca77656bf9613ce8ef9982990d0072c0a90aad1a3a7533aeb0fd1255c802",
  to: "0xe315990a56899c575e03cbbc18f6ae3f117a7459",
  transactionHash: "0x5788e90d4a85d91673f8863614294e03a80724f6f503cd3f5005bab4552e74b5",
  transactionIndex: 4
}

> eth.getTransactionReceipt("0xdaa2fcc5d94f03348dc26bfacf84828ff563ccc57f6ab8260d2bd35b5d668ef8")
{
  blockHash: "0x43340a6d232532c328211d8a8c0fa84af658dbff1f4906ab7a7d4e41f82fe3a3",
  blockNumber: 4500000,
  contractAddress: null,
  cumulativeGasUsed: 6725082,
  from: "0x1c4b87c3c650c27bdda2bae0a6d42dcb585ab978",
  gasUsed: 21000,
  logs: [],
  logsBloom: "0x...",
  status: "0x1",
  to: "0x896ab5dfbf507d7cc71e3a9d8fb55f1bd94d679e",
  transactionHash: "0xdaa2fcc5d94f03348dc26bfacf84828ff563ccc57f6ab8260d2bd35b5d668ef8",
  transactionIndex: 295
}
</pre>

I was not able to run all the integration tests, but all the unit tests pass.  Hopefully all the use cases where caught!
