### PR TITLE
Improvement for UNIX domain socket

### DIFF
--- a/core/src/main/java/org/web3j/protocol/ipc/UnixDomainSocket.java
+++ b/core/src/main/java/org/web3j/protocol/ipc/UnixDomainSocket.java
@@ -53,17 +53,21 @@ public class UnixDomainSocket implements IOFacade {
         writer.flush();
     }
 
+    private String prefix = "";
+
     @Override
     public String read() throws IOException {
         CharBuffer response = CharBuffer.allocate(bufferSize);
-        String result = "";
+        String result = prefix;
 
-        do {
+        int length;
+        while ((length = result.indexOf('\n')) < 0) {
             response.clear();
             reader.read(response);
             result += new String(response.array(), response.arrayOffset(), response.position());
-        } while (response.position() == response.limit()
-                && response.get(response.limit() - 1) != '\n');
+        }
+        prefix = result.substring(length + 1);
+        result = result.substring(0, length + 1);
 
         return result;
     }

--- a/core/src/test/java/org/web3j/protocol/ipc/UnixDomainSocketTest.java
+++ b/core/src/test/java/org/web3j/protocol/ipc/UnixDomainSocketTest.java
@@ -104,8 +104,10 @@ public class UnixDomainSocketTest {
 
         // two async requests may read parts interleavedly if not synchronized
         IpcService ipcService = new IpcService(unixDomainSocket);
-        CompletableFuture<Web3ClientVersion> ftr1 = ipcService.sendAsync(new Request(), Web3ClientVersion.class);
-        CompletableFuture<Web3ClientVersion> ftr2 = ipcService.sendAsync(new Request(), Web3ClientVersion.class);
+        CompletableFuture<Web3ClientVersion> ftr1 = ipcService.sendAsync(
+                new Request(), Web3ClientVersion.class);
+        CompletableFuture<Web3ClientVersion> ftr2 = ipcService.sendAsync(
+                new Request(), Web3ClientVersion.class);
         ftr1.get();
         ftr2.get();
     }
@@ -124,12 +126,13 @@ public class UnixDomainSocketTest {
         segments.add(response.substring(20));
         doAnswer(invocation -> {
             String segment = segments.poll();
-            if (segment == null)
+            if (segment == null) {
                 return 0;
-            Object[] args = invocation.getArguments();
-            ((CharBuffer) args[0]).append(segment);
-            System.out.println("" + Thread.currentThread() + ": read " + segment.length());
-            return segment.length();
+            } else {
+                Object[] args = invocation.getArguments();
+                ((CharBuffer) args[0]).append(segment);
+                return segment.length();
+            }
         }).when(reader).read(any(CharBuffer.class));
 
         IpcService ipcService = new IpcService(unixDomainSocket);


### PR DESCRIPTION
For long JSON/RPC response, current code has the following issues:

1. Multiple asynchronous requests may read response interleavingly, leads to incorrect JSON document;
2. If reading is faster than writing, read buffer might not be full but subsequent data will still "come" later.
