### PR TITLE
fix for BlockObservable failing when node connection is lost

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -75,13 +75,15 @@ public abstract class Filter<T> {
         EthLog ethLog = null;
         try {
             ethLog = web3j.ethGetFilterChanges(filterId).send();
+
+            if (ethLog.hasError()) {
+                throwException(ethFilter.getError());
+            }
+            process(ethLog.getLogs());
         } catch (IOException e) {
-            throwException(e);
+            System.out.println("LOG ME");
+            //throwException(e);
         }
-        if (ethLog.hasError()) {
-            throwException(ethFilter.getError());
-        }
-        process(ethLog.getLogs());
     }
 
     abstract EthFilter sendRequest() throws IOException;


### PR DESCRIPTION
fixes #279 
This changes allow for polling to continue even if node connection is lost.
What log message would be appropriate here? 
Should I just create a log object in the Filter class?