### PR TITLE
Testrpc filter fix

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -496,7 +496,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthUninstallFilter> ethUninstallFilter(BigInteger filterId) {
         return new Request<>(
                 "eth_uninstallFilter",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 EthUninstallFilter.class);
     }
@@ -505,7 +505,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterChanges(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterChanges",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 EthLog.class);
     }
@@ -661,7 +661,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhUninstallFilter> shhUninstallFilter(BigInteger filterId) {
         return new Request<>(
                 "shh_uninstallFilter",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 ShhUninstallFilter.class);
     }
@@ -670,7 +670,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhMessages> shhGetFilterChanges(BigInteger filterId) {
         return new Request<>(
                 "shh_getFilterChanges",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 ShhMessages.class);
     }
@@ -679,7 +679,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhMessages> shhGetMessages(BigInteger filterId) {
         return new Request<>(
                 "shh_getMessages",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 ShhMessages.class);
     }

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -514,7 +514,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterLogs(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterLogs",
-                Arrays.asList(Numeric.toHexStringWithPrefixSave(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 EthLog.class);
     }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -425,7 +425,7 @@ public class RequestTest extends RequestTester {
         web3j.ethUninstallFilter(Numeric.toBigInt("0xb")).send();
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"eth_uninstallFilter\","
-                + "\"params\":[\"0xb\"],\"id\":1}");
+                + "\"params\":[\"0x0b\"],\"id\":1}");
     }
 
     @Test
@@ -605,7 +605,7 @@ public class RequestTest extends RequestTester {
         web3j.shhUninstallFilter(Numeric.toBigInt("0x7")).send();
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"shh_uninstallFilter\","
-                + "\"params\":[\"0x7\"],\"id\":1}");
+                + "\"params\":[\"0x07\"],\"id\":1}");
     }
 
     @Test
@@ -613,7 +613,7 @@ public class RequestTest extends RequestTester {
         web3j.shhGetFilterChanges(Numeric.toBigInt("0x7")).send();
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"shh_getFilterChanges\","
-                + "\"params\":[\"0x7\"],\"id\":1}");
+                + "\"params\":[\"0x07\"],\"id\":1}");
     }
 
     @Test
@@ -621,7 +621,7 @@ public class RequestTest extends RequestTester {
         web3j.shhGetMessages(Numeric.toBigInt("0x7")).send();
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"shh_getMessages\","
-                + "\"params\":[\"0x7\"],\"id\":1}");
+                + "\"params\":[\"0x07\"],\"id\":1}");
     }
 
 }

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -113,7 +113,7 @@ public final class Numeric {
         return toHexStringZeroPadded(value, size, true);
     }
     
-    public static String toHexStringWithPrefixSave(BigInteger value) {
+    public static String toHexStringWithPrefixSafe(BigInteger value) {
         String result = toHexStringNoPrefix(value);
         if (result.length() < 2) {
             result = Strings.zeros(1) + result;

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -32,6 +32,16 @@ public class NumericTest {
 
     private static final String HEX_RANGE_STRING = "0x0123456789abcdef";
 
+    @Test
+    public void testQuantityEncodeLeadingZero() {
+        assertThat(Numeric.toHexStringWithPrefixSafe(BigInteger.valueOf(0L)), equalTo("0x00"));
+        assertThat(Numeric.toHexStringWithPrefixSafe(BigInteger.valueOf(1024L)), equalTo("0x400"));
+        assertThat(Numeric.toHexStringWithPrefixSafe(BigInteger.valueOf(Long.MAX_VALUE)),
+                   equalTo("0x7fffffffffffffff"));
+        assertThat(Numeric.toHexStringWithPrefixSafe(
+                   new BigInteger("204516877000845695339750056077105398031")),
+                   equalTo("0x99dc848b94efc27edfad28def049810f"));
+    }
 
     @Test
     public void testQuantityDecode() {


### PR DESCRIPTION
I found I was having issues with using filters with `testrpc/ganache-cli`, because it expects the first 9 filter id's to start with `0x0`, this pull hopes to fix this by preceding the filter id with a `0` when it is one of the first 9 filters.