### PR TITLE
Allow gasPrice to be set post construction

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -96,6 +96,13 @@ public abstract class Contract extends ManagedTransaction {
     public String getContractBinary() {
         return contractBinary;
     }
+    
+    /**
+     * Allow gasPrice to be set.
+     */
+    public void setGasPrice(BigInteger newPrice) {
+        this.gasPrice = newPrice;
+    }
 
     /**
      * Check that the contract deployed at the address associated with this smart contract wrapper


### PR DESCRIPTION
gasPrice is a dynamic value - and can be retrieved from the eth gasstation API - contract instances may be long-lived, a setter method allows a contract's gasPrice to be adjusted for long-lived contract instances.

per #289