### PR TITLE
Added 'from' property to the documentation about 'Querying the state …

### DIFF
--- a/docs/source/transactions.rst
+++ b/docs/source/transactions.rst
@@ -502,7 +502,7 @@ contract method's called, it simply returns the value from them::
 
    String encodedFunction = FunctionEncoder.encode(function)
    org.web3j.protocol.core.methods.response.EthCall response = web3j.ethCall(
-                Transaction.createEthCallTransaction(contractAddress, encodedFunction),
+                Transaction.createEthCallTransaction(<from>, contractAddress, encodedFunction),
                 DefaultBlockParameterName.LATEST)
                 .sendAsync().get();
 


### PR DESCRIPTION
…of a smart contract'

Referencing issue #269 

I enclosed the <from> parameter in brackets, as it seemed to be the existing style for parameters in the code examples which were not introduced before.

