### PR TITLE
Remove unecessary warning from EthBlock

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -54,7 +54,7 @@ public class EthBlock extends Response<EthBlock.Block> {
         private String logsBloom;
         private String transactionsRoot;
         private String stateRoot;
-        private String receiptsRoot;  // geth has this wrong currently, see https://github.com/ethereum/go-ethereum/issues/3084
+        private String receiptsRoot;
         private String author;
         private String miner;
         private String mixHash;


### PR DESCRIPTION
ethereum/go-ethereum#3084 has been fixed since 1.5.0