### PR TITLE
Improve quick start documentation. remove confusing InfuraHttpClient …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ Or use `Infura <https://infura.io/>`_, which provides **free clients** running i
 
 .. code-block:: java
 
-   Web3j web3 = Web3j.build(new InfuraHttpService("https://ropsten.infura.io/your-token"));
+   Web3j web3 = Web3j.build(new HttpService("https://ropsten.infura.io/your-token"));
 
 For further information refer to
 `Using Infura with web3j <https://web3j.github.io/web3j/infura.html>`_

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -62,7 +62,7 @@ Or use `Infura <https://infura.io/>`_, which provides **free clients** running i
 
 .. code-block:: java
 
-   Web3j web3 = Web3j.build(new InfuraHttpService("https://morden.infura.io/your-token"));
+   Web3j web3 = Web3j.build(new HttpService("https://morden.infura.io/your-token"));
 
 For further information refer to :doc:`infura`.
 


### PR DESCRIPTION
Remove unnecessary complexity for the quick introduction of the usage.
Alternatively if the usage of the class `InfuraHttpClient` is required with the service `Infura` then explicitly specify to the end used to insert in it's gradle (or whatever) dependency manager also the dependency: `compile 'org.web3j:infura:3.2.0'`