### PR TITLE
Make "recoverFromSignature" method public

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -96,7 +96,7 @@ public class Sign {
      * @param message Hash of the data that was signed.
      * @return An ECKey containing only the public part, or null if recovery wasn't possible.
      */
-    private static BigInteger recoverFromSignature(int recId, ECDSASignature sig, byte[] message) {
+    public static BigInteger recoverFromSignature(int recId, ECDSASignature sig, byte[] message) {
         verifyPrecondition(recId >= 0, "recId must be positive");
         verifyPrecondition(sig.r.signum() >= 0, "r must be positive");
         verifyPrecondition(sig.s.signum() >= 0, "s must be positive");

--- a/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 import org.junit.Test;
+
 import org.web3j.crypto.Sign.SignatureData;
 import org.web3j.utils.Numeric;
 
@@ -16,34 +17,44 @@ public class ECRecoverTest {
 
     @Test
     public void testRecoverAddressFromSignature() {
+        //CHECKSTYLE:OFF
         String signature = "0x2c6401216c9031b9a6fb8cbfccab4fcec6c951cdf40e2320108d1856eb532250576865fbcd452bcdc4c57321b619ed7a9cfd38bd973c3e1e0243ac2777fe9d5b1b";
+        //CHECKSTYLE:ON
         String address = "0x31b26e43651e9371c88af3d36c14cfd938baf4fd";
         String message = "v0G9u7huK4mJb2K1";
                 
                 
         // Message
         String prefix = PERSONAL_MESSAGE_PREFIX + message.length();
-        byte[] msgHash = Hash.sha3((prefix+message).getBytes());
+        byte[] msgHash = Hash.sha3((prefix + message).getBytes());
 
 
         // Signature
         byte[] array = Numeric.hexStringToByteArray(signature);
         byte v = array[64];
-        if (v < 27) { v += 27; }
+        if (v < 27) { 
+            v += 27; 
+        }
            
-        SignatureData sd = new SignatureData(v, (byte[]) Arrays.copyOfRange(array, 0, 32), (byte[])  Arrays.copyOfRange(array, 32, 64));
+        SignatureData sd = new SignatureData(
+                v, 
+                (byte[]) Arrays.copyOfRange(array, 0, 32), 
+                (byte[])  Arrays.copyOfRange(array, 32, 64));
 
         String addressRecovered = null;
         boolean match = false;
         
         // Iterate for each possible key to recover
-        for(int i=0; i<4; i++) {
-            BigInteger publicKey = Sign.recoverFromSignature((byte)i, new ECDSASignature(new BigInteger(1, sd.getR()), new BigInteger(1, sd.getS())), msgHash);
+        for (int i = 0; i < 4; i++) {
+            BigInteger publicKey = Sign.recoverFromSignature(
+                    (byte)i, 
+                    new ECDSASignature(new BigInteger(1, sd.getR()), new BigInteger(1, sd.getS())), 
+                    msgHash);
                
-            if(publicKey != null) {
+            if (publicKey != null) {
                 addressRecovered = "0x" + Keys.getAddress(publicKey); 
                 
-                if(addressRecovered.equals(address)) {
+                if (addressRecovered.equals(address)) {
                     match = true;
                     break;
                 }

--- a/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
@@ -10,6 +10,7 @@ import org.web3j.utils.Numeric;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class ECRecoverTest {
 
@@ -23,23 +24,19 @@ public class ECRecoverTest {
         String address = "0x31b26e43651e9371c88af3d36c14cfd938baf4fd";
         String message = "v0G9u7huK4mJb2K1";
                 
-                
-        // Message
         String prefix = PERSONAL_MESSAGE_PREFIX + message.length();
         byte[] msgHash = Hash.sha3((prefix + message).getBytes());
 
-
-        // Signature
-        byte[] array = Numeric.hexStringToByteArray(signature);
-        byte v = array[64];
+        byte[] signatureBytes = Numeric.hexStringToByteArray(signature);
+        byte v = signatureBytes[64];
         if (v < 27) { 
             v += 27; 
         }
            
         SignatureData sd = new SignatureData(
                 v, 
-                (byte[]) Arrays.copyOfRange(array, 0, 32), 
-                (byte[])  Arrays.copyOfRange(array, 32, 64));
+                (byte[]) Arrays.copyOfRange(signatureBytes, 0, 32), 
+                (byte[]) Arrays.copyOfRange(signatureBytes, 32, 64));
 
         String addressRecovered = null;
         boolean match = false;
@@ -47,7 +44,7 @@ public class ECRecoverTest {
         // Iterate for each possible key to recover
         for (int i = 0; i < 4; i++) {
             BigInteger publicKey = Sign.recoverFromSignature(
-                    (byte)i, 
+                    (byte) i, 
                     new ECDSASignature(new BigInteger(1, sd.getR()), new BigInteger(1, sd.getS())), 
                     msgHash);
                
@@ -62,6 +59,6 @@ public class ECRecoverTest {
         }
         
         assertThat(addressRecovered, is(address));
-        assertThat(match, is(true));
+        assertTrue(match);
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
@@ -1,0 +1,56 @@
+package org.web3j.crypto;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.web3j.crypto.Sign.SignatureData;
+import org.web3j.utils.Numeric;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ECRecoverTest {
+
+    public static final String PERSONAL_MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
+
+    @Test
+    public void testRecoverAddressFromSignature() {
+        String signature = "0x2c6401216c9031b9a6fb8cbfccab4fcec6c951cdf40e2320108d1856eb532250576865fbcd452bcdc4c57321b619ed7a9cfd38bd973c3e1e0243ac2777fe9d5b1b";
+        String address = "0x31b26e43651e9371c88af3d36c14cfd938baf4fd";
+        String message = "v0G9u7huK4mJb2K1";
+                
+                
+        // Message
+        String prefix = PERSONAL_MESSAGE_PREFIX + message.length();
+        byte[] msgHash = Hash.sha3((prefix+message).getBytes());
+
+
+        // Signature
+        byte[] array = Numeric.hexStringToByteArray(signature);
+        byte v = array[64];
+        if (v < 27) { v += 27; }
+           
+        SignatureData sd = new SignatureData(v, (byte[]) Arrays.copyOfRange(array, 0, 32), (byte[])  Arrays.copyOfRange(array, 32, 64));
+
+        String addressRecovered = null;
+        boolean match = false;
+        
+        // Iterate for each possible key to recover
+        for(int i=0; i<4; i++) {
+            BigInteger publicKey = Sign.recoverFromSignature((byte)i, new ECDSASignature(new BigInteger(1, sd.getR()), new BigInteger(1, sd.getS())), msgHash);
+               
+            if(publicKey != null) {
+                addressRecovered = "0x" + Keys.getAddress(publicKey); 
+                
+                if(addressRecovered.equals(address)) {
+                    match = true;
+                    break;
+                }
+            }
+        }
+        
+        assertThat(addressRecovered, is(address));
+        assertThat(match, is(true));
+    }
+}


### PR DESCRIPTION
The aim of this PR is to make the method **recoverFromSignature** public so applications can use _ecrecover_ to check signatures against a public key (or address).

Example of usage:
```
public String checkSignature(String signature, String signerAddress, String message) throws Exception {
    
     // Message
     String PERSONAL_MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
     String prefix = PERSONAL_MESSAGE_PREFIX + message.length();
     byte[] msgHash = Hash.sha3((prefix+message).getBytes());


     // Signature
     byte[] array = Numeric.hexStringToByteArray(signature);
     byte v = array[64];
     if (v < 27) { v += 27; }
        
     SignatureData sd = new SignatureData(v, (byte[]) Arrays.copyOfRange(array, 0, 32), (byte[])  Arrays.copyOfRange(array, 32, 64));

     String addressRecovered = null;
     boolean match = false;
     
     // Iterate for each possible key to recover
     for(int i=0; i<4; i++) {
         BigInteger publicKey = Sign.recoverFromSignature((byte)i, new ECDSASignature(new BigInteger(1, sd.getR()), new BigInteger(1, sd.getS())), msgHash);
            
         if(publicKey != null) {
             addressRecovered = "0x" + Keys.getAddress(publicKey); 
             
             if(addressRecovered.equals(signerAddress)) {
                 match = true;
                 break;
             }
         }
     }
     
     if(!match) {
         throw new Exception("Signature doesn't match with signer address");
     }
} 
```
