### PR TITLE
Adds web3j shutdown method

### DIFF
--- a/core/src/main/java/org/web3j/protocol/Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/Web3j.java
@@ -36,4 +36,9 @@ public interface Web3j extends Ethereum, Web3jRx {
             ScheduledExecutorService scheduledExecutorService) {
         return new JsonRpc2_0Web3j(web3jService, pollingInterval, scheduledExecutorService);
     }
+
+    /**
+     * Shutdowns a Web3j instance and cleans up opened resources.
+     */
+    void shutdown();
 }

--- a/core/src/main/java/org/web3j/protocol/Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/Web3j.java
@@ -38,7 +38,7 @@ public interface Web3j extends Ethereum, Web3jRx {
     }
 
     /**
-     * Shutdowns a Web3j instance and cleans up opened resources.
+     * Shutdowns a Web3j instance and closes opened resources.
      */
     void shutdown();
 }

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -75,6 +75,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     protected final Web3jService web3jService;
     private final JsonRpc2_0Rx web3jRx;
     private final long blockTime;
+    private final ScheduledExecutorService scheduledExecutorService;
 
     public JsonRpc2_0Web3j(Web3jService web3jService) {
         this(web3jService, DEFAULT_BLOCK_TIME, Async.defaultExecutorService());
@@ -86,6 +87,7 @@ public class JsonRpc2_0Web3j implements Web3j {
         this.web3jService = web3jService;
         this.web3jRx = new JsonRpc2_0Rx(this, scheduledExecutorService);
         this.blockTime = pollingInterval;
+        this.scheduledExecutorService = scheduledExecutorService;
     }
 
     @Override
@@ -772,5 +774,10 @@ public class JsonRpc2_0Web3j implements Web3j {
             DefaultBlockParameter startBlock) {
         return web3jRx.catchUpToLatestAndSubscribeToNewTransactionsObservable(
                 startBlock, blockTime);
+    }
+
+    @Override
+    public void shutdown() {
+        scheduledExecutorService.shutdown();
     }
 }

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -67,7 +67,7 @@ public class HttpService extends Service {
         this(DEFAULT_URL, httpClient);
     }
 
-    public  HttpService(boolean includeRawResponse) {
+    public HttpService(boolean includeRawResponse) {
         this(DEFAULT_URL, includeRawResponse);
     }
 

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
@@ -1,0 +1,27 @@
+package org.web3j.protocol.core;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.Test;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.Web3jService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class JsonRpc2_0Web3jTest {
+
+    @Test
+    public void testStopExecutorOnShutdown() {
+        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+
+        Web3j web3j = Web3j.build(
+                mock(Web3jService.class), 10, scheduledExecutorService
+        );
+
+        web3j.shutdown();
+
+        verify(scheduledExecutorService).shutdown();
+    }
+}

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -69,6 +69,12 @@ For further information refer to :doc:`infura`.
 Instructions on obtaining Ether to transact on the network can be found in the
 :ref:`testnet section of the docs <ethereum-testnets>`.
 
+When you no longer need a `Web3j` instance you need to call the `shutdown` method to close resources used by it.
+
+.. code-block:: java
+
+   web3.shutdown()
+
 
 Start sending requests
 ----------------------


### PR DESCRIPTION
Adds the `shutdown` method to the `Web3j` interface to close internal executor.

Closes #273.