### PR TITLE
Outputs a warning when non-constant function returns a value

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/GenerationReporter.java
+++ b/codegen/src/main/java/org/web3j/codegen/GenerationReporter.java
@@ -1,5 +1,8 @@
 package org.web3j.codegen;
 
+/**
+ * Can be used to provide report about a code generation process.
+ */
 interface GenerationReporter {
     void report(String msg);
 }

--- a/codegen/src/main/java/org/web3j/codegen/GenerationReporter.java
+++ b/codegen/src/main/java/org/web3j/codegen/GenerationReporter.java
@@ -1,0 +1,5 @@
+package org.web3j.codegen;
+
+interface GenerationReporter {
+    void report(String msg);
+}

--- a/codegen/src/main/java/org/web3j/codegen/LogGenerationReporter.java
+++ b/codegen/src/main/java/org/web3j/codegen/LogGenerationReporter.java
@@ -1,0 +1,17 @@
+package org.web3j.codegen;
+
+import org.slf4j.Logger;
+
+class LogGenerationReporter implements GenerationReporter {
+
+    private final Logger logger;
+
+    public LogGenerationReporter(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public void report(String msg) {
+        logger.warn(msg);
+    }
+}

--- a/codegen/src/main/java/org/web3j/codegen/LogGenerationReporter.java
+++ b/codegen/src/main/java/org/web3j/codegen/LogGenerationReporter.java
@@ -2,6 +2,9 @@ package org.web3j.codegen;
 
 import org.slf4j.Logger;
 
+/**
+ * A reporter generation that outputs messages using a logger instance.
+ */
 class LogGenerationReporter implements GenerationReporter {
 
     private final Logger logger;

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -676,8 +676,8 @@ public class SolidityFunctionWrapper extends Generator {
         if (functionDefinition.hasOutputs()) {
             //CHECKSTYLE:OFF
             reporter.report(String.format(
-                    "Definition of the function %s returns a value but is not defined as a constant function. "
-                            + "Please ensure it contains the constant modifier if you want to read the return value",
+                    "Definition of the function %s returns a value but is not defined as a view function. "
+                            + "Please ensure it contains the view modifier if you want to read the return value",
                     functionDefinition.getName()));
             //CHECKSTYLE:ON
         }

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -24,6 +24,8 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import rx.functions.Func1;
 
 import org.web3j.abi.EventEncoder;
@@ -73,6 +75,7 @@ public class SolidityFunctionWrapper extends Generator {
     private static final String WEI_VALUE = "weiValue";
 
     private static final ClassName LOG = ClassName.get(Log.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SolidityFunctionWrapper.class);
 
     private static final String CODEGEN_WARNING = "<p>Auto generated code.\n"
             + "<p><strong>Do not modify!</strong>\n"
@@ -85,9 +88,15 @@ public class SolidityFunctionWrapper extends Generator {
     private final boolean useNativeJavaTypes;
     private static final String regex = "(\\w+)(?:\\[(.*?)\\])(?:\\[(.*?)\\])?";
     private static final Pattern pattern = Pattern.compile(regex);
+    private final GenerationReporter reporter;
 
     public SolidityFunctionWrapper(boolean useNativeJavaTypes) {
+        this(useNativeJavaTypes, new LogGenerationReporter(LOGGER));
+    }
+
+    SolidityFunctionWrapper(boolean useNativeJavaTypes, GenerationReporter reporter) {
         this.useNativeJavaTypes = useNativeJavaTypes;
+        this.reporter = reporter;
     }
 
     @SuppressWarnings("unchecked")
@@ -659,10 +668,19 @@ public class SolidityFunctionWrapper extends Generator {
                 ClassName.get(RemoteCall.class), typeName);
     }
 
-    private static void buildTransactionFunction(
+    private void buildTransactionFunction(
             AbiDefinition functionDefinition,
             MethodSpec.Builder methodBuilder,
             String inputParams) throws ClassNotFoundException {
+
+        if (functionDefinition.hasOutputs()) {
+            //CHECKSTYLE:OFF
+            reporter.report(String.format(
+                    "Definition of the function %s returns a value but is not defined as a constant function. "
+                            + "Please ensure it contains the constant modifier if you want to read the return value",
+                    functionDefinition.getName()));
+            //CHECKSTYLE:ON
+        }
 
         if (functionDefinition.isPayable()) {
             methodBuilder.addParameter(BigInteger.class, WEI_VALUE);

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -189,8 +189,8 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
         //CHECKSTYLE:OFF
         verify(generationReporter).report(
-                "Definition of the function functionName returns a value but is not defined as a constant function. " +
-                        "Please ensure it contains the constant modifier if you want to read the return value");
+                "Definition of the function functionName returns a value but is not defined as a view function. " +
+                        "Please ensure it contains the view modifier if you want to read the return value");
         //CHECKSTYLE:ON
     }
 

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -32,6 +32,8 @@ import org.web3j.protocol.core.methods.response.AbiDefinition;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.web3j.codegen.SolidityFunctionWrapper.buildTypeName;
 import static org.web3j.codegen.SolidityFunctionWrapper.createValidParamName;
 import static org.web3j.codegen.SolidityFunctionWrapper.getEventNativeType;
@@ -42,10 +44,13 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
     private SolidityFunctionWrapper solidityFunctionWrapper;
 
+    private GenerationReporter generationReporter;
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        solidityFunctionWrapper = new SolidityFunctionWrapper(true);
+        generationReporter = mock(GenerationReporter.class);
+        solidityFunctionWrapper = new SolidityFunctionWrapper(true, generationReporter);
     }
 
     @Test
@@ -166,6 +171,27 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         //CHECKSTYLE:ON
 
         assertThat(methodSpec.toString(), is(expected));
+    }
+
+    @Test
+    public void testBuildingFunctionTransactionThatReturnsValueReportsWarning() throws Exception {
+        AbiDefinition functionDefinition = new AbiDefinition(
+                false,
+                Arrays.asList(
+                        new AbiDefinition.NamedType("param", "uint8")),
+                "functionName",
+                Arrays.asList(
+                        new AbiDefinition.NamedType("result", "uint8")),
+                "type",
+                false);
+
+        solidityFunctionWrapper.buildFunction(functionDefinition);
+
+        //CHECKSTYLE:OFF
+        verify(generationReporter).report(
+                "Definition of the function functionName returns a value but is not defined as a constant function. " +
+                        "Please ensure it contains the constant modifier if you want to read the return value");
+        //CHECKSTYLE:ON
     }
 
     @Test

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
@@ -82,6 +82,10 @@ public class AbiDefinition {
         return outputs;
     }
 
+    public boolean hasOutputs() {
+        return !outputs.isEmpty();
+    }
+
     public void setOutputs(List<NamedType> outputs) {
         this.outputs = outputs;
     }


### PR DESCRIPTION
If a transaction function is generated and this function returns a value, generator outputs a warning message. The warning message is sent to the output using the new interface `GenerationReporter`.

Fixes #257