### PR TITLE
deserialize json object in error response data field 

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Response.java
+++ b/core/src/main/java/org/web3j/protocol/core/Response.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import org.web3j.protocol.deserializer.KeepAsJsonDeserialzier;
+
 /**
  * Our common JSON-RPC response type.
  *

--- a/core/src/main/java/org/web3j/protocol/core/Response.java
+++ b/core/src/main/java/org/web3j/protocol/core/Response.java
@@ -1,7 +1,9 @@
 package org.web3j.protocol.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import org.web3j.protocol.deserializer.KeepAsJsonDeserialzier;
 /**
  * Our common JSON-RPC response type.
  *
@@ -65,6 +67,8 @@ public class Response<T> {
     public static class Error {
         private int code;
         private String message;
+
+        @JsonDeserialize(using = KeepAsJsonDeserialzier.class)
         private String data;
 
         public Error() {

--- a/core/src/main/java/org/web3j/protocol/deserializer/KeepAsJsonDeserialzier.java
+++ b/core/src/main/java/org/web3j/protocol/deserializer/KeepAsJsonDeserialzier.java
@@ -1,0 +1,20 @@
+package org.web3j.protocol.deserializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class KeepAsJsonDeserialzier extends JsonDeserializer<String> {
+
+    @Override
+    public String deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+        TreeNode tree = jp.getCodec().readTree(jp);
+        return tree.toString();
+    }
+}

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -119,7 +119,6 @@ public class ResponseTest extends ResponseTester {
         assertThat(ethBlock.getError().getData(), equalTo("{\"foo\":\"bar\"}"));
     }
 
-
     @Test
     public void testWeb3ClientVersion() {
         buildResponse(

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -101,6 +101,26 @@ public class ResponseTest extends ResponseTester {
     }
 
     @Test
+    public void testErrorResponseComplexData() {
+        buildResponse(
+                "{"
+                        + "  \"jsonrpc\":\"2.0\","
+                        + "  \"id\":1,"
+                        + "  \"error\":{"
+                        + "    \"code\":-32602,"
+                        + "    \"message\":\"Invalid address length, expected 40 got 64 bytes\","
+                        + "    \"data\":{\"foo\":\"bar\"}"
+                        + "  }"
+                        + "}"
+        );
+
+        EthBlock ethBlock = deserialiseResponse(EthBlock.class);
+        assertTrue(ethBlock.hasError());
+        assertThat(ethBlock.getError().getData(), equalTo("{\"foo\":\"bar\"}"));
+    }
+
+
+    @Test
     public void testWeb3ClientVersion() {
         buildResponse(
                 "{\n"


### PR DESCRIPTION
testrpc populates the "data" field of an error response with a json object. web3j wants the "data" field to be a string and is unable to parse it as an object.

use custom deserializer to allow error response data field to be json object.  jackson throws error when trying to deserialize json object to a string with default deserializers.