### PR TITLE
Throw exception if contract deployment or transaction runs out of gas

### DIFF
--- a/core/src/test/java/org/web3j/tx/TransferTest.java
+++ b/core/src/test/java/org/web3j/tx/TransferTest.java
@@ -52,6 +52,7 @@ public class TransferTest extends ManagedTransactionTester {
     private TransactionReceipt prepareTransfer() throws IOException {
         TransactionReceipt transactionReceipt = new TransactionReceipt();
         transactionReceipt.setTransactionHash(TRANSACTION_HASH);
+        transactionReceipt.setStatus("0x1");
         prepareTransaction(transactionReceipt);
 
         EthGasPrice ethGasPrice = new EthGasPrice();


### PR DESCRIPTION
Instead of checking how much gas was used by a contract this PR checks the status of the transaction. If the status is not 0x1, the transaction has failed. This is a more robust method than comparing the amount of spent gas with the amount of allocated gas since a transaction can spend exactly the allocated amount. More details here: https://ethereum.stackexchange.com/a/28078/33645

Fixes #62