### PR TITLE
make V long to support larger ChainId

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -505,7 +505,7 @@ public class EthBlock extends Response<EthBlock.Block> {
         public TransactionObject(String hash, String nonce, String blockHash, String blockNumber,
                                  String transactionIndex, String from, String to, String value,
                                  String gasPrice, String gas, String input, String creates,
-                                 String publicKey, String raw, String r, String s, int v) {
+                                 String publicKey, String raw, String r, String s, long v) {
             super(hash, nonce, blockHash, blockNumber, transactionIndex, from, to, value,
                     gasPrice, gas, input, creates, publicKey, raw, r, s, v);
         }

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -24,7 +24,7 @@ public class Transaction {
     private String raw;
     private String r;
     private String s;
-    private int v;  // see https://github.com/web3j/web3j/issues/44
+    private long v;  // see https://github.com/web3j/web3j/issues/44
 
     public Transaction() {
     }
@@ -32,7 +32,7 @@ public class Transaction {
     public Transaction(String hash, String nonce, String blockHash, String blockNumber,
                        String transactionIndex, String from, String to, String value,
                        String gas, String gasPrice, String input, String creates,
-                       String publicKey, String raw, String r, String s, int v) {
+                       String publicKey, String raw, String r, String s, long v) {
         this.hash = hash;
         this.nonce = nonce;
         this.blockHash = blockHash;
@@ -204,7 +204,7 @@ public class Transaction {
         this.s = s;
     }
 
-    public int getV() {
+    public long getV() {
         return v;
     }
 
@@ -217,9 +217,9 @@ public class Transaction {
     // https://github.com/ethereum/go-ethereum/issues/3339
     public void setV(Object v) {
         if (v instanceof String) {
-            this.v = Numeric.toBigInt((String) v).intValueExact();
+            this.v = Numeric.toBigInt((String) v).longValue();
         } else {
-            this.v = ((Integer) v);
+            this.v = ((Long) v);
         }
     }
 
@@ -315,7 +315,7 @@ public class Transaction {
         result = 31 * result + (getRaw() != null ? getRaw().hashCode() : 0);
         result = 31 * result + (getR() != null ? getR().hashCode() : 0);
         result = 31 * result + (getS() != null ? getS().hashCode() : 0);
-        result = 31 * result + getV();
+        result = 31 * result + BigInteger.valueOf(getV()).hashCode();
         return result;
     }
 }


### PR DESCRIPTION
Similar issue: #44

PIRL is an eth-clone with an unusually large chainId. It is too big to fit in an int field 3125659152 (0x1749b8c44).
https://github.com/pirl/pirl/blob/master/genesis.json

EthBlock$TransactionObject["v"] is an int and fails to store this value for the PIRL chain.

curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x22112", true],"id":1}' https://wallrpc.pirl.io/
{"jsonrpc":"2.0","id":1,"result":{"difficulty":"0x8edc0b6d85","extraData":"0x7069726c2e6d696e6572706f6f6c2e6e6574","gasLimit":"0x47e7c4","gasUsed":"0x5208","hash":"0x1187ceec93fdfa8b15794a689011711d89b2dc2b6bf144b832ceb40c80ced588","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0xf109b1d8e48f47fc5b496b0aee40fe8aaac48d2b","mixHash":"0xf875f043a682f64053e720ce3b03f0a85559a8f9f090bc7e275aa6834f7fa70b","nonce":"0xa95d915411eb74aa","number":"0x22112","parentHash":"0x8c7399566a4564a9e4174618472a7de485dbf0eace0ef4e47a6800166187249a","receiptsRoot":"0x8dbcfc58fe6d7004da159c4ab66137710424edfbf0d21fc187a39ec670107dc5","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x28f","stateRoot":"0xf0bcd8d021489717301a565b7c16d432bf21dd3f7d39a49bfdc98894b02530d6","timestamp":"0x59ece89d","totalDifficulty":"0x1cedc6c31eafa15","transactions":[{"blockHash":"0x1187ceec93fdfa8b15794a689011711d89b2dc2b6bf144b832ceb40c80ced588","blockNumber":"0x22112","from":"0xf109b1d8e48f47fc5b496b0aee40fe8aaac48d2b","gas":"0x15f90","gasPrice":"0x4e3b29200","hash":"0xe98c945ac1d6f0c21d136b3622e88e40e69d22d451ea10bc71edc0d9665fc09c","input":"0x","nonce":"0xdeea","to":"0x36a4a0155af21299959da51bb6c2086543bc1f09","transactionIndex":"0x0","value":"0x560337d390dd8c00","v":"0x1749b8c44","r":"0x860839385312064f20a3995c9bf0c3ed579722d30fecf5f6df1165eafeebf1fd","s":"0xf38b61361c185312a6f51ba74897420dae203e675890b3e52c635d1fab0601d"}],"transactionsRoot":"0xf885b8ee53b94929392928cfb46faeac14cc7da18a02b7bed5fb20ab36064eb6","uncles":[]}}

com.fasterxml.jackson.databind.JsonMappingException: BigInteger out of int range
at [Source: (okio.RealBufferedSource$1); line: 1, column: 1765] (through reference chain: org.web3j.protocol.core.methods.response.EthBlock$TransactionObject["v"]) (through reference chain: org.web3j.protocol.core.methods.response.EthBlock["result"]->org.web3j.protocol.core.methods.response.EthBlock$Block["transactions"])

