### PR TITLE
Websockets support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     ext.okhttpVersion = '3.8.1'
     ext.rxjavaVersion = '1.2.4'
     ext.slf4jVersion = '1.7.25'
+    ext.javaWebSocketVersion = '1.3.8'
 
     // test dependencies
     ext.equalsverifierVersion = '2.1.7'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -53,9 +53,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             "org.java-websocket:Java-WebSocket:$javaWebSocketVersion"
     testCompile project(path: ':crypto', configuration: 'testArtifacts'),
             "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion",
-            group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+            "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 task createProperties(dependsOn: processResources) doLast {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,9 +9,11 @@ dependencies {
             "com.github.jnr:jnr-unixsocket:$jnr_unixsocketVersion",
             "com.squareup.okhttp3:okhttp:$okhttpVersion",
             "com.squareup.okhttp3:logging-interceptor:$okhttpVersion",
-            "io.reactivex:rxjava:$rxjavaVersion"
+            "io.reactivex:rxjava:$rxjavaVersion",
+            "org.java-websocket:Java-WebSocket:$javaWebSocketVersion"
     testCompile project(path: ':crypto', configuration: 'testArtifacts'),
-            "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion"
+            "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion",
+            group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 }
 
 task createProperties(dependsOn: processResources) doLast {

--- a/core/src/main/java/org/web3j/protocol/Service.java
+++ b/core/src/main/java/org/web3j/protocol/Service.java
@@ -46,17 +46,14 @@ public abstract class Service implements Web3jService {
         return Async.run(() -> send(jsonRpc20Request, responseType));
     }
 
-
+    @Override
     public <T extends Notification<?>> Observable<T> subscribe(
             Request request,
+            String unsubscribeMethod,
             Class<T> responseType) {
         throw new UnsupportedOperationException(
                 String.format(
                         "Service %s does not support subscriptions",
                         this.getClass().getSimpleName()));
-    }
-
-    public boolean supportsSubscription() {
-        return false;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/Service.java
+++ b/core/src/main/java/org/web3j/protocol/Service.java
@@ -6,8 +6,11 @@ import java.util.concurrent.CompletableFuture;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import rx.Observable;
+
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.websocket.events.Notification;
 import org.web3j.utils.Async;
 
 /**
@@ -41,5 +44,19 @@ public abstract class Service implements Web3jService {
     public <T extends Response> CompletableFuture<T> sendAsync(
             Request jsonRpc20Request, Class<T> responseType) {
         return Async.run(() -> send(jsonRpc20Request, responseType));
+    }
+
+
+    public <T extends Notification<?>> Observable<T> subscribe(
+            Request request,
+            Class<T> responseType) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Service %s does not support subscriptions",
+                        this.getClass().getSimpleName()));
+    }
+
+    public boolean supportsSubscription() {
+        return false;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/Web3jService.java
+++ b/core/src/main/java/org/web3j/protocol/Web3jService.java
@@ -13,17 +13,58 @@ import org.web3j.protocol.websocket.events.Notification;
  * Services API.
  */
 public interface Web3jService {
+
+    /**
+     * Perform a synchronous JSON-RPC request.
+     *
+     * @param request request to perform
+     * @param responseType class of a data item returned by the request
+     * @param <T> type of a data item returned by the request
+     * @return deserialized JSON-RPC response
+     * @throws IOException thrown if failed to perform a request
+     */
     <T extends Response> T send(
             Request request, Class<T> responseType) throws IOException;
 
+    /**
+     * Performs an asynchronous JSON-RPC request.
+     *
+     * @param request request to perform
+     * @param responseType class of a data item returned by the request
+     * @param <T> type of a data item returned by the request
+     * @return CompletableFuture that will be completed when a result is returned or if a
+     *         request has failed
+     */
     <T extends Response> CompletableFuture<T> sendAsync(
             Request request, Class<T> responseType);
 
+    /**
+     * Subscribe to a stream of notifications. A stream of notifications is opened by
+     * by performing a specified JSON-RPC request and is closed by calling
+     * the unsubscribe method. Different WebSocket implementations use different pair of
+     * subscribe/unsubscribe methods.
+     *
+     * <p>This method creates an Observable that can be used to subscribe to new notifications.
+     * When a client unsubscribes from this Observable the service unsubscribes from
+     * the underlying stream of events.
+     *
+     * @param request JSON-RPC request that will be send to subscribe to a stream of
+     *                events
+     * @param unsubscribeMethod method that will be called to unsubscribe from a
+     *                          stream of notifications
+     * @param responseType class of incoming events objects in a stream
+     * @param <T> type of incoming event objects
+     * @return Observable that emits incoming events
+     */
     <T extends Notification<?>> Observable<T> subscribe(
             Request request,
+            String unsubscribeMethod,
             Class<T> responseType);
 
-    boolean supportsSubscription();
-
+    /**
+     * Closes resources used by the service.
+     *
+     * @throws IOException thrown if a service failed to close all resources
+     */
     void close() throws IOException;
 }

--- a/core/src/main/java/org/web3j/protocol/Web3jService.java
+++ b/core/src/main/java/org/web3j/protocol/Web3jService.java
@@ -3,8 +3,11 @@ package org.web3j.protocol;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
+import rx.Observable;
+
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.websocket.events.Notification;
 
 /**
  * Services API.
@@ -15,4 +18,10 @@ public interface Web3jService {
 
     <T extends Response> CompletableFuture<T> sendAsync(
             Request request, Class<T> responseType);
+
+    <T extends Notification<?>> Observable<T> subscribe(
+            Request request,
+            Class<T> responseType);
+
+    boolean supportsSubscription();
 }

--- a/core/src/main/java/org/web3j/protocol/Web3jService.java
+++ b/core/src/main/java/org/web3j/protocol/Web3jService.java
@@ -24,4 +24,6 @@ public interface Web3jService {
             Class<T> responseType);
 
     boolean supportsSubscription();
+
+    void close() throws IOException;
 }

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -45,6 +45,7 @@ import org.web3j.protocol.core.methods.response.EthProtocolVersion;
 import org.web3j.protocol.core.methods.response.EthSign;
 import org.web3j.protocol.core.methods.response.EthSubmitHashrate;
 import org.web3j.protocol.core.methods.response.EthSubmitWork;
+import org.web3j.protocol.core.methods.response.EthSubscribe;
 import org.web3j.protocol.core.methods.response.EthSyncing;
 import org.web3j.protocol.core.methods.response.EthTransaction;
 import org.web3j.protocol.core.methods.response.EthUninstallFilter;
@@ -63,6 +64,7 @@ import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.rx.JsonRpc2_0Rx;
+import org.web3j.protocol.websocket.events.NewHeadsNotification;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
 
@@ -685,6 +687,18 @@ public class JsonRpc2_0Web3j implements Web3j {
                 Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 ShhMessages.class);
+    }
+
+    @Override
+    public Observable<NewHeadsNotification> newHeadsNotifications() {
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("newHeads", Collections.emptyMap()),
+                        web3jService,
+                        EthSubscribe.class),
+                NewHeadsNotification.class
+        );
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -69,8 +69,6 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.rx.JsonRpc2_0Rx;
 import org.web3j.protocol.websocket.events.LogNotification;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
-import org.web3j.protocol.websocket.events.PendingTransactionNotification;
-import org.web3j.protocol.websocket.events.SyncingNotfication;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
 
@@ -734,32 +732,6 @@ public class JsonRpc2_0Web3j implements Web3j {
             params.put("topics", topics);
         }
         return params;
-    }
-
-    @Override
-    public Observable<PendingTransactionNotification> newPendingTransactionsNotifications() {
-        return web3jService.subscribe(
-                new Request<>(
-                        "eth_subscribe",
-                        Arrays.asList("newPendingTransactions"),
-                        web3jService,
-                        EthSubscribe.class),
-                "eth_unsubscribe",
-                PendingTransactionNotification.class
-        );
-    }
-
-    @Override
-    public Observable<SyncingNotfication> syncingStatusNotifications() {
-        return web3jService.subscribe(
-                new Request<>(
-                        "eth_subscribe",
-                        Arrays.asList("syncing"),
-                        web3jService,
-                        EthSubscribe.class),
-                "eth_unsubscribe",
-                SyncingNotfication.class
-        );
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -703,6 +703,7 @@ public class JsonRpc2_0Web3j implements Web3j {
                         Collections.singletonList("newHeads"),
                         web3jService,
                         EthSubscribe.class),
+                "eth_unsubscribe",
                 NewHeadsNotification.class
         );
     }
@@ -719,6 +720,7 @@ public class JsonRpc2_0Web3j implements Web3j {
                         Arrays.asList("logs", params),
                         web3jService,
                         EthSubscribe.class),
+                "eth_unsubscribe",
                 LogNotification.class
         );
     }
@@ -742,6 +744,7 @@ public class JsonRpc2_0Web3j implements Web3j {
                         Arrays.asList("newPendingTransactions"),
                         web3jService,
                         EthSubscribe.class),
+                "eth_unsubscribe",
                 PendingTransactionNotification.class
         );
     }
@@ -754,6 +757,7 @@ public class JsonRpc2_0Web3j implements Web3j {
                         Arrays.asList("syncing"),
                         web3jService,
                         EthSubscribe.class),
+                "eth_unsubscribe",
                 SyncingNotfication.class
         );
     }

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -1,5 +1,6 @@
 package org.web3j.protocol.core;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
@@ -779,5 +780,10 @@ public class JsonRpc2_0Web3j implements Web3j {
     @Override
     public void shutdown() {
         scheduledExecutorService.shutdown();
+        try {
+            web3jService.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to close web3j service", e);
+        }
     }
 }

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import rx.Observable;
@@ -64,7 +67,10 @@ import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.rx.JsonRpc2_0Rx;
+import org.web3j.protocol.websocket.events.LogNotification;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
+import org.web3j.protocol.websocket.events.PendingTransactionNotification;
+import org.web3j.protocol.websocket.events.SyncingNotfication;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
 
@@ -694,10 +700,61 @@ public class JsonRpc2_0Web3j implements Web3j {
         return web3jService.subscribe(
                 new Request<>(
                         "eth_subscribe",
-                        Arrays.asList("newHeads", Collections.emptyMap()),
+                        Collections.singletonList("newHeads"),
                         web3jService,
                         EthSubscribe.class),
                 NewHeadsNotification.class
+        );
+    }
+
+    @Override
+    public Observable<LogNotification> logsNotifications(
+            List<String> addresses, List<String> topics) {
+
+        Map<String, Object> params = createLogsParams(addresses, topics);
+
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("logs", params),
+                        web3jService,
+                        EthSubscribe.class),
+                LogNotification.class
+        );
+    }
+
+    private Map<String, Object> createLogsParams(List<String> addresses, List<String> topics) {
+        Map<String, Object> params = new HashMap<>();
+        if (!addresses.isEmpty()) {
+            params.put("address", addresses);
+        }
+        if (!topics.isEmpty()) {
+            params.put("topics", topics);
+        }
+        return params;
+    }
+
+    @Override
+    public Observable<PendingTransactionNotification> newPendingTransactionsNotifications() {
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("newPendingTransactions"),
+                        web3jService,
+                        EthSubscribe.class),
+                PendingTransactionNotification.class
+        );
+    }
+
+    @Override
+    public Observable<SyncingNotfication> syncingStatusNotifications() {
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("syncing"),
+                        web3jService,
+                        EthSubscribe.class),
+                SyncingNotfication.class
         );
     }
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthSubscribe.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthSubscribe.java
@@ -1,0 +1,9 @@
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+public class EthSubscribe extends Response<String> {
+    public String getSubscriptionId() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthUnsubscribe.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthUnsubscribe.java
@@ -1,0 +1,7 @@
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+public class EthUnsubscribe extends Response<Boolean> {
+
+}

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -159,4 +159,9 @@ public class HttpService extends Service {
     public HashMap<String, String> getHeaders() {
         return headers;
     }
+
+    @Override
+    public void close() throws IOException {
+
+    }
 }

--- a/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
+++ b/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
@@ -43,12 +43,7 @@ public class IpcService extends Service {
 
     @Override
     protected InputStream performIO(String payload) throws IOException {
-        IOFacade io;
-        if (ioFacade != null) {
-            io = ioFacade;
-        } else {
-            io = getIO();
-        }
+        IOFacade io = getIoFacade();
         io.write(payload);
         log.debug(">> " + payload);
 
@@ -64,10 +59,22 @@ public class IpcService extends Service {
         return new ByteArrayInputStream(result.getBytes("UTF-8"));
     }
 
+    private IOFacade getIoFacade() {
+        IOFacade io;
+        if (ioFacade != null) {
+            io = ioFacade;
+        } else {
+            io = getIO();
+        }
+        return io;
+    }
+
     @Override
     public void close() throws IOException {
-        if (ioFacade != null) {
-            ioFacade.close();
+        IOFacade io = getIoFacade();
+
+        if (io != null) {
+            io.close();
         }
     }
 }

--- a/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
+++ b/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
@@ -64,7 +64,7 @@ public class IpcService extends Service {
         return new ByteArrayInputStream(result.getBytes("UTF-8"));
     }
 
-    @Deprecated
+    @Override
     public void close() throws IOException {
         if (ioFacade != null) {
             ioFacade.close();

--- a/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
+++ b/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
@@ -1,5 +1,7 @@
 package org.web3j.protocol.rx;
 
+import java.util.List;
+
 import rx.Observable;
 
 import org.web3j.protocol.core.DefaultBlockParameter;
@@ -7,7 +9,10 @@ import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.Transaction;
+import org.web3j.protocol.websocket.events.LogNotification;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
+import org.web3j.protocol.websocket.events.PendingTransactionNotification;
+import org.web3j.protocol.websocket.events.SyncingNotfication;
 
 /**
  * The Observables JSON-RPC client event API.
@@ -176,4 +181,30 @@ public interface Web3jRx {
      * @return Observable that emits a notification for every new header
      */
     Observable<NewHeadsNotification> newHeadsNotifications();
+
+    /**
+     * Creates an observable that emits notifications for logs included in new imported blocks.
+     *
+     * @param addresses only return logs from this list of address. Return logs from all addresses
+     *                  if the list is empty
+     * @param topics only return logs that match specified topics. Returns logs for all topics if
+     *               the list is empty
+     * @return Observable that emits logs included in new blocks
+     */
+    Observable<LogNotification> logsNotifications(List<String> addresses, List<String> topics);
+
+    /**
+     * Creates an observable that emits a notification when a new transaction is added
+     * to the pending state and is signed with a key that is available in the node.
+     *
+     * @return Observable that emits a notification when a new transaction is added
+     *         to the pending state
+     */
+    Observable<PendingTransactionNotification> newPendingTransactionsNotifications();
+
+    /**
+     * Creates an observable that emits a notification when a node starts or stops syncing.
+     * @return Observalbe that emits changes to syncing status
+     */
+    Observable<SyncingNotfication> syncingStatusNotifications();
 }

--- a/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
+++ b/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
@@ -192,19 +192,4 @@ public interface Web3jRx {
      * @return Observable that emits logs included in new blocks
      */
     Observable<LogNotification> logsNotifications(List<String> addresses, List<String> topics);
-
-    /**
-     * Creates an observable that emits a notification when a new transaction is added
-     * to the pending state and is signed with a key that is available in the node.
-     *
-     * @return Observable that emits a notification when a new transaction is added
-     *         to the pending state
-     */
-    Observable<PendingTransactionNotification> newPendingTransactionsNotifications();
-
-    /**
-     * Creates an observable that emits a notification when a node starts or stops syncing.
-     * @return Observalbe that emits changes to syncing status
-     */
-    Observable<SyncingNotfication> syncingStatusNotifications();
 }

--- a/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
+++ b/core/src/main/java/org/web3j/protocol/rx/Web3jRx.java
@@ -7,6 +7,7 @@ import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.Transaction;
+import org.web3j.protocol.websocket.events.NewHeadsNotification;
 
 /**
  * The Observables JSON-RPC client event API.
@@ -167,4 +168,12 @@ public interface Web3jRx {
      */
     Observable<Transaction> catchUpToLatestAndSubscribeToNewTransactionsObservable(
             DefaultBlockParameter startBlock);
+
+    /**
+     * Creates an observable that emits a notification when a new header is appended to a chain,
+     * including chain reorganizations.
+     *
+     * @return Observable that emits a notification for every new header
+     */
+    Observable<NewHeadsNotification> newHeadsNotifications();
 }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -1,0 +1,45 @@
+package org.web3j.protocol.websocket;
+
+import java.net.URI;
+
+import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class WebSocketClient extends org.java_websocket.client.WebSocketClient {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketClient.class);
+
+    final WebSocketService service;
+
+    public WebSocketClient(URI serverUri, WebSocketService service) {
+        super(serverUri);
+        this.service = service;
+    }
+
+    @Override
+    public void onOpen(ServerHandshake serverHandshake) {
+        log.info("Opened WebSocket connection to {}", uri);
+    }
+
+    @Override
+    public void onMessage(String s) {
+        try {
+            log.debug("Received message {} from server {}", s, uri);
+            service.onReply(s);
+            log.debug("Processed message {} from server {}", s, uri);
+        } catch (Exception e) {
+            log.error("Failed to process message '{}' from server {}", s, uri);
+        }
+    }
+
+    @Override
+    public void onClose(int i, String s, boolean b) {
+        log.info("Closed WebSocket connection to {}", uri);
+    }
+
+    @Override
+    public void onError(Exception e) {
+        log.error(String.format("WebSocket connection to {} failed with error", uri), e);
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -10,11 +10,10 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketClient.class);
 
-    final WebSocketService service;
+    private WebSocketListener listener;
 
-    public WebSocketClient(URI serverUri, WebSocketService service) {
+    public WebSocketClient(URI serverUri) {
         super(serverUri);
-        this.service = service;
     }
 
     @Override
@@ -26,7 +25,7 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
     public void onMessage(String s) {
         try {
             log.debug("Received message {} from server {}", s, uri);
-            service.onReply(s);
+            listener.onMessage(s);
             log.debug("Processed message {} from server {}", s, uri);
         } catch (Exception e) {
             log.error("Failed to process message '{}' from server {}", s, uri);
@@ -41,5 +40,9 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
     @Override
     public void onError(Exception e) {
         log.error(String.format("WebSocket connection to {} failed with error", uri), e);
+    }
+
+    public void setListener(WebSocketListener listener) {
+        this.listener = listener;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -6,6 +6,10 @@ import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Web socket client implementation that connects to a specify URI. Allows to provide a listener
+ * that will be called when a new message is received by the client.
+ */
 public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketClient.class);
@@ -33,8 +37,9 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
     }
 
     @Override
-    public void onClose(int i, String s, boolean b) {
-        log.info("Closed WebSocket connection to {}", uri);
+    public void onClose(int code, String reason, boolean remote) {
+        log.info("Closed WebSocket connection to {}, because of reason: '{}'."
+                + "Conection closed remotely: {}", uri, reason, remote);
     }
 
     @Override
@@ -42,6 +47,11 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
         log.error(String.format("WebSocket connection to {} failed with error", uri), e);
     }
 
+    /**
+     * Set a listener that will be called when a new message is received by the client.
+     *
+     * @param listener WebSocket listener
+     */
     public void setListener(WebSocketListener listener) {
         this.listener = listener;
     }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -30,7 +30,6 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
         try {
             log.debug("Received message {} from server {}", s, uri);
             listener.onMessage(s);
-            log.debug("Processed message {} from server {}", s, uri);
         } catch (Exception e) {
             log.error("Failed to process message '{}' from server {}", s, uri);
         }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -6,7 +6,7 @@ import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class WebSocketClient extends org.java_websocket.client.WebSocketClient {
+public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketClient.class);
 

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -40,11 +40,13 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
     public void onClose(int code, String reason, boolean remote) {
         log.info("Closed WebSocket connection to {}, because of reason: '{}'."
                 + "Conection closed remotely: {}", uri, reason, remote);
+        listener.onClose();
     }
 
     @Override
     public void onError(Exception e) {
         log.error(String.format("WebSocket connection to {} failed with error", uri), e);
+        listener.onError(e);
     }
 
     /**

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
@@ -1,0 +1,7 @@
+package org.web3j.protocol.websocket;
+
+import java.io.IOException;
+
+public interface WebSocketListener {
+    void onMessage(String message) throws IOException;
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
@@ -9,8 +9,13 @@ public interface WebSocketListener {
 
     /**
      * Called when a new WebSocket message is delivered.
+     *
      * @param message new WebSocket message
      * @throws IOException thrown if an observer failed to process the message
      */
     void onMessage(String message) throws IOException;
+
+    void onError(Exception e);
+
+    void onClose();
 }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketListener.java
@@ -2,6 +2,15 @@ package org.web3j.protocol.websocket;
 
 import java.io.IOException;
 
+/**
+ * A listener used to notify about about new WebSocket messages.
+ */
 public interface WebSocketListener {
+
+    /**
+     * Called when a new WebSocket message is delivered.
+     * @param message new WebSocket message
+     * @throws IOException thrown if an observer failed to process the message
+     */
     void onMessage(String message) throws IOException;
 }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
@@ -8,16 +8,16 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> type of a data item that should be returned by the sent request
  */
 class WebSocketRequest<T> {
-    private CompletableFuture<T> completableFuture;
+    private CompletableFuture<T> onReply;
     private Class<T> responseType;
 
-    public WebSocketRequest(CompletableFuture<T> completableFuture, Class<T> responseType) {
-        this.completableFuture = completableFuture;
+    public WebSocketRequest(CompletableFuture<T> onReply, Class<T> responseType) {
+        this.onReply = onReply;
         this.responseType = responseType;
     }
 
-    public CompletableFuture<T> getCompletableFuture() {
-        return completableFuture;
+    public CompletableFuture<T> getOnReply() {
+        return onReply;
     }
 
     public Class<T> getResponseType() {

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
@@ -2,6 +2,11 @@ package org.web3j.protocol.websocket;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Objects necessary to process a reply for a request sent via WebSocket protocol.
+ *
+ * @param <T> type of a data item that should be returned by the sent request
+ */
 class WebSocketRequest<T> {
     private CompletableFuture<T> completableFuture;
     private Class<T> responseType;

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketRequest.java
@@ -1,0 +1,21 @@
+package org.web3j.protocol.websocket;
+
+import java.util.concurrent.CompletableFuture;
+
+class WebSocketRequest<T> {
+    private CompletableFuture<T> completableFuture;
+    private Class<T> responseType;
+
+    public WebSocketRequest(CompletableFuture<T> completableFuture, Class<T> responseType) {
+        this.completableFuture = completableFuture;
+        this.responseType = responseType;
+    }
+
+    public CompletableFuture<T> getCompletableFuture() {
+        return completableFuture;
+    }
+
+    public Class<T> getResponseType() {
+        return responseType;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -6,6 +6,7 @@ import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -14,16 +15,23 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import rx.Observable;
+import rx.subjects.PublishSubject;
+
 import org.web3j.protocol.ObjectMapperFactory;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthSubscribe;
+import org.web3j.protocol.core.methods.response.EthUnsubscribe;
+import org.web3j.protocol.websocket.events.Notification;
 
 public class WebSocketService implements Web3jService {
 
@@ -36,6 +44,8 @@ public class WebSocketService implements Web3jService {
     private final ObjectMapper objectMapper;
 
     private Map<Long, WebSocketRequest<?>> requestForId = new HashMap<>();
+    private Map<Long, WebSocketSubscription<?>> pendingSubscription = new HashMap<>();
+    private Map<String, WebSocketSubscription<?>> subscriptionForId = new HashMap<>();
 
     public WebSocketService(String serverUrl, boolean includeRawResponses) {
         this.webSocketClient = new WebSocketClient(parseURI(serverUrl), this);
@@ -75,7 +85,7 @@ public class WebSocketService implements Web3jService {
                 throw (IOException) e.getCause();
             }
 
-            throw new RuntimeException("Unexpected exception", e);
+            throw new RuntimeException("Unexpected exception", e.getCause());
         }
     }
 
@@ -87,14 +97,19 @@ public class WebSocketService implements Web3jService {
         long requestId = request.getId();
         requestForId.put(requestId, new WebSocketRequest<>(result, responseType));
         try {
-            String payload = objectMapper.writeValueAsString(request);
-            webSocketClient.send(payload);
-            setTimeout(requestId);
+            sendRequest(request, requestId);
         } catch (IOException e) {
             closeRequest(requestId, e);
         }
 
         return result;
+    }
+
+    private void sendRequest(Request request, long requestId) throws JsonProcessingException {
+        String payload = objectMapper.writeValueAsString(request);
+        log.debug("Sending request: {}", payload);
+        webSocketClient.send(payload);
+        setTimeout(requestId);
     }
 
     private void setTimeout(long requestId) {
@@ -107,35 +122,89 @@ public class WebSocketService implements Web3jService {
                 TimeUnit.SECONDS);
     }
 
-    private void closeRequest(long requestId, Exception e) {
+    void closeRequest(long requestId, Exception e) {
         CompletableFuture result = requestForId.get(requestId).getCompletableFuture();
         requestForId.remove(requestId);
         result.completeExceptionally(e);
     }
 
-    boolean isWaitingForReply(long requestId) {
-        return requestForId.containsKey(requestId);
-    }
-
     void onReply(String replyStr) throws IOException {
         JsonNode replyJson = parseToTree(replyStr);
 
-        WebSocketRequest request = getAndRemoveRequest(replyJson);
-        Class<?> responseType = request.getResponseType();
-        CompletableFuture<Object> future = request.getCompletableFuture();
-
-        try {
-            Object reply = objectMapper.convertValue(replyJson, responseType);
-            future.complete(reply);
-        } catch (IllegalArgumentException e) {
-            future.completeExceptionally(
-                    new IOException(
-                            String.format(
-                                    "Failed to parse '%s' as type %s",
-                                    replyStr,
-                                    responseType),
-                            e));
+        if (isReply(replyJson)) {
+            processRequestReply(replyStr, replyJson);
+        } else if (isSubscriptionEvent(replyJson)) {
+            processSubscriptionEvent(replyStr, replyJson);
+        } else {
+            throw new IOException("Unknown message type");
         }
+    }
+
+    private void processRequestReply(String replyStr, JsonNode replyJson) throws IOException {
+        long replyId = getReplyId(replyJson);
+        WebSocketRequest request = getAndRemoveRequest(replyId);
+        try {
+            Object reply = objectMapper.convertValue(replyJson, request.getResponseType());
+
+            if (reply instanceof EthSubscribe) {
+                subscribeForEvents(replyId, (EthSubscribe) reply);
+            }
+
+            sendReplyToListener(request, reply);
+        } catch (IllegalArgumentException e) {
+            sendExceptionToListener(replyStr, request, e);
+        }
+    }
+
+    private void subscribeForEvents(long replyId, EthSubscribe reply) {
+        WebSocketSubscription<?> subscription = pendingSubscription.remove(replyId);
+        subscriptionForId.put(reply.getSubscriptionId(), subscription);
+    }
+
+    private void sendReplyToListener(WebSocketRequest request, Object reply) {
+        request.getCompletableFuture().complete(reply);
+    }
+
+    private void sendExceptionToListener(
+            String replyStr,
+            WebSocketRequest request,
+            IllegalArgumentException e) {
+        request.getCompletableFuture().completeExceptionally(
+                new IOException(
+                        String.format(
+                                "Failed to parse '%s' as type %s",
+                                replyStr,
+                                request.getResponseType()),
+                        e));
+    }
+
+    private void processSubscriptionEvent(String replyStr, JsonNode replyJson) {
+        log.info("Processing event: {}", replyStr);
+        String subscriptionId = extractSubscriptionId(replyJson);
+        WebSocketSubscription subscription = subscriptionForId.get(subscriptionId);
+
+        if (subscription == null) {
+            unsubscribeFromEventsStream(subscriptionId);
+        } else {
+            sendEventToSubscriber(replyJson, subscription);
+        }
+    }
+
+    private String extractSubscriptionId(JsonNode replyJson) {
+        return replyJson.get("params").get("subscription").asText();
+    }
+
+    private void sendEventToSubscriber(JsonNode replyJson, WebSocketSubscription subscription) {
+        Object event = objectMapper.convertValue(replyJson, subscription.getResponseType());
+        subscription.getSubject().onNext(event);
+    }
+
+    private boolean isReply(JsonNode replyJson) {
+        return replyJson.has("id");
+    }
+
+    private boolean isSubscriptionEvent(JsonNode replyJson) {
+        return replyJson.has("method");
     }
 
     private JsonNode parseToTree(String replyStr) throws IOException {
@@ -146,8 +215,7 @@ public class WebSocketService implements Web3jService {
         }
     }
 
-    private WebSocketRequest getAndRemoveRequest(JsonNode replyJson) throws IOException {
-        long id = getReplyId(replyJson);
+    private WebSocketRequest getAndRemoveRequest(long id) throws IOException {
         if (!requestForId.containsKey(id)) {
             throw new IOException(String.format(
                     "Received reply for unexpected request id: %d",
@@ -181,9 +249,91 @@ public class WebSocketService implements Web3jService {
         }
     }
 
+    @Override
+    public <T extends Notification<?>> Observable<T> subscribe(
+            Request request,
+            Class<T> responseType) {
+        PublishSubject<T> subject = PublishSubject.create();
+
+        pendingSubscription.put(
+                request.getId(),
+                new WebSocketSubscription<>(subject, responseType));
+        sendSubscribeRequest(request, subject);
+
+        return subject
+                .doOnUnsubscribe(() -> closeSubscription(subject));
+
+    }
+
+    private <T extends Notification<?>> void closeSubscription(PublishSubject<T> subject) {
+        subject.onCompleted();
+        String subscriptionId = getSubscriptionId(subject);
+        subscriptionForId.remove(subscriptionId);
+        if (subscriptionId != null) {
+            unsubscribeFromEventsStream(subscriptionId);
+        }
+    }
+
+    private <T extends Notification<?>> void sendSubscribeRequest(
+            Request request,
+            PublishSubject<T> subject) {
+        sendAsync(request, EthSubscribe.class)
+                .thenAccept(ethSubscribe -> {
+                    log.info(
+                            "Subscribed to RPC events with id {}",
+                            ethSubscribe.getSubscriptionId());
+                })
+                .exceptionally(throwable -> {
+                    log.error(
+                            "Failed to subscribe to RPC events with request id {}",
+                            request.getId());
+                    subject.onError(throwable.getCause());
+                    return null;
+                });
+    }
+
+    private <T extends Notification<?>> String getSubscriptionId(PublishSubject<T> subject) {
+        return subscriptionForId.entrySet().stream()
+                .filter(entry -> entry.getValue().getSubject() == subject)
+                .map(entry -> entry.getKey())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void unsubscribeFromEventsStream(String subscriptionId) {
+        sendAsync(unsubscribeRequest(subscriptionId), EthUnsubscribe.class)
+                .thenAccept(ethUnsubscribe -> {
+                    log.debug(
+                            "Successfully unsubscribed from subscription with id {}",
+                            subscriptionId);
+                })
+                .exceptionally(throwable -> {
+                    log.error("Failed to unsubscribe from subscription with id {}", subscriptionId);
+                    return null;
+                });
+    }
+
+    private Request<String, EthUnsubscribe> unsubscribeRequest(String subscriptionId) {
+        return new Request<>(
+                        "eth_unsubscribe",
+                        Arrays.asList(subscriptionId),
+                        this,
+                        EthUnsubscribe.class);
+    }
+
+    @Override
+    public boolean supportsSubscription() {
+        return true;
+    }
+
     public void close() {
         webSocketClient.close();
         executor.shutdown();
+    }
+
+    // Method for unit-tests
+    boolean isWaitingForReply(long requestId) {
+        return requestForId.containsKey(requestId);
     }
 }
 

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -53,6 +53,13 @@ public class WebSocketService implements Web3jService {
         this.objectMapper = ObjectMapperFactory.getObjectMapper(includeRawResponses);
     }
 
+    public WebSocketService(WebSocketClient webSocketClient,
+                     boolean includeRawResponses) {
+        this.webSocketClient = webSocketClient;
+        this.executor = Executors.newScheduledThreadPool(1);
+        this.objectMapper = ObjectMapperFactory.getObjectMapper(includeRawResponses);
+    }
+
     WebSocketService(WebSocketClient webSocketClient,
                      ScheduledExecutorService executor,
                      boolean includeRawResponses) {

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -33,17 +33,34 @@ import org.web3j.protocol.core.methods.response.EthSubscribe;
 import org.web3j.protocol.core.methods.response.EthUnsubscribe;
 import org.web3j.protocol.websocket.events.Notification;
 
+/**
+ * Web socket service that allows to interact with JSON-RPC via WebSocket protocol.
+ *
+ * <p>Allows to interact with JSON-RPC either by sending individual requests or by
+ * subscribing to a stream of notifications. To subscribe to a notification it first
+ * sends a special JSON-RPC request that returns a unique subscription id. A subscription
+ * id is used to identify events for a single notifications stream.
+ *
+ * <p>To unsubscribe from a stream of notifications it should send another JSON-RPC
+ * request.
+ */
 public class WebSocketService implements Web3jService {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketService.class);
 
+    // Timeout for JSON-RPC requests
     static final long REQUEST_TIMEOUT = 60;
 
+    // WebSocket client
     private final WebSocketClient webSocketClient;
+    // Executor to schedule request timeouts
     private final ScheduledExecutorService executor;
+    // Object mapper to map incoming JSON objects
     private final ObjectMapper objectMapper;
 
+    // Map of a sent request id to objects necessary to process this id
     private Map<Long, WebSocketRequest<?>> requestForId = new HashMap<>();
+    // Map of a subscription id to objects necessary to process incoming events
     private Map<String, WebSocketSubscription<?>> subscriptionForId = new HashMap<>();
 
     public WebSocketService(String serverUrl, boolean includeRawResponses) {

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -1,0 +1,189 @@
+package org.web3j.protocol.websocket;
+
+import java.io.IOException;
+
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.web3j.protocol.ObjectMapperFactory;
+import org.web3j.protocol.Web3jService;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.Response;
+
+public class WebSocketService implements Web3jService {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketService.class);
+
+    static final long REQUEST_TIMEOUT = 60;
+
+    private final WebSocketClient webSocketClient;
+    private final ScheduledExecutorService executor;
+    private final ObjectMapper objectMapper;
+
+    private Map<Long, WebSocketRequest<?>> requestForId = new HashMap<>();
+
+    public WebSocketService(String serverUrl, boolean includeRawResponses) {
+        this.webSocketClient = new WebSocketClient(parseURI(serverUrl), this);
+        this.executor = Executors.newScheduledThreadPool(1);
+        this.objectMapper = ObjectMapperFactory.getObjectMapper(includeRawResponses);
+    }
+
+    WebSocketService(WebSocketClient webSocketClient,
+                     ScheduledExecutorService executor,
+                     boolean includeRawResponses) {
+        this.webSocketClient = webSocketClient;
+        this.executor = executor;
+        this.objectMapper = ObjectMapperFactory.getObjectMapper(includeRawResponses);
+    }
+
+    public void connect() throws ConnectException {
+        try {
+            boolean connected = webSocketClient.connectBlocking();
+            if (!connected) {
+                throw new ConnectException("Failed to connect to WebSocket");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while connecting via WebSocket protocol");
+        }
+    }
+
+    @Override
+    public <T extends Response> T send(Request request, Class<T> responseType) throws IOException {
+        try {
+            return sendAsync(request, responseType).get();
+        } catch (InterruptedException e) {
+            Thread.interrupted();
+            throw new IOException("Interrupted WebSocket request", e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+
+            throw new RuntimeException("Unexpected exception", e);
+        }
+    }
+
+    @Override
+    public <T extends Response> CompletableFuture<T> sendAsync(
+            Request request,
+            Class<T> responseType) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        long requestId = request.getId();
+        requestForId.put(requestId, new WebSocketRequest<>(result, responseType));
+        try {
+            String payload = objectMapper.writeValueAsString(request);
+            webSocketClient.send(payload);
+            setTimeout(requestId);
+        } catch (IOException e) {
+            closeRequest(requestId, e);
+        }
+
+        return result;
+    }
+
+    private void setTimeout(long requestId) {
+        executor.schedule(
+                () -> closeRequest(
+                    requestId,
+                    new IOException(
+                        String.format("Request with id %d timed out", requestId))),
+                REQUEST_TIMEOUT,
+                TimeUnit.SECONDS);
+    }
+
+    private void closeRequest(long requestId, Exception e) {
+        CompletableFuture result = requestForId.get(requestId).getCompletableFuture();
+        requestForId.remove(requestId);
+        result.completeExceptionally(e);
+    }
+
+    boolean isWaitingForReply(long requestId) {
+        return requestForId.containsKey(requestId);
+    }
+
+    void onReply(String replyStr) throws IOException {
+        JsonNode replyJson = parseToTree(replyStr);
+
+        WebSocketRequest request = getAndRemoveRequest(replyJson);
+        Class<?> responseType = request.getResponseType();
+        CompletableFuture<Object> future = request.getCompletableFuture();
+
+        try {
+            Object reply = objectMapper.convertValue(replyJson, responseType);
+            future.complete(reply);
+        } catch (IllegalArgumentException e) {
+            future.completeExceptionally(
+                    new IOException(
+                            String.format(
+                                    "Failed to parse '%s' as type %s",
+                                    replyStr,
+                                    responseType),
+                            e));
+        }
+    }
+
+    private JsonNode parseToTree(String replyStr) throws IOException {
+        try {
+            return objectMapper.readTree(replyStr);
+        } catch (IOException e) {
+            throw new IOException("Failed to parse incoming WebSocket message", e);
+        }
+    }
+
+    private WebSocketRequest getAndRemoveRequest(JsonNode replyJson) throws IOException {
+        long id = getReplyId(replyJson);
+        if (!requestForId.containsKey(id)) {
+            throw new IOException(String.format(
+                    "Received reply for unexpected request id: %d",
+                    id));
+        }
+        WebSocketRequest request = requestForId.get(id);
+        requestForId.remove(id);
+        return request;
+    }
+
+    private long getReplyId(JsonNode replyJson) throws IOException {
+        JsonNode idField = replyJson.get("id");
+        if (idField == null) {
+            throw new IOException("'id' field is missing in the reply");
+        }
+
+        if (!idField.isIntegralNumber()) {
+            throw new IOException(String.format(
+                    "'id' expected to be long, but it is: '%s'",
+                    idField.asText()));
+        }
+
+        return idField.longValue();
+    }
+
+    private static URI parseURI(String serverUrl) {
+        try {
+            return new URI(serverUrl);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(String.format("Failed to parse URL: '%s'", serverUrl), e);
+        }
+    }
+
+    public void close() {
+        webSocketClient.close();
+        executor.shutdown();
+    }
+}
+

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -115,7 +115,7 @@ public class WebSocketService implements Web3jService {
 
             @Override
             public void onError(Exception e) {
-
+                log.error("Received error from a WebSocket connection", e);
             }
 
             @Override
@@ -177,7 +177,7 @@ public class WebSocketService implements Web3jService {
     }
 
     void closeRequest(long requestId, Exception e) {
-        CompletableFuture result = requestForId.get(requestId).getCompletableFuture();
+        CompletableFuture result = requestForId.get(requestId).getOnReply();
         requestForId.remove(requestId);
         result.completeExceptionally(e);
     }
@@ -261,14 +261,14 @@ public class WebSocketService implements Web3jService {
     }
 
     private void sendReplyToListener(WebSocketRequest request, Object reply) {
-        request.getCompletableFuture().complete(reply);
+        request.getOnReply().complete(reply);
     }
 
     private void sendExceptionToListener(
             String replyStr,
             WebSocketRequest request,
             IllegalArgumentException e) {
-        request.getCompletableFuture().completeExceptionally(
+        request.getOnReply().completeExceptionally(
                 new IOException(
                         String.format(
                                 "Failed to parse '%s' as type %s",
@@ -431,7 +431,7 @@ public class WebSocketService implements Web3jService {
 
     private void closeOutstandingRequests() {
         requestForId.values().forEach(request -> {
-            request.getCompletableFuture()
+            request.getOnReply()
                     .completeExceptionally(new IOException("Connection was closed"));
         });
     }

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -326,6 +326,7 @@ public class WebSocketService implements Web3jService {
         return true;
     }
 
+    @Override
     public void close() {
         webSocketClient.close();
         executor.shutdown();

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
@@ -2,10 +2,21 @@ package org.web3j.protocol.websocket;
 
 import rx.subjects.BehaviorSubject;
 
+/**
+ * Objects necessary to process a new item received via a WebSocket subscription.
+ *
+ * @param <T> type of a data item that should be returned by a WebSocket subscription.
+ */
 public class WebSocketSubscription<T> {
     private BehaviorSubject<T> subject;
     private Class<T> responseType;
 
+    /**
+     * Creates WebSocketSubscription.
+     *
+     * @param subject used to send new data items to listeners
+     * @param responseType type of a data item returned by a WebSocket subscription
+     */
     public WebSocketSubscription(BehaviorSubject<T> subject, Class<T> responseType) {
         this.subject = subject;
         this.responseType = responseType;

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
@@ -1,0 +1,21 @@
+package org.web3j.protocol.websocket;
+
+import rx.subjects.PublishSubject;
+
+public class WebSocketSubscription<T> {
+    private PublishSubject<T> subject;
+    private Class<T> responseType;
+
+    public WebSocketSubscription(PublishSubject<T> subject, Class<T> responseType) {
+        this.subject = subject;
+        this.responseType = responseType;
+    }
+
+    public PublishSubject<T> getSubject() {
+        return subject;
+    }
+
+    public Class<T> getResponseType() {
+        return responseType;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketSubscription.java
@@ -1,17 +1,17 @@
 package org.web3j.protocol.websocket;
 
-import rx.subjects.PublishSubject;
+import rx.subjects.BehaviorSubject;
 
 public class WebSocketSubscription<T> {
-    private PublishSubject<T> subject;
+    private BehaviorSubject<T> subject;
     private Class<T> responseType;
 
-    public WebSocketSubscription(PublishSubject<T> subject, Class<T> responseType) {
+    public WebSocketSubscription(BehaviorSubject<T> subject, Class<T> responseType) {
         this.subject = subject;
         this.responseType = responseType;
     }
 
-    public PublishSubject<T> getSubject() {
+    public BehaviorSubject<T> getSubject() {
         return subject;
     }
 

--- a/core/src/main/java/org/web3j/protocol/websocket/events/Log.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/Log.java
@@ -1,0 +1,46 @@
+package org.web3j.protocol.websocket.events;
+
+import java.util.List;
+
+public class Log {
+    private String address;
+    private String blockHash;
+    private String blockNumber;
+    private String data;
+    private String logIndex;
+    private List<String> topics;
+    private String transactionHash;
+    private String transactionIndex;
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public String getBlockNumber() {
+        return blockNumber;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public String getLogIndex() {
+        return logIndex;
+    }
+
+    public List<String> getTopics() {
+        return topics;
+    }
+
+    public String getTransactionHash() {
+        return transactionHash;
+    }
+
+    public String getTransactionIndex() {
+        return transactionIndex;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/events/LogNotification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/LogNotification.java
@@ -1,0 +1,4 @@
+package org.web3j.protocol.websocket.events;
+
+public class LogNotification extends Notification<Log> {
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NewHead.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NewHead.java
@@ -1,6 +1,6 @@
 package org.web3j.protocol.websocket.events;
 
-public class NewHeadsNotificationParam {
+public class NewHead {
     private String difficulty;
     private String extraData;
     private String gasLimit;

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotification.java
@@ -1,7 +1,7 @@
 package org.web3j.protocol.websocket.events;
 
 public class NewHeadsNotification
-        extends Notification<NewHeadsNotificationParam> {
+        extends Notification<NewHead> {
 }
 
 

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotification.java
@@ -1,0 +1,8 @@
+package org.web3j.protocol.websocket.events;
+
+public class NewHeadsNotification
+        extends Notification<NewHeadsNotificationParam> {
+}
+
+
+

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotificationParam.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NewHeadsNotificationParam.java
@@ -1,0 +1,74 @@
+package org.web3j.protocol.websocket.events;
+
+public class NewHeadsNotificationParam {
+    private String difficulty;
+    private String extraData;
+    private String gasLimit;
+    private String gasUsed;
+    private String logsBloom;
+    private String miner;
+    private String nonce;
+    private String number;
+    private String parentHash;
+    private String receiptRoot;
+    private String sha3Uncles;
+    private String stateRoot;
+    private String timestamp;
+    private String transactionRoot;
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public String getExtraData() {
+        return extraData;
+    }
+
+    public String getGasLimit() {
+        return gasLimit;
+    }
+
+    public String getGasUsed() {
+        return gasUsed;
+    }
+
+    public String getLogsBloom() {
+        return logsBloom;
+    }
+
+    public String getMiner() {
+        return miner;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public String getParentHash() {
+        return parentHash;
+    }
+
+    public String getReceiptRoot() {
+        return receiptRoot;
+    }
+
+    public String getSha3Uncles() {
+        return sha3Uncles;
+    }
+
+    public String getStateRoot() {
+        return stateRoot;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public String getTransactionRoot() {
+        return transactionRoot;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/events/Notification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/Notification.java
@@ -1,0 +1,23 @@
+package org.web3j.protocol.websocket.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Notification<T> {
+    private String jsonrpc;
+    private String method;
+    private NotificationParams<T> params;
+
+    public String getJsonrpc() {
+        return jsonrpc;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public NotificationParams<T> getParams() {
+        return params;
+    }
+}
+

--- a/core/src/main/java/org/web3j/protocol/websocket/events/Notification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/Notification.java
@@ -2,6 +2,11 @@ package org.web3j.protocol.websocket.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Base class for WebSocket notifications.
+ *
+ * @param <T> type of data return by a particular subscription
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Notification<T> {
     private String jsonrpc;

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NotificationParams.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NotificationParams.java
@@ -1,0 +1,17 @@
+package org.web3j.protocol.websocket.events;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NotificationParams<T> {
+    private T result;
+    private String subsciption;
+
+    public T getResult() {
+        return result;
+    }
+
+    public String getSubsciption() {
+        return subsciption;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/events/NotificationParams.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/NotificationParams.java
@@ -2,6 +2,11 @@ package org.web3j.protocol.websocket.events;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Generic class for a notification param. Contains a subscription id and a data item.
+ *
+ * @param <T> type of data return by a particular subscription
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NotificationParams<T> {
     private T result;

--- a/core/src/main/java/org/web3j/protocol/websocket/events/PendingTransactionNotification.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/PendingTransactionNotification.java
@@ -1,0 +1,4 @@
+package org.web3j.protocol.websocket.events;
+
+public class PendingTransactionNotification extends Notification<String> {
+}

--- a/core/src/main/java/org/web3j/protocol/websocket/events/SyncingNotfication.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/events/SyncingNotfication.java
@@ -1,0 +1,6 @@
+package org.web3j.protocol.websocket.events;
+
+import org.web3j.protocol.core.methods.response.EthSyncing;
+
+public class SyncingNotfication extends Notification<EthSyncing> {
+}

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
@@ -10,11 +10,9 @@ import org.web3j.protocol.Web3jService;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-public class JsonRpc2_0WebSocketClientJTest {
+public class JsonRpc2_0Web3jTest {
 
     private ScheduledExecutorService scheduledExecutorService
             = mock(ScheduledExecutorService.class);

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
@@ -8,20 +8,21 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class JsonRpc2_0WebSocketClientJTest {
 
     @Test
-    public void testStopExecutorOnShutdown() {
+    public void testStopExecutorOnShutdown() throws Exception {
         ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+        Web3jService service = mock(Web3jService.class);
 
-        Web3j web3j = Web3j.build(
-                mock(Web3jService.class), 10, scheduledExecutorService
-        );
+        Web3j web3j = Web3j.build(service, 10, scheduledExecutorService);
 
         web3j.shutdown();
 
         verify(scheduledExecutorService).shutdown();
+        verify(service).close();
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
@@ -1,5 +1,6 @@
 package org.web3j.protocol.core;
 
+import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.Test;
@@ -7,22 +8,33 @@ import org.junit.Test;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JsonRpc2_0WebSocketClientJTest {
 
+    private ScheduledExecutorService scheduledExecutorService
+            = mock(ScheduledExecutorService.class);
+    private Web3jService service = mock(Web3jService.class);
+
+    private Web3j web3j = Web3j.build(service, 10, scheduledExecutorService);
+
     @Test
     public void testStopExecutorOnShutdown() throws Exception {
-        ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
-        Web3jService service = mock(Web3jService.class);
-
-        Web3j web3j = Web3j.build(service, 10, scheduledExecutorService);
-
         web3j.shutdown();
 
         verify(scheduledExecutorService).shutdown();
         verify(service).close();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testThrowsRuntimeExceptionIfFailedToCloseService() throws Exception {
+        doThrow(new IOException("Failed to close"))
+                .when(service).close();
+
+        web3j.shutdown();
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0WebSocketClientJTest.java
@@ -10,7 +10,7 @@ import org.web3j.protocol.Web3jService;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class JsonRpc2_0Web3jTest {
+public class JsonRpc2_0WebSocketClientJTest {
 
     @Test
     public void testStopExecutorOnShutdown() {

--- a/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
@@ -1,5 +1,8 @@
 package org.web3j.protocol.core;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.junit.Test;
 
 import org.web3j.protocol.Web3j;
@@ -26,6 +29,45 @@ public class WebSocketEventTest {
 
         verify(webSocketClient).send(matches(
                 "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
-                        + "\"params\":\\[\"newHeads\",\\{}],\"id\":[0-9]{1,}}"));
+                        + "\"params\":\\[\"newHeads\"],\"id\":[0-9]{1,}}"));
+    }
+
+    @Test
+    public void testLogsNotificationsWithoutArguments() {
+        web3j.logsNotifications(new ArrayList<>(), new ArrayList<>());
+
+        verify(webSocketClient).send(matches(
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
+                        + "\"params\":\\[\"logs\",\\{}],\"id\":[0-9]{1,}}"));
+    }
+
+    @Test
+    public void testLogsNotificationsWithArguments() {
+        web3j.logsNotifications(
+                Collections.singletonList("0x1"),
+                Collections.singletonList("0x2"));
+
+        verify(webSocketClient).send(matches(
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
+                        + "\"params\":\\[\"logs\",\\{\"address\":\\[\"0x1\"],"
+                        + "\"topics\":\\[\"0x2\"]}],\"id\":[0-9]{1,}}"));
+    }
+
+    @Test
+    public void testPendingTransactionsNotifications() {
+        web3j.newPendingTransactionsNotifications();
+
+        verify(webSocketClient).send(matches(
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\",\"params\":"
+                        + "\\[\"newPendingTransactions\"],\"id\":[0-9]{1,}}"));
+    }
+
+    @Test
+    public void testSyncingStatusNotifications() {
+        web3j.syncingStatusNotifications();
+
+        verify(webSocketClient).send(matches(
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
+                        + "\"params\":\\[\"syncing\"],\"id\":[0-9]{1,}}"));
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
@@ -7,7 +7,6 @@ import org.web3j.protocol.websocket.WebSocketClient;
 import org.web3j.protocol.websocket.WebSocketService;
 
 import static org.mockito.Matchers.matches;
-import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
@@ -1,17 +1,28 @@
 package org.web3j.protocol.core;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Before;
 import org.junit.Test;
 
+import org.web3j.protocol.ObjectMapperFactory;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.websocket.WebSocketClient;
+import org.web3j.protocol.websocket.WebSocketListener;
 import org.web3j.protocol.websocket.WebSocketService;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class WebSocketEventTest {
 
@@ -22,6 +33,30 @@ public class WebSocketEventTest {
     );
 
     private Web3j web3j = Web3j.build(webSocketService);
+
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
+
+    private WebSocketListener listener;
+
+    @Before
+    public void before() throws Exception {
+        when(webSocketClient.connectBlocking()).thenReturn(true);
+
+        doAnswer(invocation -> {
+            listener = invocation.getArgumentAt(0, WebSocketListener.class);
+            return null;
+        }).when(webSocketClient).setListener(any());
+
+        doAnswer(invocation -> {
+            String message = invocation.getArgumentAt(0, String.class);
+            int requestId = getRequestId(message);
+
+            sendSubscriptionConfirmation(requestId);
+            return null;
+        }).when(webSocketClient).send(anyString());
+
+        webSocketService.connect();
+    }
 
     @Test
     public void testNewHeadsNotifications() {
@@ -69,5 +104,21 @@ public class WebSocketEventTest {
         verify(webSocketClient).send(matches(
                 "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
                         + "\"params\":\\[\"syncing\"],\"id\":[0-9]{1,}}"));
+    }
+
+    private int getRequestId(String message) throws IOException {
+        JsonNode messageJson = objectMapper.readTree(message);
+        return messageJson.get("id").asInt();
+    }
+
+    private void sendSubscriptionConfirmation(int requestId) throws IOException {
+        listener.onMessage(
+                String.format(
+                        "{"
+                                + "\"jsonrpc\":\"2.0\","
+                                + "\"id\":%d,"
+                                + "\"result\":\"0xcd0c3e8af590364c09d0fa6a1210faf5\""
+                                + "}",
+                        requestId));
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/WebSocketEventTest.java
@@ -1,0 +1,32 @@
+package org.web3j.protocol.core;
+
+import org.junit.Test;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.websocket.WebSocketClient;
+import org.web3j.protocol.websocket.WebSocketService;
+
+import static org.mockito.Matchers.matches;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class WebSocketEventTest {
+
+    private WebSocketClient webSocketClient = mock(WebSocketClient.class);
+
+    private WebSocketService webSocketService = new WebSocketService(
+            webSocketClient, true
+    );
+
+    private Web3j web3j = Web3j.build(webSocketService);
+
+    @Test
+    public void testNewHeadsNotifications() {
+        web3j.newHeadsNotifications();
+
+        verify(webSocketClient).send(matches(
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
+                        + "\"params\":\\[\"newHeads\",\\{}],\"id\":[0-9]{1,}}"));
+    }
+}

--- a/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
@@ -1,8 +1,14 @@
 package org.web3j.protocol.http;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 import org.junit.Test;
+
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthSubscribe;
+import org.web3j.protocol.websocket.events.NewHeadsNotification;
 
 import static org.junit.Assert.assertTrue;
 
@@ -34,6 +40,21 @@ public class HttpServiceTest {
         
         assertTrue(httpService.getHeaders().get(headerName1).equals(headerValue1));
         assertTrue(httpService.getHeaders().get(headerName2).equals(headerValue2));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void subscriptionNotSupported() {
+        Request<Object, EthSubscribe> subscribeRequest = new Request<>(
+                "eth_subscribe",
+                Arrays.asList("newHeads", Collections.emptyMap()),
+                httpService,
+                EthSubscribe.class);
+
+        httpService.subscribe(
+                subscribeRequest,
+                "eth_unsubscribe",
+                NewHeadsNotification.class
+        );
     }
     
 }

--- a/core/src/test/java/org/web3j/protocol/ipc/IpcServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/ipc/IpcServiceTest.java
@@ -38,4 +38,11 @@ public class IpcServiceTest {
 
         verify(ioFacade).write("{\"jsonrpc\":\"2.0\",\"method\":null,\"params\":null,\"id\":0}");
     }
+
+    @Test
+    public void testClose() throws IOException {
+        ipcService.close();
+
+        verify(ioFacade).close();
+    }
 }

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketClientTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketClientTest.java
@@ -1,0 +1,45 @@
+package org.web3j.protocol.websocket;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class WebSocketClientTest {
+
+    private WebSocketListener listener = mock(WebSocketListener.class);
+
+    private WebSocketClient client;
+
+    @Before
+    public void before() throws Exception {
+        client = new WebSocketClient(new URI("ws://localhost/"));
+        client.setListener(listener);
+    }
+
+    @Test
+    public void testNotifyListenerOnMessage() throws Exception {
+        client.onMessage("message");
+
+        verify(listener).onMessage("message");
+    }
+
+    @Test
+    public void testNotifyListenerOnError() throws Exception {
+        IOException e = new IOException("123");
+        client.onError(e);
+
+        verify(listener).onError(e);
+    }
+
+    @Test
+    public void testNotifyListenerOnClose() throws Exception {
+        client.onClose(1, "reason", true);
+
+        verify(listener).onClose();
+    }
+}

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -2,7 +2,6 @@ package org.web3j.protocol.websocket;
 
 import java.io.IOException;
 import java.net.ConnectException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -23,7 +22,6 @@ import rx.Observer;
 import rx.Subscriber;
 import rx.Subscription;
 
-import org.web3j.protocol.core.JsonRpc2_0Web3j;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.EthSubscribe;
@@ -41,10 +39,11 @@ import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class WebSocketServiceTest {
+
+    private static final int REQUEST_ID = 1;
 
     private WebSocketClient webSocketClient = mock(WebSocketClient.class);
     private ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
@@ -213,9 +212,9 @@ public class WebSocketServiceTest {
             return null;
         }).when(webSocketClient).send(anyString());
 
-        Executors.newSingleThreadExecutor().execute(() -> {
+        runAsync(() -> {
             try {
-                requestSent.await();
+                requestSent.await(2, TimeUnit.SECONDS);
                 sendGethVersionReply();
             } catch (Exception e) {
                 e.printStackTrace();
@@ -248,32 +247,37 @@ public class WebSocketServiceTest {
         CountDownLatch completedCalled = new CountDownLatch(1);
         AtomicReference<NewHeadsNotification> actualNotificationRef = new AtomicReference<>();
 
-        final Subscription subscription = subscribeToEvents()
-                .subscribe(new Subscriber<NewHeadsNotification>() {
-                    @Override
-                    public void onCompleted() {
-                        completedCalled.countDown();
-                    }
+        runAsync(() -> {
+            final Subscription subscription = subscribeToEvents()
+                    .subscribe(new Subscriber<NewHeadsNotification>() {
+                        @Override
+                        public void onCompleted() {
+                            completedCalled.countDown();
+                        }
 
-                    @Override
-                    public void onError(Throwable e) {
+                        @Override
+                        public void onError(Throwable e) {
 
-                    }
+                        }
 
-                    @Override
-                    public void onNext(NewHeadsNotification newHeadsNotification) {
-                        actualNotificationRef.set(newHeadsNotification);
-                        eventReceived.countDown();
-                    }
-                });
+                        @Override
+                        public void onNext(NewHeadsNotification newHeadsNotification) {
+                            actualNotificationRef.set(newHeadsNotification);
+                            eventReceived.countDown();
+                        }
+                    });
+            try {
+                eventReceived.await(2, TimeUnit.SECONDS);
+                subscription.unsubscribe();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
 
         sendSubscriptionConfirmation();
         sendWebSocketEvent();
 
-        assertTrue(eventReceived.await(2, TimeUnit.SECONDS));
-        subscription.unsubscribe();
-
-        assertTrue(completedCalled.await(2, TimeUnit.SECONDS));
+        assertTrue(completedCalled.await(6, TimeUnit.SECONDS));
         assertEquals(
                 "0xd9263f42a87",
                 actualNotificationRef.get().getParams().getResult().getDifficulty());
@@ -281,57 +285,58 @@ public class WebSocketServiceTest {
 
     @Test
     public void testSendUnsubscribeRequest() throws Exception {
-        Observable<NewHeadsNotification> obserable = subscribeToEvents();
+        CountDownLatch unsubscribed = new CountDownLatch(1);
+
+        runAsync(() -> {
+            Observable<NewHeadsNotification> observable = subscribeToEvents();
+            observable.subscribe().unsubscribe();
+            unsubscribed.countDown();
+
+        });
         sendSubscriptionConfirmation();
         sendWebSocketEvent();
 
-        obserable.subscribe().unsubscribe();
-
+        assertTrue(unsubscribed.await(2, TimeUnit.SECONDS));
         verifyUnsubscribed();
     }
 
     @Test
-    public void testDoSendUnsubscribeRequestIfUnsubscribedBeforeConfirmation() throws Exception {
-        Observable<NewHeadsNotification> obserable = subscribeToEvents();
-        obserable.subscribe().unsubscribe();
-
-        verifyStartedSubscriptionHadnshake();
-        verifyNoMoreInteractions(webSocketClient);
-    }
-
-    @Test
     public void testStopWaitingForSubscriptionReplyAfterTimeout() throws Exception {
-        Observable<NewHeadsNotification> obserable = subscribeToEvents();
         CountDownLatch errorReceived = new CountDownLatch(1);
         AtomicReference<Throwable> actualThrowable = new AtomicReference<>();
 
-        obserable.subscribe(new Observer<NewHeadsNotification>() {
-            @Override
-            public void onCompleted() {
-            }
+        runAsync(() -> {
+            subscribeToEvents().subscribe(new Observer<NewHeadsNotification>() {
+                @Override
+                public void onCompleted() {
+                }
 
-            @Override
-            public void onError(Throwable e) {
-                actualThrowable.set(e);
-                errorReceived.countDown();
-            }
+                @Override
+                public void onError(Throwable e) {
+                    actualThrowable.set(e);
+                    errorReceived.countDown();
+                }
 
-            @Override
-            public void onNext(NewHeadsNotification newHeadsNotification) {
+                @Override
+                public void onNext(NewHeadsNotification newHeadsNotification) {
 
-            }
+                }
+            });
         });
 
+        waitForRequestSent();
         Exception e = new IOException("timeout");
         service.closeRequest(1, e);
 
         assertTrue(errorReceived.await(2, TimeUnit.SECONDS));
-        assertEquals(
-                actualThrowable.get(),
-                e);
+        assertEquals(e, actualThrowable.get());
     }
 
-    private Observable<NewHeadsNotification> subscribeToEvents() throws IOException {
+    private void runAsync(Runnable runnable) {
+        Executors.newSingleThreadExecutor().execute(runnable);
+    }
+
+    private Observable<NewHeadsNotification> subscribeToEvents() {
         subscribeRequest = new Request<>(
                 "eth_subscribe",
                 Arrays.asList("newHeads", Collections.emptyMap()),
@@ -380,13 +385,21 @@ public class WebSocketServiceTest {
                         + "\"params\":[\"0xcd0c3e8af590364c09d0fa6a1210faf5\"]"));
     }
 
-    private void sendSubscriptionConfirmation() throws IOException {
+    private void sendSubscriptionConfirmation() throws Exception {
+        waitForRequestSent();
+
         service.onMessage(
                 "{"
                         + "\"jsonrpc\":\"2.0\","
                         + "\"id\":1,"
                         + "\"result\":\"0xcd0c3e8af590364c09d0fa6a1210faf5\""
                         + "}");
+    }
+
+    private void waitForRequestSent() throws InterruptedException {
+        while (!service.isWaitingForReply(REQUEST_ID)) {
+            Thread.sleep(50);
+        }
     }
 
     private void sendWebSocketEvent() throws IOException {

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -341,6 +341,7 @@ public class WebSocketServiceTest {
 
         return service.subscribe(
                 subscribeRequest,
+                "eth_unsubscribe",
                 NewHeadsNotification.class
         );
     }

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -274,7 +274,12 @@ public class WebSocketServiceTest {
             }
         });
 
+
         sendSubscriptionConfirmation();
+        // A subscriber can miss an event if it comes at the same time as
+        // a subscription confirmation. Waiting for a bit to ensure
+        // delivery
+        Thread.sleep(100);
         sendWebSocketEvent();
 
         assertTrue(completedCalled.await(6, TimeUnit.SECONDS));

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -2,6 +2,7 @@ package org.web3j.protocol.websocket;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -130,7 +130,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Failed to parse incoming WebSocket message");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onMessage("{");
+        service.onWebSocketMessage("{");
     }
 
     @Test
@@ -138,7 +138,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("'id' expected to be long, but it is: 'true'");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onMessage("{\"id\":true}");
+        service.onWebSocketMessage("{\"id\":true}");
     }
 
     @Test
@@ -146,7 +146,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Unknown message type");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onMessage("{}");
+        service.onWebSocketMessage("{}");
     }
 
     @Test
@@ -154,7 +154,8 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Received reply for unexpected request id: 12345");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onMessage("{\"jsonrpc\":\"2.0\",\"id\":12345,\"result\":\"geth-version\"}");
+        service.onWebSocketMessage(
+                "{\"jsonrpc\":\"2.0\",\"id\":12345,\"result\":\"geth-version\"}");
     }
 
     @Test
@@ -396,7 +397,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendErrorReply() throws IOException {
-        service.onMessage(
+        service.onWebSocketMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"id\":1,"
@@ -409,7 +410,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendGethVersionReply() throws IOException {
-        service.onMessage(
+        service.onWebSocketMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"id\":1,"
@@ -432,7 +433,7 @@ public class WebSocketServiceTest {
     private void sendSubscriptionConfirmation() throws Exception {
         waitForRequestSent();
 
-        service.onMessage(
+        service.onWebSocketMessage(
                 "{"
                         + "\"jsonrpc\":\"2.0\","
                         + "\"id\":1,"
@@ -447,7 +448,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendWebSocketEvent() throws IOException {
-        service.onMessage(
+        service.onWebSocketMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"method\":\"eth_subscription\","

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -232,7 +232,7 @@ public class WebSocketServiceTest {
                 requestSent.await(2, TimeUnit.SECONDS);
                 sendGethVersionReply();
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         });
 

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -1,0 +1,208 @@
+package org.web3j.protocol.websocket;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.web3j.protocol.core.JsonRpc2_0Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.Web3ClientVersion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebSocketServiceTest {
+
+    private WebSocketClient webSocketClient = mock(WebSocketClient.class);
+    private ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
+
+    private WebSocketService service = new WebSocketService(webSocketClient, executorService, true);
+
+    private Request<?, Web3ClientVersion> request = new Request<>(
+            "web3_clientVersion",
+            Collections.<String>emptyList(),
+            service,
+            Web3ClientVersion.class);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void before() throws InterruptedException {
+        when(webSocketClient.connectBlocking()).thenReturn(true);
+        request.setId(1);
+    }
+
+    @Test
+    public void testThrowExceptionIfServerUrlIsInvalid() {
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Failed to parse URL: 'invalid\\url'");
+        new WebSocketService("invalid\\url", true);
+    }
+
+    @Test
+    public void testConnectViaWebSocketClient() throws Exception {
+        service.connect();
+
+        verify(webSocketClient).connectBlocking();
+    }
+
+    @Test
+    public void testInterruptCurrentThreadIfConnectionIsInterrupted() throws Exception {
+        when(webSocketClient.connectBlocking()).thenThrow(new InterruptedException());
+        service.connect();
+
+        assertTrue("Interrupted flag was not set properly",
+                Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    public void testThrowExceptionIfConnectionFailed() throws Exception {
+        thrown.expect(ConnectException.class);
+        thrown.expectMessage("Failed to connect to WebSocket");
+        when(webSocketClient.connectBlocking()).thenReturn(false);
+        service.connect();
+    }
+
+    @Test
+    public void testNotWaitingForReplyWithUnknownId() {
+        assertFalse(service.isWaitingForReply(123));
+    }
+
+    @Test
+    public void testWaitingForReplyToSentRequest() throws Exception {
+        service.sendAsync(request, Web3ClientVersion.class);
+
+        assertTrue(service.isWaitingForReply(request.getId()));
+    }
+
+    @Test
+    public void testNoLongerWaitingForResponseAfterReply() throws Exception {
+        service.sendAsync(request, Web3ClientVersion.class);
+        service.onReply("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"geth-version\"}");
+
+        assertFalse(service.isWaitingForReply(1));
+    }
+
+    @Test
+    public void testSendWebSocketRequest() throws Exception {
+        service.sendAsync(request, Web3ClientVersion.class);
+
+        verify(webSocketClient).send(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[],\"id\":1}");
+    }
+
+    @Test
+    public void testIgnoreInvalidReplies() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("Failed to parse incoming WebSocket message");
+        service.sendAsync(request, Web3ClientVersion.class);
+        service.onReply("{");
+    }
+
+    @Test
+    public void testThrowExceptionIfIdHasInvalidType() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("'id' expected to be long, but it is: 'true'");
+        service.sendAsync(request, Web3ClientVersion.class);
+        service.onReply("{\"id\":true}");
+    }
+
+    @Test
+    public void testThrowExceptionIfIdIsMissing() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("'id' field is missing in the reply");
+        service.sendAsync(request, Web3ClientVersion.class);
+        service.onReply("{}");
+    }
+
+    @Test
+    public void testThrowExceptionIfUnexpectedIdIsReceived() throws Exception {
+        thrown.expect(IOException.class);
+        thrown.expectMessage("Received reply for unexpected request id: 12345");
+        service.sendAsync(request, Web3ClientVersion.class);
+        service.onReply("{\"jsonrpc\":\"2.0\",\"id\":12345,\"result\":\"geth-version\"}");
+    }
+
+    @Test
+    public void testReceiveReply() throws Exception {
+        CompletableFuture<Web3ClientVersion> reply = service.sendAsync(
+                request,
+                Web3ClientVersion.class);
+        service.onReply("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"geth-version\"}");
+
+        assertTrue(reply.isDone());
+        assertEquals("geth-version", reply.get().getWeb3ClientVersion());
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testCancelRequestAfterTimeout() throws Exception {
+        when(executorService.schedule(
+                any(Runnable.class),
+                eq(WebSocketService.REQUEST_TIMEOUT),
+                eq(TimeUnit.SECONDS)))
+                .then(invocation -> {
+                    Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+                    runnable.run();
+                    return null;
+                });
+
+        CompletableFuture<Web3ClientVersion> reply = service.sendAsync(
+                request,
+                Web3ClientVersion.class);
+
+        assertTrue(reply.isDone());
+        reply.get();
+    }
+
+    @Test
+    public void testSyncRequest() throws Exception {
+        CountDownLatch requestSent = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            requestSent.countDown();
+            return null;
+        }).when(webSocketClient).send(anyString());
+
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                requestSent.await();
+                service.onReply("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"geth-version\"}");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        Web3ClientVersion reply = service.send(request, Web3ClientVersion.class);
+
+        assertEquals(reply.getWeb3ClientVersion(), "geth-version");
+    }
+
+    @Test
+    public void testCloseWebSocketOnClose() throws Exception {
+        service.close();
+
+        verify(webSocketClient).close();
+        verify(executorService).shutdown();
+    }
+
+}

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -130,7 +130,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Failed to parse incoming WebSocket message");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onReply("{");
+        service.onMessage("{");
     }
 
     @Test
@@ -138,7 +138,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("'id' expected to be long, but it is: 'true'");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onReply("{\"id\":true}");
+        service.onMessage("{\"id\":true}");
     }
 
     @Test
@@ -146,7 +146,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Unknown message type");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onReply("{}");
+        service.onMessage("{}");
     }
 
     @Test
@@ -154,7 +154,7 @@ public class WebSocketServiceTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("Received reply for unexpected request id: 12345");
         service.sendAsync(request, Web3ClientVersion.class);
-        service.onReply("{\"jsonrpc\":\"2.0\",\"id\":12345,\"result\":\"geth-version\"}");
+        service.onMessage("{\"jsonrpc\":\"2.0\",\"id\":12345,\"result\":\"geth-version\"}");
     }
 
     @Test
@@ -290,13 +290,6 @@ public class WebSocketServiceTest {
     }
 
     @Test
-    public void testUnsubscribeIfReceivedUnexpectedSubscriptionId() throws Exception {
-        sendWebSocketEvent();
-
-        verifyUnsubscribed();
-    }
-
-    @Test
     public void testDoSendUnsubscribeRequestIfUnsubscribedBeforeConfirmation() throws Exception {
         Observable<NewHeadsNotification> obserable = subscribeToEvents();
         obserable.subscribe().unsubscribe();
@@ -337,7 +330,7 @@ public class WebSocketServiceTest {
                 e);
     }
 
-    private Observable<NewHeadsNotification> subscribeToEvents() {
+    private Observable<NewHeadsNotification> subscribeToEvents() throws IOException {
         subscribeRequest = new Request<>(
                 "eth_subscribe",
                 Arrays.asList("newHeads", Collections.emptyMap()),
@@ -352,7 +345,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendErrorReply() throws IOException {
-        service.onReply(
+        service.onMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"id\":1,"
@@ -365,7 +358,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendGethVersionReply() throws IOException {
-        service.onReply(
+        service.onMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"id\":1,"
@@ -386,7 +379,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendSubscriptionConfirmation() throws IOException {
-        service.onReply(
+        service.onMessage(
                 "{"
                         + "\"jsonrpc\":\"2.0\","
                         + "\"id\":1,"
@@ -395,7 +388,7 @@ public class WebSocketServiceTest {
     }
 
     private void sendWebSocketEvent() throws IOException {
-        service.onReply(
+        service.onMessage(
                 "{"
                         + "  \"jsonrpc\":\"2.0\","
                         + "  \"method\":\"eth_subscription\","

--- a/geth/src/main/java/org/web3j/protocol/geth/Geth.java
+++ b/geth/src/main/java/org/web3j/protocol/geth/Geth.java
@@ -1,5 +1,7 @@
 package org.web3j.protocol.geth;
 
+import rx.Observable;
+
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.Admin;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
@@ -8,6 +10,8 @@ import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.geth.response.PersonalEcRecover;
 import org.web3j.protocol.geth.response.PersonalImportRawKey;
+import org.web3j.protocol.websocket.events.PendingTransactionNotification;
+import org.web3j.protocol.websocket.events.SyncingNotfication;
 
 /**
  * JSON-RPC Request object building factory for Geth. 
@@ -18,7 +22,7 @@ public interface Geth extends Admin {
     }
         
     Request<?, PersonalImportRawKey> personalImportRawKey(String keydata, String password);
-    
+
     Request<?, BooleanResponse> personalLockAccount(String accountId);
     
     Request<?, PersonalSign> personalSign(String message, String accountId, String password);
@@ -28,5 +32,20 @@ public interface Geth extends Admin {
     Request<?, MinerStartResponse> minerStart(int threadCount);
 
     Request<?, BooleanResponse> minerStop();
+
+    /**
+     * Creates an observable that emits a notification when a new transaction is added
+     * to the pending state and is signed with a key that is available in the node.
+     *
+     * @return Observable that emits a notification when a new transaction is added
+     *         to the pending state
+     */
+    Observable<PendingTransactionNotification> newPendingTransactionsNotifications();
+
+    /**
+     * Creates an observable that emits a notification when a node starts or stops syncing.
+     * @return Observalbe that emits changes to syncing status
+     */
+    Observable<SyncingNotfication> syncingStatusNotifications();
 
 }

--- a/geth/src/main/java/org/web3j/protocol/geth/JsonRpc2_0Geth.java
+++ b/geth/src/main/java/org/web3j/protocol/geth/JsonRpc2_0Geth.java
@@ -3,14 +3,19 @@ package org.web3j.protocol.geth;
 import java.util.Arrays;
 import java.util.Collections;
 
+import rx.Observable;
+
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.JsonRpc2_0Admin;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.admin.methods.response.PersonalSign;
 import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthSubscribe;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.geth.response.PersonalEcRecover;
 import org.web3j.protocol.geth.response.PersonalImportRawKey;
+import org.web3j.protocol.websocket.events.PendingTransactionNotification;
+import org.web3j.protocol.websocket.events.SyncingNotfication;
 
 /**
  * JSON-RPC 2.0 factory implementation for Geth.
@@ -78,4 +83,28 @@ public class JsonRpc2_0Geth extends JsonRpc2_0Admin implements Geth {
                 BooleanResponse.class);
     }
 
+    public Observable<PendingTransactionNotification> newPendingTransactionsNotifications() {
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("newPendingTransactions"),
+                        web3jService,
+                        EthSubscribe.class),
+                "eth_unsubscribe",
+                PendingTransactionNotification.class
+        );
+    }
+
+    @Override
+    public Observable<SyncingNotfication> syncingStatusNotifications() {
+        return web3jService.subscribe(
+                new Request<>(
+                        "eth_subscribe",
+                        Arrays.asList("syncing"),
+                        web3jService,
+                        EthSubscribe.class),
+                "eth_unsubscribe",
+                SyncingNotfication.class
+        );
+    }
 }

--- a/geth/src/test/java/org/web3j/protocol/geth/JsonRpc2_0GethTest.java
+++ b/geth/src/test/java/org/web3j/protocol/geth/JsonRpc2_0GethTest.java
@@ -1,8 +1,6 @@
-package org.web3j.protocol.core;
+package org.web3j.protocol.geth;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.web3j.protocol.ObjectMapperFactory;
-import org.web3j.protocol.Web3j;
 import org.web3j.protocol.websocket.WebSocketClient;
 import org.web3j.protocol.websocket.WebSocketListener;
 import org.web3j.protocol.websocket.WebSocketService;
@@ -24,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class WebSocketEventTest {
+public class JsonRpc2_0GethTest {
 
     private WebSocketClient webSocketClient = mock(WebSocketClient.class);
 
@@ -32,7 +29,7 @@ public class WebSocketEventTest {
             webSocketClient, true
     );
 
-    private Web3j web3j = Web3j.build(webSocketService);
+    private Geth geth = Geth.build(webSocketService);
 
     private final ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
 
@@ -58,34 +55,23 @@ public class WebSocketEventTest {
         webSocketService.connect();
     }
 
+
     @Test
-    public void testNewHeadsNotifications() {
-        web3j.newHeadsNotifications();
+    public void testPendingTransactionsNotifications() {
+        geth.newPendingTransactionsNotifications();
 
         verify(webSocketClient).send(matches(
-                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
-                        + "\"params\":\\[\"newHeads\"],\"id\":[0-9]{1,}}"));
+                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\",\"params\":"
+                        + "\\[\"newPendingTransactions\"],\"id\":[0-9]{1,}}"));
     }
 
     @Test
-    public void testLogsNotificationsWithoutArguments() {
-        web3j.logsNotifications(new ArrayList<>(), new ArrayList<>());
+    public void testSyncingStatusNotifications() {
+        geth.syncingStatusNotifications();
 
         verify(webSocketClient).send(matches(
                 "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
-                        + "\"params\":\\[\"logs\",\\{}],\"id\":[0-9]{1,}}"));
-    }
-
-    @Test
-    public void testLogsNotificationsWithArguments() {
-        web3j.logsNotifications(
-                Collections.singletonList("0x1"),
-                Collections.singletonList("0x2"));
-
-        verify(webSocketClient).send(matches(
-                "\\{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscribe\","
-                        + "\"params\":\\[\"logs\",\\{\"address\":\\[\"0x1\"],"
-                        + "\"topics\":\\[\"0x2\"]}],\"id\":[0-9]{1,}}"));
+                        + "\"params\":\\[\"syncing\"],\"id\":[0-9]{1,}}"));
     }
 
     private int getRequestId(String message) throws IOException {


### PR DESCRIPTION
Implements `WebSocketService` that allows calling JSON-RPC methods via WebSocket protocol and allows to subscribe to real-time notifications.
Also adds new methods to the `Web3jRx` that allows subscribing to JSON-RPC notifications.

The PR is already too big for a review, so I had to stop, but there are few things that are still missing: 

* Support for Parity pub-sub method. Parity allows subscribing to more notifications than Geth and PR allows using Parity's pub-sub mechanism
* Integration tests for WebSockets
* User documentation (I write it once this PR is approved, since we can change the design during the review)