### PR TITLE
allow external BC lifecycle management

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -32,7 +32,9 @@ public class Keys {
     public static final int PRIVATE_KEY_LENGTH_IN_HEX = PRIVATE_KEY_SIZE << 1;
 
     static {
-        Security.addProvider(new BouncyCastleProvider());
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
     }
 
     private Keys() { }


### PR DESCRIPTION
When redeploying a Java EE application multiple times, you get a class cast exception on BouncyCastle because of the static registration of the BC security provider.
This patch allows you to manage the BC security provider lifecycle outside of the "static world" of web3j.