### PR TITLE
Remove deprecated IPC interface

### DIFF
--- a/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
+++ b/core/src/main/java/org/web3j/protocol/ipc/IpcService.java
@@ -16,25 +16,12 @@ public class IpcService extends Service {
 
     private static final Logger log = LoggerFactory.getLogger(IpcService.class);
 
-    private final IOFacade ioFacade;
-
-    @Deprecated
-    public IpcService(IOFacade ioFacade, boolean includeRawResponses) {
-        super(includeRawResponses);
-        this.ioFacade = ioFacade;
-    }
-
-    @Deprecated
-    public IpcService(IOFacade ioFacade) {
-        this(ioFacade, false);
-    }
-
     public IpcService(boolean includeRawResponses) {
-        this(null, includeRawResponses);
+        super(includeRawResponses);
     }
 
     public IpcService() {
-        this(null, false);
+        this(false);
     }
 
     protected IOFacade getIO() {
@@ -43,15 +30,13 @@ public class IpcService extends Service {
 
     @Override
     protected InputStream performIO(String payload) throws IOException {
-        IOFacade io = getIoFacade();
+        IOFacade io = getIO();
         io.write(payload);
         log.debug(">> " + payload);
 
         String result = io.read();
         log.debug("<< " + result);
-        if (io != ioFacade) {
-            io.close();
-        }
+        io.close();
 
         // It's not ideal converting back into an inputStream, but we want
         // to be consistent with the HTTPService API.
@@ -59,22 +44,7 @@ public class IpcService extends Service {
         return new ByteArrayInputStream(result.getBytes("UTF-8"));
     }
 
-    private IOFacade getIoFacade() {
-        IOFacade io;
-        if (ioFacade != null) {
-            io = ioFacade;
-        } else {
-            io = getIO();
-        }
-        return io;
-    }
-
     @Override
     public void close() throws IOException {
-        IOFacade io = getIoFacade();
-
-        if (io != null) {
-            io.close();
-        }
     }
 }

--- a/core/src/test/java/org/web3j/protocol/ipc/IpcServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/ipc/IpcServiceTest.java
@@ -38,11 +38,4 @@ public class IpcServiceTest {
 
         verify(ioFacade).write("{\"jsonrpc\":\"2.0\",\"method\":null,\"params\":null,\"id\":0}");
     }
-
-    @Test
-    public void testClose() throws IOException {
-        ipcService.close();
-
-        verify(ioFacade).close();
-    }
 }


### PR DESCRIPTION
Cleanup after #494 merged.
Because it breaks interface, please feel free to merge it in appropriate milestone.
