### PR TITLE
fix status check on contract transactions

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -43,7 +43,6 @@ public abstract class Contract extends ManagedTransaction {
 
     // https://www.reddit.com/r/ethereum/comments/5g8ia6/attention_miners_we_recommend_raising_gas_limit/
     public static final BigInteger GAS_LIMIT = BigInteger.valueOf(4_300_000);
-    public static final String SUCCESSFUL_TRANSACTION_STATUS = "0x1";
 
     protected final String contractBinary;
     protected String contractAddress;
@@ -254,8 +253,7 @@ public abstract class Contract extends ManagedTransaction {
 
         TransactionReceipt receipt = send(contractAddress, data, weiValue, gasPrice, gasLimit);
 
-        if (receipt.getStatus() != null
-                && !SUCCESSFUL_TRANSACTION_STATUS.equals(receipt.getStatus())) {
+        if (!receipt.isStatusOK()) {
             throw new TransactionException(
                     String.format(
                             "Transaction has failed with status: %s. "


### PR DESCRIPTION
Similar to https://github.com/web3j/web3j/pull/483 but uses `TransactionReceipt.isStatusOK` instead.