### PR TITLE
fix List<Boolean> type transfer bug

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/Bool.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/Bool.java
@@ -14,6 +14,10 @@ public class Bool implements Type<Boolean> {
         this.value = value;
     }
 
+    public Bool(Boolean value) {
+        this.value = value;
+    }
+    
     @Override
     public String getTypeAsString() {
         return TYPE_NAME;


### PR DESCRIPTION
In abi generated code,  below code will raise a error : "org.web3j.abi.TypeMappingException: java.lang.NoSuchMethodException: org.web3j.abi.datatypes.Bool.<init>(java.lang.Boolean)"

new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Bool>(
                        org.web3j.abi.Utils.typeMap(boolListParams, org.web3j.abi.datatypes.Bool.class)),

because of the Bool.class has contructor method with param boolean  but not Boolean