### PR TITLE
Add support for large Vs

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -27,7 +27,7 @@ public class Transaction {
     private String raw;
     private String r;
     private String s;
-    private int v;  // see https://github.com/web3j/web3j/issues/44
+    private long v;  // see https://github.com/web3j/web3j/issues/44
 
     public Transaction() {
     }
@@ -35,7 +35,7 @@ public class Transaction {
     public Transaction(String hash, String nonce, String blockHash, String blockNumber,
                        String transactionIndex, String from, String to, String value,
                        String gas, String gasPrice, String input, String creates,
-                       String publicKey, String raw, String r, String s, int v) {
+                       String publicKey, String raw, String r, String s, long v) {
         this.hash = hash;
         this.nonce = nonce;
         this.blockHash = blockHash;
@@ -207,15 +207,15 @@ public class Transaction {
         this.s = s;
     }
 
-    public int getV() {
+    public long getV() {
         return v;
     }
 
-    public Integer getChainId() {
+    public Long getChainId() {
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
             return null;
         }
-        Integer chainId = (v - CHAIN_ID_INC) / 2;
+        Long chainId = (v - CHAIN_ID_INC) / 2;
         return chainId;
     }
 
@@ -228,9 +228,11 @@ public class Transaction {
     // https://github.com/ethereum/go-ethereum/issues/3339
     public void setV(Object v) {
         if (v instanceof String) {
-            this.v = Numeric.toBigInt((String) v).intValueExact();
+            this.v = Numeric.toBigInt((String) v).longValueExact();
+        } else if (v instanceof Integer) {
+            this.v = ((Integer) v).longValue();
         } else {
-            this.v = ((Integer) v);
+            this.v = (Long) v;
         }
     }
 
@@ -326,7 +328,7 @@ public class Transaction {
         result = 31 * result + (getRaw() != null ? getRaw().hashCode() : 0);
         result = 31 * result + (getR() != null ? getR().hashCode() : 0);
         result = 31 * result + (getS() != null ? getS().hashCode() : 0);
-        result = 31 * result + getV();
+        result = 31 * result + BigInteger.valueOf(getV()).hashCode();
         return result;
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -903,7 +903,7 @@ public class ResponseTest extends ResponseTester {
     public void testTransactionChainId() {
         Transaction transaction = new Transaction();
         transaction.setV(0x25);
-        assertThat(transaction.getChainId(), equalTo(1));
+        assertThat(transaction.getChainId(), equalTo(1L));
     }
 
     @Test

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import org.junit.Test;
 
 import org.web3j.protocol.ResponseTester;
-import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 import org.web3j.protocol.core.methods.response.DbGetHex;
 import org.web3j.protocol.core.methods.response.DbGetString;
@@ -905,6 +904,14 @@ public class ResponseTest extends ResponseTester {
         transaction.setV(0x25);
         assertThat(transaction.getChainId(), equalTo(1L));
     }
+
+    @Test
+    public void testTransactionLongChainId() {
+        Transaction transaction = new Transaction();
+        transaction.setV(0x4A817C823L);
+        assertThat(transaction.getChainId(), equalTo(10000000000L));
+    }
+
 
     @Test
     public void testEthTransactionNull() {


### PR DESCRIPTION
Closes #450, #451, #473
Some coins (i.e. forks) require more than an int (e.g. PIRL) for the V in transactions - add support for those.
Two of the issues above have already been closed, but they have not been resolved as of now.