### PR TITLE
Remove unused walletFile.setCrypto(crypto)

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Wallet.java
+++ b/crypto/src/main/java/org/web3j/crypto/Wallet.java
@@ -104,7 +104,6 @@ public class Wallet {
         WalletFile.Crypto crypto = new WalletFile.Crypto();
         crypto.setCipher(CIPHER);
         crypto.setCiphertext(Numeric.toHexStringNoPrefix(cipherText));
-        walletFile.setCrypto(crypto);
 
         WalletFile.CipherParams cipherParams = new WalletFile.CipherParams();
         cipherParams.setIv(Numeric.toHexStringNoPrefix(iv));


### PR DESCRIPTION
On line 122, `walletFile.setCrypto(crypto)` is called again, which will override the first call. I suggest to remove the first call.