### PR TITLE
Do not generate methods for constant functions that return void

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -249,9 +249,7 @@ public class SolidityFunctionWrapper extends Generator {
         for (AbiDefinition functionDefinition : functionDefinitions) {
             if (functionDefinition.getType().equals("function")) {
                 MethodSpec ms = buildFunction(functionDefinition);
-                if (ms != null) {
-                    methodSpecs.add(ms);
-                }
+                methodSpecs.add(ms);
 
             } else if (functionDefinition.getType().equals("event")) {
                 methodSpecs.addAll(buildEventFunctions(functionDefinition, classBuilder));
@@ -597,10 +595,6 @@ public class SolidityFunctionWrapper extends Generator {
 
         List<TypeName> outputParameterTypes = buildTypeNames(functionDefinition.getOutputs());
         if (functionDefinition.isConstant()) {
-            if (outputParameterTypes.isEmpty()) {
-                // ignore constant functions that are not meant to be transacted
-                return null;
-            }
             buildConstantFunction(
                     functionDefinition, methodBuilder, outputParameterTypes, inputParams);
         } else {
@@ -620,7 +614,8 @@ public class SolidityFunctionWrapper extends Generator {
         String functionName = functionDefinition.getName();
 
         if (outputParameterTypes.isEmpty()) {
-            // should not happen
+            methodBuilder.addStatement("throw new RuntimeException"
+                    + "(\"cannot call constant function with void return type\")");
         } else if (outputParameterTypes.size() == 1) {
 
             TypeName typeName = outputParameterTypes.get(0);

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -249,7 +249,9 @@ public class SolidityFunctionWrapper extends Generator {
         for (AbiDefinition functionDefinition : functionDefinitions) {
             if (functionDefinition.getType().equals("function")) {
                 MethodSpec ms = buildFunction(functionDefinition);
-                if (ms != null) methodSpecs.add(ms);
+                if (ms != null) {
+                    methodSpecs.add(ms);
+                }
 
             } else if (functionDefinition.getType().equals("event")) {
                 methodSpecs.addAll(buildEventFunctions(functionDefinition, classBuilder));

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -248,7 +248,8 @@ public class SolidityFunctionWrapper extends Generator {
 
         for (AbiDefinition functionDefinition : functionDefinitions) {
             if (functionDefinition.getType().equals("function")) {
-                methodSpecs.add(buildFunction(functionDefinition));
+                MethodSpec ms = buildFunction(functionDefinition);
+                if (ms != null) methodSpecs.add(ms);
 
             } else if (functionDefinition.getType().equals("event")) {
                 methodSpecs.addAll(buildEventFunctions(functionDefinition, classBuilder));
@@ -594,6 +595,10 @@ public class SolidityFunctionWrapper extends Generator {
 
         List<TypeName> outputParameterTypes = buildTypeNames(functionDefinition.getOutputs());
         if (functionDefinition.isConstant()) {
+            if (outputParameterTypes.isEmpty()) {
+                // ignore constant functions that are not meant to be transacted
+                return null;
+            }
             buildConstantFunction(
                     functionDefinition, methodBuilder, outputParameterTypes, inputParams);
         } else {
@@ -613,7 +618,7 @@ public class SolidityFunctionWrapper extends Generator {
         String functionName = functionDefinition.getName();
 
         if (outputParameterTypes.isEmpty()) {
-            throw new RuntimeException("Only transactional methods should have void return types");
+            // should not happen
         } else if (outputParameterTypes.size() == 1) {
 
             TypeName typeName = outputParameterTypes.get(0);

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -296,7 +296,15 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 false);
 
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
-        assertNull(methodSpec);
+
+        //CHECKSTYLE:OFF
+        String expected =
+                "public void functionName(java.math.BigInteger param) {\n"
+                + "  throw new RuntimeException(\"cannot call constant function with void return type\");\n"
+                + "}\n";
+        //CHECKSTYLE:ON
+
+        assertThat(methodSpec.toString(), is(expected));
     }
 
     @Test

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -31,6 +31,7 @@ import org.web3j.protocol.core.methods.response.AbiDefinition;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -283,7 +284,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         assertThat(methodSpec.toString(), is(expected));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testBuildFunctionConstantInvalid() throws Exception {
         AbiDefinition functionDefinition = new AbiDefinition(
                 true,
@@ -294,7 +295,8 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                 "type",
                 false);
 
-        solidityFunctionWrapper.buildFunction(functionDefinition);
+        MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
+        assertNull(methodSpec);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/web3j/web3j/issues/324 -- this is needed to use OpenZeppelin's RBAC.