### PR TITLE
[WIP] Prefix message signing according to eth_sign. (#575)

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -52,12 +52,12 @@ public class Sign {
         return Hash.sha3(result);
     }
 
-    public static SignatureData signMessage(byte[] message, ECKeyPair keyPair) {
-        return signMessage(message, keyPair, true);
-    }
-
     public static SignatureData signPrefixedMessage(byte[] message, ECKeyPair keyPair) {
         return signMessage(getMessageHash(message), keyPair, false);
+    }
+
+    public static SignatureData signMessage(byte[] message, ECKeyPair keyPair) {
+        return signMessage(message, keyPair, true);
     }
 
     public static SignatureData signMessage(byte[] message, ECKeyPair keyPair, boolean needToHash) {

--- a/crypto/src/test/java/org/web3j/crypto/SignTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignTest.java
@@ -20,11 +20,11 @@ public class SignTest {
         Sign.SignatureData signatureData = Sign.signMessage(TEST_MESSAGE, SampleKeys.KEY_PAIR);
 
         Sign.SignatureData expected = new Sign.SignatureData(
-                (byte) 27,
+                (byte) 28,
                 Numeric.hexStringToByteArray(
-                        "0x9631f6d21dec448a213585a4a41a28ef3d4337548aa34734478b563036163786"),
+                        "0x0464eee9e2fe1a10ffe48c78b80de1ed8dcf996f3f60955cb2e03cb21903d930"),
                 Numeric.hexStringToByteArray(
-                        "0x2ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b")
+                        "0x06624da478b3f862582e85b31c6a21c6cae2eee2bd50f55c93c4faad9d9c8d7f")
         );
 
         assertThat(signatureData, is(expected));

--- a/crypto/src/test/java/org/web3j/crypto/SignTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignTest.java
@@ -17,7 +17,7 @@ public class SignTest {
 
     @Test
     public void testSignMessage() {
-        Sign.SignatureData signatureData = Sign.signMessage(TEST_MESSAGE, SampleKeys.KEY_PAIR);
+        Sign.SignatureData signatureData = Sign.signPrefixedMessage(TEST_MESSAGE, SampleKeys.KEY_PAIR);
 
         Sign.SignatureData expected = new Sign.SignatureData(
                 (byte) 28,
@@ -32,8 +32,8 @@ public class SignTest {
 
     @Test
     public void testSignedMessageToKey() throws SignatureException {
-        Sign.SignatureData signatureData = Sign.signMessage(TEST_MESSAGE, SampleKeys.KEY_PAIR);
-        BigInteger key = Sign.signedMessageToKey(TEST_MESSAGE, signatureData);
+        Sign.SignatureData signatureData = Sign.signPrefixedMessage(TEST_MESSAGE, SampleKeys.KEY_PAIR);
+        BigInteger key = Sign.signedPrefixedMessageToKey(TEST_MESSAGE, signatureData);
         assertThat(key, equalTo(SampleKeys.PUBLIC_KEY));
     }
 


### PR DESCRIPTION
As we discussed before, I have been unable to run the ./gradlew integration tests. But opening a PR so it is easier to get this discussion going. :)

I've updated the test cases by using the key pair to sign a message using ethers. I will be adding more test cases to ethers soon, generated by parity and geth.

I am also concerned that any dapp that has previously signed a message with web3j will no longer get the correct key back when calling `signedMessageToKey`, so this is at best, something that should probably be a major version change. The other option is to add a `signedPrefixedMessageToKey` and a `signPrefixedMessage` and deprecate the non-prefixed version.