### PR TITLE
Fixes #656 usage strings to be in sync with command parsing

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -24,7 +24,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
             + "[--javaTypes|--solidityTypes] "
             + "<input binary file>.bin <input abi file>.abi "
             + "-p|--package <base package name> "
-            + "-o|--output <destination base directory>";
+            + "-o|--outputDir <destination base directory>";
 
     private final String binaryFileLocation;
     private final String absFileLocation;

--- a/codegen/src/main/java/org/web3j/codegen/TruffleJsonFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/TruffleJsonFunctionWrapperGenerator.java
@@ -40,7 +40,7 @@ public class TruffleJsonFunctionWrapperGenerator extends FunctionWrapperGenerato
             + "[--javaTypes|--solidityTypes] "
             + "<input truffle json file>.json "
             + "-p|--package <base package name> "
-            + "-o|--output <destination base directory>";
+            + "-o|--outputDir <destination base directory>";
 
 
     private String jsonFileLocation;


### PR DESCRIPTION
Usage string and actual usage were not in sync. I think changing the usage to reflect actual usage is the only way to go for it to stay backwards compatible.