### PR TITLE
Added WebSocketClient constructor to allow access to headers

### DIFF
--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketClient.java
@@ -1,6 +1,7 @@
 package org.web3j.protocol.websocket;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
@@ -18,6 +19,10 @@ public class WebSocketClient extends org.java_websocket.client.WebSocketClient {
 
     public WebSocketClient(URI serverUri) {
         super(serverUri);
+    }
+
+    public WebSocketClient( URI serverUri, Map<String,String> httpHeaders) {
+        super(serverUri, httpHeaders);
     }
 
     @Override


### PR DESCRIPTION
Support for websockets issue #261 

This allows access to the websocket headers. This way we can add basic authentication or other headers when creating a new WebSocketClient.