### PR TITLE
Update link to Truffle Contract Schema to the recent one

### DIFF
--- a/docs/source/smart_contracts.rst
+++ b/docs/source/smart_contracts.rst
@@ -182,7 +182,7 @@ avoid blocking.
 
 web3j also supports the generation of Java smart contract function wrappers directly from
 `Truffle's <http://truffleframework.com/>`_
-`Contract Schema <https://github.com/trufflesuite/truffle-contract-schema>`_
+`Contract Schema <https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract-schema>`_
 via the :doc:`command_line` utility.
 
 .. code-block:: bash


### PR DESCRIPTION
Truffle has moved all modules to a monorepo at trufflesuite/truffle, so I think it's a good idea to update the link and avoid confusion.