### PR TITLE
Ignore logs without topics when parsing events

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -421,7 +421,7 @@ public abstract class Contract extends ManagedTransaction {
 
         List<String> topics = log.getTopics();
         String encodedEventSignature = EventEncoder.encode(event);
-        if (!topics.get(0).equals(encodedEventSignature)) {
+        if (topics.size() == 0 || !topics.get(0).equals(encodedEventSignature)) {
             return null;
         }
 


### PR DESCRIPTION
### What does this PR do?
Skips over anonymous logs when parsing events. 

### Where should the reviewer start?
Still need to add a test.

### Why is it needed?
Currently when a transaction has an anonymous log (log0) amongst event logs, an IndexOutOfBoundsException is thrown when filtering for a specific event.

