### PR TITLE
fixes issue with IndexOutOfBoundsException when trying to populate wo…

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/MnemonicUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/MnemonicUtils.java
@@ -256,11 +256,12 @@ public class MnemonicUtils {
         try {
             return readAllLines(inputStream);
         } catch (Exception e) {
-            throw new IllegalStateException(e);
+            return Collections.emptyList();
         }
     }
-
-    private static List<String> readAllLines(InputStream inputStream) throws IOException {
+    
+    
+    public static List<String> readAllLines(InputStream inputStream) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
         List<String> data = new ArrayList<>();
         for (String line; (line = br.readLine()) != null; ) {


### PR DESCRIPTION
…rd list

### What does this PR do?
Returns an empty list

### Where should the reviewer start?
Line 259

### Why is it needed?
Fixes an issue with IndexOutOfBoundsException when trying to populate word list for BIP39 wallet.  It seems that the problem is that the file path with the mnemonic words is incorrectly parsed.

