### PR TITLE
Feature/720 add snapshot repo details

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,9 +134,6 @@ Android:
      <version>3.3.1-android</version>
    </dependency>
 
-If you would like to use snapshots instead please add a new maven repository pointing to:
-https://oss.sonatype.org/content/repositories/snapshots
-into the relevant maven settings or POM file, please see: https://maven.apache.org/guides/mini/guide-multiple-repositories.html
 
 Gradle
 ------
@@ -154,14 +151,39 @@ Android:
    compile ('org.web3j:core:3.3.1-android')
 
 
-If you would like to use snapshots instead please add the following into your gradle script.
+Snapshot dependencies
+---------------------
 
-.. code-block: groovy
+If you would like to use snapshots instead please add a new maven repository pointing to:
+
+::
+
+  https://oss.sonatype.org/content/repositories/snapshots
+
+Please refer to the `maven <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ or `gradle <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ documentation for further detail.
+
+Sample gradle configuration:
+
+.. code-block:: groovy
+
    repositories {
       maven {
          url "https://oss.sonatype.org/content/repositories/snapshots"
       }
    }
+
+Sample maven configuration:
+
+.. code-block:: xml
+
+   <repositories>
+     <repository>
+       <id>sonatype-snasphots</id>
+       <name>Sonatype rnapshots repo</name>
+       <url>https://oss.sonatype.org/content/repositories/snapshot</url>
+     </repository>
+   </repositories>
+
 
 Start a client
 --------------

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,10 @@ Android:
      <version>3.3.1-android</version>
    </dependency>
 
+If you would like to use snapshots instead please add a new maven repository pointing to:
+https://oss.sonatype.org/content/repositories/snapshots
+into the relevant maven settings or POM file, please see: https://maven.apache.org/guides/mini/guide-multiple-repositories.html
+
 Gradle
 ------
 
@@ -149,6 +153,15 @@ Android:
 
    compile ('org.web3j:core:3.3.1-android')
 
+
+If you would like to use snapshots instead please add the following into your gradle script.
+
+.. code-block: groovy
+   repositories {
+      maven {
+         url "https://oss.sonatype.org/content/repositories/snapshots"
+      }
+   }
 
 Start a client
 --------------

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,10 @@ demonstrates a number of core features of Ethereum with web3j, including:
 Getting started
 ---------------
 
-Add the relevant dependency to your project:
+Typically your application should depend on release versions of web3j, but you may also use snapshot dependencies
+for early access to features and fixes, refer to the  `Snapshot Dependencies`_ section.
+
+| Add the relevant dependency to your project:
 
 Maven
 -----
@@ -149,40 +152,6 @@ Android:
 .. code-block:: groovy
 
    compile ('org.web3j:core:3.3.1-android')
-
-
-Snapshot dependencies
----------------------
-
-If you would like to use snapshots instead please add a new maven repository pointing to:
-
-::
-
-  https://oss.sonatype.org/content/repositories/snapshots
-
-Please refer to the `maven <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ or `gradle <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ documentation for further detail.
-
-Sample gradle configuration:
-
-.. code-block:: groovy
-
-   repositories {
-      maven {
-         url "https://oss.sonatype.org/content/repositories/snapshots"
-      }
-   }
-
-Sample maven configuration:
-
-.. code-block:: xml
-
-   <repositories>
-     <repository>
-       <id>sonatype-snasphots</id>
-       <name>Sonatype snapshots repo</name>
-       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-     </repository>
-   </repositories>
 
 
 Start a client
@@ -602,6 +571,44 @@ To run the integration tests:
 .. code-block:: bash
 
    $ ./gradlew  -Pintegration-tests=true :integration-tests:test
+
+
+.. _snapshot-dependencies:
+
+Snapshot Dependencies
+---------------------
+
+Snapshot versions of web3j follow the ``<major>.<minor>.<build>-SNAPSHOT`` convention, for example: 3.6.0-SNAPSHOT.
+
+| If you would like to use snapshots instead please add a new maven repository pointing to:
+
+::
+
+  https://oss.sonatype.org/content/repositories/snapshots
+
+Please refer to the `maven <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ or `gradle <https://maven.apache.org/guides/mini/guide-multiple-repositories.html>`_ documentation for further detail.
+
+Sample gradle configuration:
+
+.. code-block:: groovy
+
+   repositories {
+      maven {
+         url "https://oss.sonatype.org/content/repositories/snapshots"
+      }
+   }
+
+Sample maven configuration:
+
+.. code-block:: xml
+
+   <repositories>
+     <repository>
+       <id>sonatype-snasphots</id>
+       <name>Sonatype snapshots repo</name>
+       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+     </repository>
+   </repositories>
 
 Thanks and credits
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ Sample maven configuration:
    <repositories>
      <repository>
        <id>sonatype-snasphots</id>
-       <name>Sonatype rnapshots repo</name>
+       <name>Sonatype snapshots repo</name>
        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
      </repository>
    </repositories>

--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,7 @@ Sample maven configuration:
      <repository>
        <id>sonatype-snasphots</id>
        <name>Sonatype rnapshots repo</name>
-       <url>https://oss.sonatype.org/content/repositories/snapshot</url>
+       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
      </repository>
    </repositories>
 

--- a/README.rst
+++ b/README.rst
@@ -573,8 +573,6 @@ To run the integration tests:
    $ ./gradlew  -Pintegration-tests=true :integration-tests:test
 
 
-.. _snapshot-dependencies:
-
 Snapshot Dependencies
 ---------------------
 


### PR DESCRIPTION
### What does this PR do?
Updates the readme.rst file to include details on how to import snapshots

### Where should the reviewer start?
readme.rst

### Why is it needed?
Snapshots cannot be published to bintray, so we have to directly push them to nexus ourselves. Without instructions in the readme file clients won't be able to import snapshot builds.

