### PR TITLE
#720: improve the build script to publish snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ hs_err_pid*
 */build/
 */out/
 
-gradle.properties
-
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     ext.bouncycastleVersion = '1.54'
     ext.jacksonVersion = '2.8.5'
@@ -43,9 +42,6 @@ allprojects {
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
-
-    group 'org.web3j'
-    version '3.6.0'
 
     apply plugin: 'java'
     apply plugin: 'jacoco'
@@ -92,11 +88,11 @@ subprojects {
 
     dependencies {
         testCompile "junit:junit:$junitVersion",
-                    "org.mockito:mockito-core:$mockitoVersion"
+                "org.mockito:mockito-core:$mockitoVersion"
     }
 }
 
-configure(subprojects.findAll {it.name != 'integration-tests'}) {
+configure(subprojects.findAll { it.name != 'integration-tests' }) {
     // Required for Maven Nexus repository
     apply plugin: 'maven'
     apply plugin: 'signing'
@@ -127,6 +123,9 @@ configure(subprojects.findAll {it.name != 'integration-tests'}) {
     ext {
         ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
         ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''
+        bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+        bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+        isSnapshotVersion = project.version.endsWith("-SNAPSHOT")
     }
 
     publishing {
@@ -150,7 +149,12 @@ configure(subprojects.findAll {it.name != 'integration-tests'}) {
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                repository(url: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/') {
+                onlyIf {
+                    ossrhUsername != '' && ossrhPassword != ''
+                }
+
+                String repoUrl = isSnapshotVersion ? "http://oss.sonatype.org/content/repositories/snapshots/" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                repository(url: repoUrl) {
                     authentication(
                             userName: ossrhUsername,
                             password: ossrhPassword
@@ -193,8 +197,8 @@ configure(subprojects.findAll {it.name != 'integration-tests'}) {
     }
 
     bintray {
-        user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-        key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+        user = bintrayUser
+        key = bintrayKey
         publications = ['mavenJava']
         publish = true
         pkg {
@@ -214,10 +218,12 @@ configure(subprojects.findAll {it.name != 'integration-tests'}) {
         //TODO run clean & closeAndPromoteRepository once
         dependsOn 'build'
         dependsOn 'uploadArchives'
-        dependsOn 'bintrayUpload'
 
+        if (!isSnapshotVersion && bintrayUser != '' && bintrayKey != '') {
+            dependsOn 'bintrayUpload'
+            tasks.findByName('bintrayUpload').mustRunAfter 'build'
+        }
         tasks.findByName('uploadArchives').mustRunAfter 'build'
-        tasks.findByName('bintrayUpload').mustRunAfter 'build'
     }
 }
 
@@ -226,7 +232,7 @@ task jacocoRootTestReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = subprojects.test
     additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
     sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories =  files(subprojects.sourceSets.main.output)
+    classDirectories = files(subprojects.sourceSets.main.output)
     executionData = files(subprojects.jacocoTestReport.executionData)
     reports {
         xml.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+group=org.web3j
+version=3.6.0-SNAPSHOT


### PR DESCRIPTION
### What does this PR do?
Updates the gradle build scripts to:
1. externalise the build version into a separate properties file
2. support publishing of snapshots
3. not run publish tasks if no credentials are provided

### Where should the reviewer start?
build.gradle

### Why is it needed?
To support publishing of snapshots
