### PR TITLE
Added optional transaction hash in TransactionException.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/exceptions/TransactionException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/TransactionException.java
@@ -1,15 +1,33 @@
 package org.web3j.protocol.exceptions;
 
+import java.util.Optional;
+
 /**
  * Transaction timeout exception indicates that we have breached some threshold waiting for a
  * transaction to execute.
  */
 public class TransactionException extends Exception {
+
+    private Optional<String> transactionHash = Optional.empty();
+
     public TransactionException(String message) {
         super(message);
     }
 
+    public TransactionException(String message, String transactionHash) {
+        super(message);
+        this.transactionHash = Optional.ofNullable(transactionHash);
+    }
+
     public TransactionException(Throwable cause) {
         super(cause);
+    }
+
+    /**
+     * Obtain the transaction hash .
+     * @return optional transaction hash .
+     */
+    public Optional<String> getTransactionHash() {
+        return transactionHash;
     }
 }

--- a/core/src/main/java/org/web3j/tx/response/PollingTransactionReceiptProcessor.java
+++ b/core/src/main/java/org/web3j/tx/response/PollingTransactionReceiptProcessor.java
@@ -50,6 +50,6 @@ public class PollingTransactionReceiptProcessor extends TransactionReceiptProces
 
         throw new TransactionException("Transaction receipt was not generated after "
                 + ((sleepDuration * attempts) / 1000
-                + " seconds for transaction: " + transactionHash));
+                + " seconds for transaction: " + transactionHash), transactionHash);
     }
 }

--- a/core/src/main/java/org/web3j/tx/response/QueuingTransactionReceiptProcessor.java
+++ b/core/src/main/java/org/web3j/tx/response/QueuingTransactionReceiptProcessor.java
@@ -63,7 +63,7 @@ public class QueuingTransactionReceiptProcessor extends TransactionReceiptProces
                         throw new TransactionException(
                                 "No transaction receipt for txHash: " + transactionHash
                                         + "received after " + pollingAttemptsPerTxHash
-                                        + " attempts");
+                                        + " attempts", transactionHash);
                     } else {
                         requestWrapper.incrementCount();
                     }

--- a/core/src/test/java/org/web3j/tx/response/PollingTransactionReceiptProcessorTest.java
+++ b/core/src/test/java/org/web3j/tx/response/PollingTransactionReceiptProcessorTest.java
@@ -13,8 +13,8 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionException;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;

--- a/core/src/test/java/org/web3j/tx/response/PollingTransactionReceiptProcessorTest.java
+++ b/core/src/test/java/org/web3j/tx/response/PollingTransactionReceiptProcessorTest.java
@@ -14,6 +14,8 @@ import org.web3j.protocol.exceptions.TransactionException;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -54,7 +56,8 @@ public class PollingTransactionReceiptProcessorTest {
             processor.waitForTransactionReceipt(TRANSACTION_HASH);
             fail("call should fail with TransactionException");
         } catch (TransactionException e) {
-            // this is expected
+            assertTrue(e.getTransactionHash().isPresent());
+            assertEquals(e.getTransactionHash().get(), TRANSACTION_HASH);
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Added to TransactionException the field transaction hash.

### Where should the reviewer start?

Checking the `TransactionReceiptProcessor` implementations

### Why is it needed?

Imagine your `PollingTransactionReceiptProcessor` not generated the transaction receipt after X second, with this you can detect and caught it and with the field, you can reprocess the transaction hash or store it in the database.

