### PR TITLE
Updated OkHttp CipherSuites to include all INFURA CiperSuites

### DIFF
--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -3,9 +3,12 @@ package org.web3j.protocol.http;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import okhttp3.CipherSuite;
+import okhttp3.ConnectionSpec;
 import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -24,6 +27,39 @@ import org.web3j.protocol.exceptions.ClientConnectionException;
  * HTTP implementation of our services API.
  */
 public class HttpService extends Service {
+    /**
+     * Copied from {@link ConnectionSpec#APPROVED_CIPHER_SUITES}.
+     */
+    private static final CipherSuite[] INFURA_CIPHER_SUITES = new CipherSuite[] {
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+
+        // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
+        // continue to include them until better suites are commonly available. For example, none
+        // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+        CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+        CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+        CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+
+        // Additional INFURA CipherSuites
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256
+    };
+    
+    private static final ConnectionSpec INFURA_CIPHER_SUITE_SPEC = new ConnectionSpec
+            .Builder(ConnectionSpec.MODERN_TLS).cipherSuites(INFURA_CIPHER_SUITES).build();
 
     public static final MediaType JSON_MEDIA_TYPE
             = MediaType.parse("application/json; charset=utf-8");
@@ -76,7 +112,8 @@ public class HttpService extends Service {
     }
 
     private static OkHttpClient createOkHttpClient() {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectionSpecs(Collections.singletonList(INFURA_CIPHER_SUITE_SPEC));
         configureLogging(builder);
         return builder.build();
     }


### PR DESCRIPTION
### What does this PR do?
INFURA was recently updated to allow a [very small of SSL CiperSuites](https://www.ssllabs.com/ssltest/analyze.html?d=mainnet.infura.io&latest):
 - `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
 - `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
 - `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384`
 - `TLS_RSA_WITH_AES_128_GCM_SHA256`
 - `TLS_RSA_WITH_AES_128_CBC_SHA256`
 - `TLS_RSA_WITH_AES_256_GCM_SHA384`
 - `TLS_RSA_WITH_AES_256_CBC_SHA256`

Out of those 8 CipherSuites, only 4 are enabled by default in OkHttp.

This PR updates how Web3j builds the OkHttp client. Now Web3j explicitly enables *all* CiperSuites supported by INFURA on its OkHttp client.

### Where should the reviewer start?
`HttpService.java` is the only file that was changed. Looking at OkHttp [`ConnectionSpec.java`](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/ConnectionSpec.java#L63-L88) might also help

### Why is it needed?
In my particular case, I'm running Web3j on a machine which disables the 4 INFURA CipherSuites that OkHttp enables out of the box. This makes it impossible for me to use the library, without enabling the other missing 4 CipherSuites

A better way would be to allow passing a custom OkHttp client to Web3j but I think its overkill