### PR TITLE
[WIP] - Client side load balancing

### DIFF
--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -38,9 +38,12 @@ public class HttpService extends Service {
             CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
             CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 
-            // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
-            // continue to include them until better suites are commonly available. For example, none
-            // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
+            // Note that the following cipher suites are all on
+            // HTTP/2's bad cipher suites list. We'll
+            // continue to include them until better suites are
+            // commonly available. For example, none
+            // of the better cipher suites listed above shipped
+            // with Android 4.4 or Java 7.
             CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
             CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
             CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -31,31 +31,31 @@ public class HttpService extends Service {
      * Copied from {@link ConnectionSpec#APPROVED_CIPHER_SUITES}.
      */
     private static final CipherSuite[] INFURA_CIPHER_SUITES = new CipherSuite[] {
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-        CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 
-        // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
-        // continue to include them until better suites are commonly available. For example, none
-        // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-        CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-        CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
-        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
-        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
-        CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+            // Note that the following cipher suites are all on HTTP/2's bad cipher suites list. We'll
+            // continue to include them until better suites are commonly available. For example, none
+            // of the better cipher suites listed above shipped with Android 4.4 or Java 7.
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+            CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+            CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 
-        // Additional INFURA CipherSuites
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-        CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-        CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-        CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256
+            // Additional INFURA CipherSuites
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256
     };
 
     private static final ConnectionSpec INFURA_CIPHER_SUITE_SPEC = new ConnectionSpec
@@ -89,16 +89,16 @@ public class HttpService extends Service {
         this(httpClient, includeRawResponses, DEFAULT_URL);
     }
 
-    private HttpService(OkHttpClient httpClient, String url) {
-        this(httpClient, false, url);
+    private HttpService(OkHttpClient httpClient, String... urls) {
+        this(httpClient, false, urls);
     }
 
-    public HttpService(String url) {
-        this(createOkHttpClient(), url);
+    public HttpService(String... urls) {
+        this(createOkHttpClient(), urls);
     }
 
-    public HttpService(boolean includeRawResponse, String url) {
-        this(createOkHttpClient(), includeRawResponse, url);
+    public HttpService(boolean includeRawResponse, String... urls) {
+        this(createOkHttpClient(), includeRawResponse, urls);
     }
 
     public HttpService(OkHttpClient httpClient) {
@@ -142,7 +142,8 @@ public class HttpService extends Service {
                     .post(requestBody)
                     .build();
         } catch (IllegalStateException e) {
-            url = next();
+            log.error("Node connection has failed", e);
+            url = nextUrl();
             if (url != null) {
                 httpRequest = new okhttp3.Request.Builder()
                         .url(url)
@@ -215,7 +216,7 @@ public class HttpService extends Service {
         return headers;
     }
 
-    public String next() {
+    private String nextUrl() {
         ++counter;
         if (counter == urls.length) {
             counter = 0;

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -170,7 +170,6 @@ public class HttpService extends Service {
         }
     }
 
-
     private InputStream buildInputStream(ResponseBody responseBody) throws IOException {
         InputStream inputStream = responseBody.byteStream();
 

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -154,7 +154,7 @@ public class HttpService extends Service {
                 response = httpClient.newCall(httpRequest).execute();
                 break;
             } catch (Exception e) {
-                log.warn("Failed called, trying next url");
+                log.error("Failed called, trying next url", e);
                 url = nextUrl();
             }
         } while (true);

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -136,20 +136,12 @@ public class HttpService extends Service {
         okhttp3.Request httpRequest;
         String url = urls[counter];
         try {
-            httpRequest = new okhttp3.Request.Builder()
-                    .url(url)
-                    .headers(headers)
-                    .post(requestBody)
-                    .build();
+            httpRequest = buildHttpRequest(url, headers, requestBody);
         } catch (IllegalStateException e) {
             log.error("Node connection has failed", e);
             url = nextUrl();
             if (url != null) {
-                httpRequest = new okhttp3.Request.Builder()
-                        .url(url)
-                        .headers(headers)
-                        .post(requestBody)
-                        .build();
+                httpRequest = buildHttpRequest(url, headers, requestBody);
             } else {
                 throw e;
             }
@@ -201,6 +193,17 @@ public class HttpService extends Service {
 
     private Headers buildHeaders() {
         return Headers.of(headers);
+    }
+
+    private okhttp3.Request buildHttpRequest(String url, okhttp3.Headers headers,
+                                             RequestBody requestBody) {
+        okhttp3.Request httpRequest = new okhttp3.Request.Builder()
+                .url(url)
+                .headers(headers)
+                .post(requestBody)
+                .build();
+
+        return httpRequest;
     }
 
     public void addHeader(String key, String value) {

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -143,23 +143,21 @@ public class HttpService extends Service {
 
     @Override
     protected InputStream performIO(String request) throws IOException {
-
         RequestBody requestBody = RequestBody.create(JSON_MEDIA_TYPE, request);
         Headers headers = buildHeaders();
-        okhttp3.Request httpRequest;
         String url = urls[counter];
-        try {
+        okhttp3.Request httpRequest;
+        okhttp3.Response response;
+        do {
             httpRequest = buildHttpRequest(url, headers, requestBody);
-        } catch (IllegalStateException e) {
-            log.error("Node connection has failed", e);
-            url = nextUrl();
-            if (url != null) {
-                httpRequest = buildHttpRequest(url, headers, requestBody);
-            } else {
-                throw e;
+            try {
+                response = httpClient.newCall(httpRequest).execute();
+                break;
+            } catch (Exception e) {
+                log.warn("Failed called, trying next url");
+                url = nextUrl();
             }
-        }
-        okhttp3.Response response = httpClient.newCall(httpRequest).execute();
+        } while (true);
         ResponseBody responseBody = response.body();
         if (response.isSuccessful()) {
             if (responseBody != null) {

--- a/integration-tests/src/test/java/org/web3j/protocol/core/CoreIT.java
+++ b/integration-tests/src/test/java/org/web3j/protocol/core/CoreIT.java
@@ -81,6 +81,14 @@ public class CoreIT {
     }
 
     @Test
+    public void testWeb3MultiClientVersion() throws Exception {
+        this.web3j = Web3j.build(new HttpService("http://localhost:22001","http://localhost:22002","http://127.0.0.1:7545"));
+        Web3ClientVersion web3ClientVersion = web3j.web3ClientVersion().send();
+        String clientVersion = web3ClientVersion.getWeb3ClientVersion();
+        assertFalse(clientVersion.isEmpty());
+    }
+
+    @Test
     public void testWeb3Sha3() throws Exception {
         Web3Sha3 web3Sha3 = web3j.web3Sha3("0x68656c6c6f20776f726c64").send();
         assertThat(web3Sha3.getResult(),


### PR DESCRIPTION
### Done:
- [x] Multiple http node support;
- [x] Old tests are running;
- [x] New test for multiple nodes;

### Mentions with respect to the comments: 
- [x] I had to pull in `release/4.0` branch in order to overcome the `CLEARTEXT error` and be able to run the tests.

- [x]  I noticed there is a rule which enforced me to keep the url/urls parameter on the last position in the constructor:
```java
public HttpService(OkHttpClient httpClient, boolean includeRawResponses, String... urls)
```
Please let me know if there is anyway to overcome this in order not to change the position of the parameter.

