### PR TITLE
missing project dependency "crypto"

### DIFF
--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -2,8 +2,7 @@
 description 'web3j project code generators'
 
 dependencies {
-    compile project(':core'),
-     compile project(':crypto'),
+    compile project(':core'), project(':crypto'),
             "com.squareup:javapoet:$javapoetVersion",
             "info.picocli:picocli:$picocliVersion"
     testCompile project(path: ':core', configuration: 'testArtifacts')

--- a/codegen/build.gradle
+++ b/codegen/build.gradle
@@ -3,6 +3,7 @@ description 'web3j project code generators'
 
 dependencies {
     compile project(':core'),
+     compile project(':crypto'),
             "com.squareup:javapoet:$javapoetVersion",
             "info.picocli:picocli:$picocliVersion"
     testCompile project(path: ':core', configuration: 'testArtifacts')


### PR DESCRIPTION
SolidityFunctionWrapper uses org.web3j.crypto.Credentials. Dependency to crpyto is needed (alternatively moving to core or utils)

### What does this PR do?
adds a dependency to the crypto subproject

### Where should the reviewer start?
build.grade

### Why is it needed?
to run the TruffleJsonFunctionWrapperGenerator in standalone mode

