### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+## How to contribute to web3j
+
+Thank you for reading this! If you'd like to report a bug or join in the buidl-ing of web3j, then here are some notes on how to do that.
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/web3j/web3j/issues). If there is then please add any more information that you have, or give it a :+1:. This will help us prioritize work.
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/web3j/web3j/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or event better an **executable test case** demonstrating the expected behavior that is not occurring. 
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Do you intend to add a new feature or change an existing one?**
+
+* Suggest your change in the [gitter channel](https://gitter.im/web3j/web3j) then start writing code.
+
+* Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+
+#### **Do you have questions about the source code?**
+
+* Ask any question about how to use web3j should be directed to the [gitter channel](https://gitter.im/web3j/web3j)
+
+## :heart: BUIDL :heart:
+
+team web3j 


### PR DESCRIPTION
### What does this PR do?
adds contributing guidelines for web3j fixes #781 

### Why is it needed?
To help developers get started on contributing to web3j
