### PR TITLE
Updated RawTransactionManager.java with new sign(rawTx) method

### DIFF
--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -21,7 +21,8 @@ import org.web3j.utils.TxHashVerifier;
  * locally.
  *
  * <p>This transaction manager provides support for specifying the chain id for transactions as per
- * <a href="https://github.com/ethereum/EIPs/issues/155">EIP155</a>.
+ * <a href="https://github.com/ethereum/EIPs/issues/155">EIP155</a>, as well as for locally signing
+ * RawTransaction instances without broadcasting them.
  */
 public class RawTransactionManager extends TransactionManager {
 
@@ -103,9 +104,12 @@ public class RawTransactionManager extends TransactionManager {
 
         return signAndSend(rawTransaction);
     }
-
-    public EthSendTransaction signAndSend(RawTransaction rawTransaction)
-            throws IOException {
+    
+    /*
+     * @param rawTransaction a RawTransaction istance to be signed
+     * @return The transaction signed and encoded without ever broadcasting it
+     */
+    public String sign(RawTransaction rawTransaction) {
 
         byte[] signedMessage;
 
@@ -115,7 +119,12 @@ public class RawTransactionManager extends TransactionManager {
             signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
         }
 
-        String hexValue = Numeric.toHexString(signedMessage);
+        return Numeric.toHexString(signedMessage);
+    }
+
+    public EthSendTransaction signAndSend(RawTransaction rawTransaction)
+            throws IOException {
+        String hexValue = sign(rawTransaction);
         EthSendTransaction ethSendTransaction = web3j.ethSendRawTransaction(hexValue).send();
 
         if (ethSendTransaction != null && !ethSendTransaction.hasError()) {


### PR DESCRIPTION
Added sign(rawTransaction) method to quickly return a signed, hex-encoded transaction representation without ever broadcasting it.
Updated existing signAndSend(rawTransaction) method to include the new method.

### What does this PR do?
Read above

### Where should the reviewer start?
line 24

### Why is it needed?
The current standard for locally signing txs without broadcasting them is, imo, more laborious and less logically intuitive as per docs: https://docs.web3j.io/transactions.html#signing-transactions

