### PR TITLE
Update jnr-unixsocket to v0.21. Resolves Issue #810.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.bouncycastleVersion = '1.54'
     ext.jacksonVersion = '2.8.5'
     ext.javapoetVersion = '1.7.0'
-    ext.jnr_unixsocketVersion = '0.15'
+    ext.jnr_unixsocketVersion = '0.21'
     ext.okhttpVersion = '3.8.1'
     ext.rxjavaVersion = '2.2.2'
     ext.slf4jVersion = '1.7.25'


### PR DESCRIPTION
### What does this PR do?
This PR Resolves Issue #810.
tl;dr The jnr-unixsocket version currently used is 2+ years out of date and includes an ambiguously licensed dependency which MAY require copyleft handling. 

In addition to other bugfixes dealing with a scenario in which the socket would deadlock, and using Java ByteOrder's native endianness, bumping the jnr-unixsocket version to 0.21 mitigates the concern over Web3J's transitive dependency jnr-posix, as it is explicitly licensed under EITHER EPLv2 OR GPLv2 OR LGPLv2.1, allowing compatibility with derivative works which wish not to maintain copyleft provisions.

### Where should the reviewer start?
The only change to this repo is bumping the `jnr_unixsocketVersion` in the root `build.gradle`. Please consult https://github.com/jnr/jnr-unixsocket/compare/jnr-unixsocket-0.15...jnr-unixsocket-0.21 for impact analysis. As explained in the above section, this version bump only has 3 changes: a deadlock bugfix, opting to use default native/system endianness, and bumping downstream dependencies.

### Why is it needed?
Hopefully you've got the gist of why by now. Copyleft is a virus.

