### PR TITLE
Upgrade Bouncycastle to 1.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.bouncycastleVersion = '1.54'
+    ext.bouncycastleVersion = '1.60'
     ext.jacksonVersion = '2.8.5'
     ext.javapoetVersion = '1.7.0'
     ext.jnr_unixsocketVersion = '0.21'


### PR DESCRIPTION
### What does this PR do?
Upgrades the BouncyCastle dependency from 1.54 to 1.60

### Where should the reviewer start?
build.gradle

### Why is it needed?
BouncyCastle 1.54 is vulnerable to the following CVEs:

CVE-2016-1000341, CVE-2016-1000352, CVE-2016-1000340, CVE-2016-2427, CVE-2018-1000613, CVE-2016-1000339, CVE-2016-1000346, CVE-2016-1000338, CVE-2017-13098, CVE-2016-1000343, CVE-2018-1000180, CVE-2016-1000342, CVE-2016-1000345, CVE-2016-1000344

