### PR TITLE
Make the HARDENED_BIT of org.web3j.crypto.Bip32ECKeyPair public

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
+++ b/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
@@ -18,7 +18,7 @@ import static org.web3j.crypto.Hash.sha256hash160;
  * https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
  */
 public class Bip32ECKeyPair extends ECKeyPair {
-    static final int HARDENED_BIT = 0x80000000;
+    public static final int HARDENED_BIT = 0x80000000;
 
     private final boolean parentHasPrivate;
     private final int childNumber;


### PR DESCRIPTION
### What does this PR do?
Make the HARDENED_BIT field public as suggested in #838 

### Why is it needed?
Because users need that HARDENED_BIT to generate a derivation path to actually use the Bip32ECKeyPair class.

