### PR TITLE
skip metadata for validating contract code

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -182,6 +182,10 @@ public abstract class Contract extends ManagedTransaction {
         }
 
         String code = Numeric.cleanHexPrefix(ethGetCode.getCode());
+        int metadataIndex = code.indexOf("a165627a7a72305820");
+        if (metadataIndex != -1) {
+            code = code.substring(0, metadataIndex);
+        }
         // There may be multiple contracts in the Solidity bytecode, hence we only check for a
         // match with a subset
         return !code.isEmpty() && contractBinary.contains(code);

--- a/core/src/test/java/org/web3j/tx/ContractTest.java
+++ b/core/src/test/java/org/web3j/tx/ContractTest.java
@@ -127,6 +127,16 @@ public class ContractTest extends ManagedTransactionTester {
     }
 
     @Test
+    public void testIsValidSkipMetadata() throws Exception {
+        prepareEthGetCode(TEST_CONTRACT_BINARY
+                + "a165627a7a72305820"
+                + "a9bc86938894dc250f6ea25dd823d4472fad6087edcda429a3504e3713a9fc880029");
+
+        Contract contract = deployContract(createTransactionReceipt());
+        assertTrue(contract.isValid());
+    }
+
+    @Test
     public void testIsValidDifferentCode() throws Exception {
         prepareEthGetCode(TEST_CONTRACT_BINARY + "0");
 


### PR DESCRIPTION
This PR makes sure that we do not include code metadata when validating for contract validity.
See also: https://github.com/web3j/web3j/issues/874