### PR TITLE
include call data when getting gasPrice & gasLimit in ContractGasProvider

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -289,8 +289,8 @@ public abstract class Contract extends ManagedTransaction {
             throws TransactionException, IOException {
 
         TransactionReceipt receipt = send(contractAddress, data, weiValue,
-                gasProvider.getGasPrice(funcName),
-                gasProvider.getGasLimit(funcName));
+                gasProvider.getGasPrice(funcName, data),
+                gasProvider.getGasLimit(funcName, data));
 
         if (!receipt.isStatusOK()) {
             throw new TransactionException(

--- a/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
@@ -3,12 +3,18 @@ package org.web3j.tx.gas;
 import java.math.BigInteger;
 
 public interface ContractGasProvider {
+    @Deprecated
     BigInteger getGasPrice(String contractFunc);
+
+    BigInteger getGasPrice(String funcName, String data);
 
     @Deprecated
     BigInteger getGasPrice();
 
+    @Deprecated
     BigInteger getGasLimit(String contractFunc);
+
+    BigInteger getGasLimit(String contractFunc, String data);
 
     @Deprecated
     BigInteger getGasLimit();

--- a/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
@@ -6,7 +6,7 @@ public interface ContractGasProvider {
     @Deprecated
     BigInteger getGasPrice(String contractFunc);
 
-    BigInteger getGasPrice(String funcName, String data);
+    BigInteger getGasPrice(String contractFunc, String data);
 
     @Deprecated
     BigInteger getGasPrice();

--- a/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
@@ -12,7 +12,7 @@ public class StaticGasProvider implements ContractGasProvider {
     }
 
     @Override
-    public BigInteger getGasPrice(String funcName, String data) {
+    public BigInteger getGasPrice(String contractFunc, String data) {
         return gasPrice;
     }
 

--- a/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
@@ -12,6 +12,11 @@ public class StaticGasProvider implements ContractGasProvider {
     }
 
     @Override
+    public BigInteger getGasPrice(String funcName, String data) {
+        return gasPrice;
+    }
+
+    @Override
     public BigInteger getGasPrice(String contractFunc) {
         return gasPrice;
     }
@@ -19,6 +24,11 @@ public class StaticGasProvider implements ContractGasProvider {
     @Override
     public BigInteger getGasPrice() {
         return gasPrice;
+    }
+
+    @Override
+    public BigInteger getGasLimit(String contractFunc, String data) {
+        return gasLimit;
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Update ContractGasProvider interface to allow passing call data.  

### Where should the reviewer start?
ContractGasProvider interface and Contract.executeTransaction() protected method.

### Why is it needed?
If ContractGasProvider only has function name, it is difficult to make informed decisions about gas price.  Alternatively Contract.executeTransaction() could be changed from protected to public, or the ContractGasProvider could be moved to ManagedTransaction .
