### PR TITLE
Remove references to Web3jFactory in the android documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,13 +222,6 @@ To use an RxJava Flowable:
        ...
    });
 
-**Note:** for Android use:
-
-.. code-block:: java
-
-   Web3j web3 = Web3jFactory.build(new HttpService());  // defaults to http://localhost:8545/
-   ...
-
 
 IPC
 ---

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -99,11 +99,6 @@ To use an RxJava Flowable::
        ...
    });
 
-**Note:** for Android use::
-
-   Web3j web3 = Web3jFactory.build(new HttpService());  // defaults to http://localhost:8545/
-   ...
-
 
 IPC
 ---


### PR DESCRIPTION
### What does this PR do?
Corrects the documentation as it is causing confusion, see issue #651 

### Where should the reviewer start?
The modified RST files.

### Why is it needed?
Web3jFactory has been removed and users ought to use Web3j instead.

