### PR TITLE
Add feature to generate BIP-39 wallet file from known mnemonic

### DIFF
--- a/core/src/main/java/org/web3j/crypto/WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/WalletUtils.java
@@ -118,7 +118,8 @@ public class WalletUtils {
      * @throws CipherException if the underlying cipher is not available
      * @throws IOException if the destination cannot be written to
      */
-    public static Bip39Wallet generateBip39WalletFromMnemonic(String password, String mnemonic, File destinationDirectory)
+    public static Bip39Wallet generateBip39WalletFromMnemonic(
+            String password, String mnemonic, File destinationDirectory)
             throws CipherException, IOException {
         byte[] seed = MnemonicUtils.generateSeed(mnemonic, password);
         ECKeyPair privateKey = ECKeyPair.create(sha256(seed));

--- a/core/src/main/java/org/web3j/crypto/WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/WalletUtils.java
@@ -108,6 +108,26 @@ public class WalletUtils {
         return new Bip39Wallet(walletFile, mnemonic);
     }
 
+    /**
+     * Generates a BIP-39 compatible Ethereum wallet using a mnemonic passed as argument.
+     *
+     * @param password Will be used for both wallet encryption and passphrase for BIP-39 seed
+     * @param mnemonic The mnemonic that will be used to generate the seed
+     * @param destinationDirectory The directory containing the wallet
+     * @return A BIP-39 compatible Ethereum wallet
+     * @throws CipherException if the underlying cipher is not available
+     * @throws IOException if the destination cannot be written to
+     */
+    public static Bip39Wallet generateBip39WalletFromMnemonic(String password, String mnemonic, File destinationDirectory)
+            throws CipherException, IOException {
+        byte[] seed = MnemonicUtils.generateSeed(mnemonic, password);
+        ECKeyPair privateKey = ECKeyPair.create(sha256(seed));
+
+        String walletFile = generateWalletFile(password, privateKey, destinationDirectory, false);
+
+        return new Bip39Wallet(walletFile, mnemonic);
+    }
+
     public static Credentials loadCredentials(String password, String source)
             throws IOException, CipherException {
         return loadCredentials(password, new File(source));

--- a/core/src/test/java/org/web3j/crypto/WalletUtilsTest.java
+++ b/core/src/test/java/org/web3j/crypto/WalletUtilsTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
 import static org.web3j.crypto.Hash.sha256;
 import static org.web3j.crypto.SampleKeys.CREDENTIALS;
 import static org.web3j.crypto.SampleKeys.KEY_PAIR;
-import static org.web3j.crypto.SampleKeys.PASSWORD;
 import static org.web3j.crypto.SampleKeys.MNEMONIC;
+import static org.web3j.crypto.SampleKeys.PASSWORD;
 import static org.web3j.crypto.WalletUtils.isValidAddress;
 import static org.web3j.crypto.WalletUtils.isValidPrivateKey;
 
@@ -51,7 +51,8 @@ public class WalletUtilsTest {
 
     @Test
     public void testGenerateBip39WalletFromMnemonic() throws Exception {
-        Bip39Wallet wallet = WalletUtils.generateBip39WalletFromMnemonic(PASSWORD, MNEMONIC, tempDir);
+        Bip39Wallet wallet = WalletUtils.generateBip39WalletFromMnemonic(
+                PASSWORD, MNEMONIC, tempDir);
         byte[] seed = MnemonicUtils.generateSeed(wallet.getMnemonic(), PASSWORD);
         Credentials credentials = Credentials.create(ECKeyPair.create(sha256(seed)));
 

--- a/core/src/test/java/org/web3j/crypto/WalletUtilsTest.java
+++ b/core/src/test/java/org/web3j/crypto/WalletUtilsTest.java
@@ -19,6 +19,7 @@ import static org.web3j.crypto.Hash.sha256;
 import static org.web3j.crypto.SampleKeys.CREDENTIALS;
 import static org.web3j.crypto.SampleKeys.KEY_PAIR;
 import static org.web3j.crypto.SampleKeys.PASSWORD;
+import static org.web3j.crypto.SampleKeys.MNEMONIC;
 import static org.web3j.crypto.WalletUtils.isValidAddress;
 import static org.web3j.crypto.WalletUtils.isValidPrivateKey;
 
@@ -42,6 +43,15 @@ public class WalletUtilsTest {
     @Test
     public void testGenerateBip39Wallets() throws Exception {
         Bip39Wallet wallet = WalletUtils.generateBip39Wallet(PASSWORD, tempDir);
+        byte[] seed = MnemonicUtils.generateSeed(wallet.getMnemonic(), PASSWORD);
+        Credentials credentials = Credentials.create(ECKeyPair.create(sha256(seed)));
+
+        assertEquals(credentials, WalletUtils.loadBip39Credentials(PASSWORD, wallet.getMnemonic()));
+    }
+
+    @Test
+    public void testGenerateBip39WalletFromMnemonic() throws Exception {
+        Bip39Wallet wallet = WalletUtils.generateBip39WalletFromMnemonic(PASSWORD, MNEMONIC, tempDir);
         byte[] seed = MnemonicUtils.generateSeed(wallet.getMnemonic(), PASSWORD);
         Credentials credentials = Credentials.create(ECKeyPair.create(sha256(seed)));
 

--- a/crypto/src/test/java/org/web3j/crypto/SampleKeys.java
+++ b/crypto/src/test/java/org/web3j/crypto/SampleKeys.java
@@ -18,7 +18,8 @@ public class SampleKeys {
     public static final String ADDRESS_NO_PREFIX = Numeric.cleanHexPrefix(ADDRESS);
 
     public static final String PASSWORD = "Insecure Pa55w0rd";
-    public static final String MNEMONIC = "scatter major grant return flee easy female jungle vivid movie bicycle absent weather inspire carry";
+    public static final String MNEMONIC = "scatter major grant return flee easy female jungle"
+            + " vivid movie bicycle absent weather inspire carry";
 
     static final BigInteger PRIVATE_KEY = Numeric.toBigInt(PRIVATE_KEY_STRING);
     static final BigInteger PUBLIC_KEY = Numeric.toBigInt(PUBLIC_KEY_STRING);

--- a/crypto/src/test/java/org/web3j/crypto/SampleKeys.java
+++ b/crypto/src/test/java/org/web3j/crypto/SampleKeys.java
@@ -18,6 +18,7 @@ public class SampleKeys {
     public static final String ADDRESS_NO_PREFIX = Numeric.cleanHexPrefix(ADDRESS);
 
     public static final String PASSWORD = "Insecure Pa55w0rd";
+    public static final String MNEMONIC = "scatter major grant return flee easy female jungle vivid movie bicycle absent weather inspire carry";
 
     static final BigInteger PRIVATE_KEY = Numeric.toBigInt(PRIVATE_KEY_STRING);
     static final BigInteger PUBLIC_KEY = Numeric.toBigInt(PUBLIC_KEY_STRING);


### PR DESCRIPTION
### What does this PR do?
Adds a method in WalletUtils class to generate a BIP-39 wallet file using a given mnemonic string. This PR resolves issue #897.

### Where should the reviewer start?
`generateBip39WalletFromMnemonic` method in WalletUtils class, `testGenerateBip39WalletFromMnemonic` method in WalletUtilsTest class.

### Why is it needed?
Currently, there is not a method to generate a `WalletFile` without generating a new random mnemonic.

