### PR TITLE
Add ScheduledExecutorService to Parity constructor like in org/web3j/…

### DIFF
--- a/parity/src/main/java/org/web3j/protocol/parity/JsonRpc2_0Parity.java
+++ b/parity/src/main/java/org/web3j/protocol/parity/JsonRpc2_0Parity.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import org.web3j.crypto.WalletFile;
@@ -37,6 +38,14 @@ public class JsonRpc2_0Parity extends JsonRpc2_0Admin implements Parity {
 
     public JsonRpc2_0Parity(Web3jService web3jService) {
         super(web3jService);
+    }
+
+    public JsonRpc2_0Parity(
+            Web3jService web3jService,
+            long pollingInterval,
+            ScheduledExecutorService scheduledExecutorService
+    ) {
+        super(web3jService, pollingInterval, scheduledExecutorService);
     }
 
     @Override

--- a/parity/src/main/java/org/web3j/protocol/parity/Parity.java
+++ b/parity/src/main/java/org/web3j/protocol/parity/Parity.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.web3j.crypto.WalletFile;
 import org.web3j.protocol.Web3jService;
@@ -25,8 +26,32 @@ import org.web3j.protocol.parity.methods.response.ParityListRecentDapps;
  * JSON-RPC Request object building factory for Parity.
  */
 public interface Parity extends Admin, Trace {
+
+    /**
+     * Construct a new Parity instance.
+     * @param web3jService web3j service instance - i.e. HTTP or IPC
+     * @return new Parity instance
+     */
     static Parity build(Web3jService web3jService) {
         return new JsonRpc2_0Parity(web3jService);
+    }
+
+    /**
+     * Construct a new Parity instance.
+     *
+     * @param web3jService web3j service instance - i.e. HTTP or IPC
+     * @param pollingInterval polling interval for responses from network nodes
+     * @param scheduledExecutorService executor service to use for scheduled tasks.
+     *                                 <strong>You are responsible for terminating this thread
+     *                                 pool</strong>
+     * @return new Parity instance
+     */
+    static Parity build(
+            Web3jService web3jService,
+            long pollingInterval,
+            ScheduledExecutorService scheduledExecutorService
+    ) {
+        return new JsonRpc2_0Parity(web3jService, pollingInterval, scheduledExecutorService);
     }
 
     Request<?, ParityAllAccountsInfo> parityAllAccountsInfo();


### PR DESCRIPTION
…protocol/Web3j.java

### What does this PR do?
Add `ScheduledExecutorService` to `Parity` so now it is possible to build the class like a 'org.web3j.protocol.Web3j'.

### Where should the reviewer start?
Compare changes in `org/web3j/protocol/parity/Parity.java` with `org/web3j/protocol/Web3j.java`.

### Why is it needed?
To specify `ScheduledExecutorService` and be compatible with `org/web3j/protocol/Web3j.java`.

