### PR TITLE
Change Chain ID type from byte to long

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -111,7 +111,7 @@ public class Sign {
      * @param message Hash of the data that was signed.
      * @return An ECKey containing only the public part, or null if recovery wasn't possible.
      */
-    public static BigInteger recoverFromSignature(int recId, ECDSASignature sig, byte[] message) {
+    public static BigInteger recoverFromSignature(long recId, ECDSASignature sig, byte[] message) {
         verifyPrecondition(recId >= 0, "recId must be positive");
         verifyPrecondition(sig.r.signum() >= 0, "r must be positive");
         verifyPrecondition(sig.s.signum() >= 0, "s must be positive");
@@ -120,7 +120,7 @@ public class Sign {
         // 1.0 For j from 0 to h   (h == recId here and the loop is outside this function)
         //   1.1 Let x = r + jn
         BigInteger n = CURVE.getN();  // Curve order.
-        BigInteger i = BigInteger.valueOf((long) recId / 2);
+        BigInteger i = BigInteger.valueOf(recId / 2);
         BigInteger x = sig.r.add(i.multiply(n));
         //   1.2. Convert the integer x to an octet string X of length mlen using the conversion
         //        routine specified in Section 2.3.7, where mlen = ⌈(log2 p)/8⌉ or mlen = ⌈m/8⌉.
@@ -217,7 +217,7 @@ public class Sign {
         verifyPrecondition(r != null && r.length == 32, "r must be 32 bytes");
         verifyPrecondition(s != null && s.length == 32, "s must be 32 bytes");
 
-        int header = signatureData.getV() & 0xFF;
+        long header = signatureData.getV() & 0xFF;
         // The header byte: 0x1B = first key with even y, 0x1C = first key with odd y,
         //                  0x1D = second key with even y, 0x1E = second key with odd y
         if (header < 27 || header > 34) {
@@ -228,7 +228,7 @@ public class Sign {
                 new BigInteger(1, signatureData.getR()),
                 new BigInteger(1, signatureData.getS()));
 
-        int recId = header - 27;
+        long recId = header - 27;
         BigInteger key = recoverFromSignature(recId, sig, messageHash);
         if (key == null) {
             throw new SignatureException("Could not recover public key from signature");
@@ -277,17 +277,17 @@ public class Sign {
     }
 
     public static class SignatureData {
-        private final byte v;
+        private final long v;
         private final byte[] r;
         private final byte[] s;
 
-        public SignatureData(byte v, byte[] r, byte[] s) {
+        public SignatureData(long v, byte[] r, byte[] s) {
             this.v = v;
             this.r = r;
             this.s = s;
         }
 
-        public byte getV() {
+        public long getV() {
             return v;
         }
 

--- a/crypto/src/main/java/org/web3j/crypto/SignedRawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/SignedRawTransaction.java
@@ -22,14 +22,14 @@ public class SignedRawTransaction extends RawTransaction {
     }
 
     public String getFrom() throws SignatureException {
-        Integer chainId = getChainId();
+        Long chainId = getChainId();
         byte[] encodedTransaction;
         if (null == chainId) {
             encodedTransaction = TransactionEncoder.encode(this);
         } else {
             encodedTransaction = TransactionEncoder.encode(this, chainId.byteValue());
         }
-        byte v = signatureData.getV();
+        long v = signatureData.getV();
         byte[] r = signatureData.getR();
         byte[] s = signatureData.getS();
         Sign.SignatureData signatureDataV = new Sign.SignatureData(getRealV(v), r, s);
@@ -44,7 +44,7 @@ public class SignedRawTransaction extends RawTransaction {
         }
     }
 
-    private byte getRealV(byte v) {
+    private long getRealV(long v) {
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
             return v;
         }
@@ -56,12 +56,12 @@ public class SignedRawTransaction extends RawTransaction {
         return (byte) (realV + inc);
     }
 
-    public Integer getChainId() {
-        byte v = signatureData.getV();
+    public Long getChainId() {
+        long v = signatureData.getV();
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
             return null;
         }
-        Integer chainId = (v - CHAIN_ID_INC) / 2;
+        Long chainId = (v - CHAIN_ID_INC) / 2;
         return chainId;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -25,7 +25,7 @@ public class TransactionEncoder {
     }
 
     public static byte[] signMessage(
-            RawTransaction rawTransaction, byte chainId, Credentials credentials) {
+            RawTransaction rawTransaction, long chainId, Credentials credentials) {
         byte[] encodedTransaction = encode(rawTransaction, chainId);
         Sign.SignatureData signatureData = Sign.signMessage(
                 encodedTransaction, credentials.getEcKeyPair());
@@ -35,8 +35,8 @@ public class TransactionEncoder {
     }
 
     public static Sign.SignatureData createEip155SignatureData(
-            Sign.SignatureData signatureData, byte chainId) {
-        byte v = (byte) (signatureData.getV() + (chainId << 1) + 8);
+            Sign.SignatureData signatureData, long chainId) {
+        long v = signatureData.getV() + (chainId << 1) + 8;
 
         return new Sign.SignatureData(
                 v, signatureData.getR(), signatureData.getS());
@@ -47,6 +47,10 @@ public class TransactionEncoder {
     }
 
     public static byte[] encode(RawTransaction rawTransaction, byte chainId) {
+        return encode(rawTransaction, (long) chainId);
+    }
+
+    public static byte[] encode(RawTransaction rawTransaction, long chainId) {
         Sign.SignatureData signatureData = new Sign.SignatureData(
                 chainId, new byte[] {}, new byte[] {});
         return encode(rawTransaction, signatureData);

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -75,7 +75,7 @@ public class TransactionDecoderTest {
         BigInteger gasLimit = BigInteger.TEN;
         String to = "0x0add5355";
         BigInteger value = BigInteger.valueOf(Long.MAX_VALUE);
-        Integer chainId = 1;
+        Long chainId = 1L;
         RawTransaction rawTransaction = RawTransaction.createEtherTransaction(
                 nonce, gasPrice, gasLimit, to, value);
         byte[] signedMessage = TransactionEncoder.signMessage(


### PR DESCRIPTION
### What does this PR do?
Allow using long Chain ID.

### Where should the reviewer start?
public static byte[] signMessage(RawTransaction rawTransaction, long chainId, Credentials credentials)

### Why is it needed?
It needed because some network have long ID. For example PIRL Chain ID is 3125659152. Byte can't accept this value.

