### PR TITLE
Updated the Pantheon interface and implementation to deprecate misspelt method names and add in the correct spelling.

### DIFF
--- a/pantheon/src/main/java/org/web3j/protocol/pantheon/JsonRpc2_0Pantheon.java
+++ b/pantheon/src/main/java/org/web3j/protocol/pantheon/JsonRpc2_0Pantheon.java
@@ -38,7 +38,7 @@ public class JsonRpc2_0Pantheon extends JsonRpc2_0Web3j implements Pantheon {
     }
 
     @Override
-    public Request<?, BooleanResponse> clicqueDiscard(String address) {
+    public Request<?, BooleanResponse> cliqueDiscard(String address) {
         return new Request<>(
                 "clique_discard",
                 Arrays.asList(address),
@@ -47,7 +47,7 @@ public class JsonRpc2_0Pantheon extends JsonRpc2_0Web3j implements Pantheon {
     }
 
     @Override
-    public Request<?, EthAccounts> clicqueGetSigners(DefaultBlockParameter defaultBlockParameter) {
+    public Request<?, EthAccounts> cliqueGetSigners(DefaultBlockParameter defaultBlockParameter) {
         return new Request<>(
                 "clique_getSigners",
                 Arrays.asList(defaultBlockParameter.getValue()),
@@ -56,7 +56,7 @@ public class JsonRpc2_0Pantheon extends JsonRpc2_0Web3j implements Pantheon {
     }
 
     @Override
-    public Request<?, EthAccounts> clicqueGetSignersAtHash(String blockHash) {
+    public Request<?, EthAccounts> cliqueGetSignersAtHash(String blockHash) {
         return new Request<>(
                 "clique_getSignersAtHash",
                 Arrays.asList(blockHash),

--- a/pantheon/src/main/java/org/web3j/protocol/pantheon/Pantheon.java
+++ b/pantheon/src/main/java/org/web3j/protocol/pantheon/Pantheon.java
@@ -21,11 +21,32 @@ public interface Pantheon extends Web3j {
 
     Request<?, BooleanResponse> minerStop();
 
-    Request<?, BooleanResponse> clicqueDiscard(String address);
+    /**
+     * @deprecated This is deprecated as the method name is wrong.
+     */
+    default Request<?, BooleanResponse> clicqueDiscard(String address) {
+        return cliqueDiscard(address);
+    }
 
-    Request<?, EthAccounts> clicqueGetSigners(DefaultBlockParameter defaultBlockParameter);
+    /**
+     * @deprecated This is deprecated as the method name is wrong.
+     */
+    default Request<?, EthAccounts> clicqueGetSigners(DefaultBlockParameter defaultBlockParameter) {
+        return cliqueGetSigners(defaultBlockParameter);
+    }
 
-    Request<?, EthAccounts> clicqueGetSignersAtHash(String blockHash);
+    /**
+     * @deprecated This is deprecated as the method name is wrong.
+     */
+    default Request<?, EthAccounts> clicqueGetSignersAtHash(String blockHash) {
+        return cliqueGetSignersAtHash(blockHash);
+    }
+
+    Request<?, BooleanResponse> cliqueDiscard(String address);
+
+    Request<?, EthAccounts> cliqueGetSigners(DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, EthAccounts> cliqueGetSignersAtHash(String blockHash);
 
     Request<?, BooleanResponse> cliquePropose(String address, Boolean signerAddition);
 


### PR DESCRIPTION
### What does this PR do?
Deprecates some methods that have the wrong name, delegates and refactors to use the right name.

The spelling is `clique`, not `clicque`

The use of defaults and deprecation is there to help people have time to move to the right version.

### Where should the reviewer start?
It's small and pretty clear. 
### Why is it needed?
So people use the right methods.
