### PR TITLE
Create Type, TypeReference, Function on the fly from ABI without compiling java code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false  # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 

--- a/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
+++ b/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
@@ -1,6 +1,9 @@
 package org.web3j.abi;
 
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,6 +13,9 @@ import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Uint;
 import org.web3j.crypto.Hash;
 import org.web3j.utils.Numeric;
+
+import static org.web3j.abi.TypeDecoder.instantiateType;
+import static org.web3j.abi.TypeReference.makeTypeReference;
 
 /**
  * <p>Ethereum Contract Application Binary Interface (ABI) encoding for functions.
@@ -87,5 +93,17 @@ public class FunctionEncoder {
         byte[] input = methodSignature.getBytes();
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);
+    }
+    public static Function encodeFunction(String fnname, List<String> solidity_inputtypes, List<Object> arguments, List<String> solidity_output_types) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        List<Type> encoded_input = new ArrayList<>();
+        Iterator argit = arguments.iterator();
+        for (String st : solidity_inputtypes) {
+            encoded_input.add(instantiateType(st, argit.next()));
+        }
+        List<TypeReference<?>> encoded_output = new ArrayList<>();
+        for (String st : solidity_output_types) {
+            encoded_output.add(makeTypeReference(st));
+        }
+        return new Function(fnname, encoded_input, encoded_output);
     }
 }

--- a/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
+++ b/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
@@ -43,6 +43,22 @@ public class FunctionEncoder {
         return encodeParameters(parameters, new StringBuilder());
     }
 
+    public static Function makeFunction(String fnname, List<String> solidityInputTypes,
+                                          List<Object> arguments, List<String> solidityOutputTypes)
+            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
+            IllegalAccessException, InvocationTargetException {
+        List<Type> encodedInput = new ArrayList<>();
+        Iterator argit = arguments.iterator();
+        for (String st : solidityInputTypes) {
+            encodedInput.add(instantiateType(st, argit.next()));
+        }
+        List<TypeReference<?>> encodedOutput = new ArrayList<>();
+        for (String st : solidityOutputTypes) {
+            encodedOutput.add(makeTypeReference(st));
+        }
+        return new Function(fnname, encodedInput, encodedOutput);
+    }
+
     private static String encodeParameters(List<Type> parameters, StringBuilder result) {
         int dynamicDataOffset = getLength(parameters) * Type.MAX_BYTE_LENGTH;
         StringBuilder dynamicData = new StringBuilder();
@@ -93,21 +109,5 @@ public class FunctionEncoder {
         byte[] input = methodSignature.getBytes();
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);
-    }
-
-    public static Function encodeFunction(String fnname, List<String> solidityInputtypes,
-            List<Object> arguments, List<String> solidityOutputTypes)
-            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
-            IllegalAccessException, InvocationTargetException {
-        List<Type> encodedInput = new ArrayList<>();
-        Iterator argit = arguments.iterator();
-        for (String st : solidityInputtypes) {
-            encodedInput.add(instantiateType(st, argit.next()));
-        }
-        List<TypeReference<?>> encodedOutput = new ArrayList<>();
-        for (String st : solidityOutputTypes) {
-            encodedOutput.add(makeTypeReference(st));
-        }
-        return new Function(fnname, encodedInput, encodedOutput);
     }
 }

--- a/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
+++ b/abi/src/main/java/org/web3j/abi/FunctionEncoder.java
@@ -94,16 +94,20 @@ public class FunctionEncoder {
         byte[] hash = Hash.sha3(input);
         return Numeric.toHexString(hash).substring(0, 10);
     }
-    public static Function encodeFunction(String fnname, List<String> solidity_inputtypes, List<Object> arguments, List<String> solidity_output_types) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        List<Type> encoded_input = new ArrayList<>();
+
+    public static Function encodeFunction(String fnname, List<String> solidityInputtypes,
+            List<Object> arguments, List<String> solidityOutputTypes)
+            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
+            IllegalAccessException, InvocationTargetException {
+        List<Type> encodedInput = new ArrayList<>();
         Iterator argit = arguments.iterator();
-        for (String st : solidity_inputtypes) {
-            encoded_input.add(instantiateType(st, argit.next()));
+        for (String st : solidityInputtypes) {
+            encodedInput.add(instantiateType(st, argit.next()));
         }
-        List<TypeReference<?>> encoded_output = new ArrayList<>();
-        for (String st : solidity_output_types) {
-            encoded_output.add(makeTypeReference(st));
+        List<TypeReference<?>> encodedOutput = new ArrayList<>();
+        for (String st : solidityOutputTypes) {
+            encodedOutput.add(makeTypeReference(st));
         }
-        return new Function(fnname, encoded_input, encoded_output);
+        return new Function(fnname, encodedInput, encodedOutput);
     }
 }

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -374,10 +374,11 @@ public class TypeDecoder {
         } else if (Utf8String.class.isAssignableFrom(rc)) {
             constructorArg = value.toString();
         } else if (Address.class.isAssignableFrom(rc)) {
-            if(value instanceof BigInteger || value instanceof Uint160)
+            if (value instanceof BigInteger || value instanceof Uint160) {
                 constructorArg = value;
-            else
+            } else {
                 constructorArg = value.toString();
+            }
         } else if (Bool.class.isAssignableFrom(rc)) {
             if (value instanceof Boolean) {
                 constructorArg = value;

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -374,7 +374,10 @@ public class TypeDecoder {
         } else if (Utf8String.class.isAssignableFrom(rc)) {
             constructorArg = value.toString();
         } else if (Address.class.isAssignableFrom(rc)) {
-            constructorArg = value.toString();
+            if(value instanceof BigInteger || value instanceof Uint160)
+                constructorArg = value;
+            else
+                constructorArg = value.toString();
         } else if (Bool.class.isAssignableFrom(rc)) {
             if (value instanceof Boolean) {
                 constructorArg = value;

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -172,25 +172,11 @@ public class TypeDecoder {
                     + arraySize);
             listcons = arrayClass.getConstructor(new Class[]{Class.class, List.class});
         }
-        //create a list of transformed arguments
+        //create a list of arguments coerced to the correct type of sub-TypeReference
         ArrayList transformedList = new ArrayList(values.size());
-        java.lang.reflect.Type subtype = ((ParameterizedType) ref.getType())
-                .getActualTypeArguments()[0];
+        TypeReference subTypeReference = ref.getSubTypeReference();
         for (Object o : values) {
-            TypeReference elementTR;
-            //array of arrays
-            if (subtype instanceof ParameterizedType) {
-                elementTR = new TypeReference<Array>() {
-                    @Override
-                    public java.lang.reflect.Type getType() {
-                        return subtype;
-                    }
-                };
-            } else {
-                //array of basic types
-                elementTR = TypeReference.create((Class) subtype);
-            }
-            transformedList.add(instantiateType(elementTR, o));
+            transformedList.add(instantiateType(subTypeReference, o));
         }
         return (Type) listcons.newInstance(ref.getClassType(), transformedList);
     }

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -10,8 +10,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import org.web3j.abi.TypeReference.StaticArrayTypeReference;
-import org.web3j.abi.datatypes.*;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Array;
+import org.web3j.abi.datatypes.Bool;
+import org.web3j.abi.datatypes.Bytes;
+import org.web3j.abi.datatypes.BytesType;
+import org.web3j.abi.datatypes.DynamicArray;
+import org.web3j.abi.datatypes.DynamicBytes;
+import org.web3j.abi.datatypes.Fixed;
+import org.web3j.abi.datatypes.FixedPointType;
+import org.web3j.abi.datatypes.Int;
+import org.web3j.abi.datatypes.IntType;
+import org.web3j.abi.datatypes.NumericType;
+import org.web3j.abi.datatypes.StaticArray;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.Ufixed;
+import org.web3j.abi.datatypes.Uint;
+import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Uint160;
 import org.web3j.utils.Numeric;
 
@@ -267,6 +282,7 @@ public class TypeDecoder {
                     e);
         }
     }
+
     static BigInteger asBigInteger(Object arg) {
         if (arg instanceof BigInteger) {
             return (BigInteger) arg;
@@ -281,6 +297,7 @@ public class TypeDecoder {
         }
         return null;
     }
+
     static List arrayToList(Object array) {
         int len = java.lang.reflect.Array.getLength(array);
         ArrayList rslt = new ArrayList(len);
@@ -289,44 +306,53 @@ public class TypeDecoder {
         }
         return rslt;
     }
-    public static Type instantiateType(String solidity_type, Object value) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException, ClassNotFoundException {
-        return instantiateType(makeTypeReference(solidity_type), value);
+
+    public static Type instantiateType(String solidityType, Object value) throws
+            InvocationTargetException, NoSuchMethodException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException {
+        return instantiateType(makeTypeReference(solidityType), value);
     }
-    public static Type instantiateType(TypeReference ref, Object value) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException {
+
+    public static Type instantiateType(TypeReference ref, Object value) throws
+            NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+            InstantiationException, ClassNotFoundException {
         Class rc = ref.getClassType();
-        if(Array.class.isAssignableFrom(rc)){
+        if (Array.class.isAssignableFrom(rc)) {
             List values;
             if (value instanceof List) {
                 values = (List) value;
             } else if (value.getClass().isArray()) {
                 values = arrayToList(value);
             } else {
-                throw new ClassCastException("Arg of type " + value.getClass() + " should be a list to instantiate web3j Array");
+                throw new ClassCastException("Arg of type " + value.getClass()
+                        + " should be a list to instantiate web3j Array");
             }
             Constructor listcons;
-            int arraySize = ref instanceof TypeReference.StaticArrayTypeReference ? ((TypeReference.StaticArrayTypeReference) ref).getSize() : -1;
+            int arraySize = ref instanceof TypeReference.StaticArrayTypeReference
+                    ? ((TypeReference.StaticArrayTypeReference) ref).getSize() : -1;
             if (arraySize <= 0) {
                 listcons = DynamicArray.class.getConstructor(new Class[]{Class.class, List.class});
             } else {
-                Class arrayClass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray" + arraySize);
+                Class arrayClass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
+                        + arraySize);
                 listcons = arrayClass.getConstructor(new Class[]{Class.class, List.class});
             }
             //create a list of transformed arguments
             ArrayList transformedList = new ArrayList(values.size());
-            java.lang.reflect.Type subtype = ((ParameterizedType) ref.getType()).getActualTypeArguments()[0];
+            java.lang.reflect.Type subtype = ((ParameterizedType) ref.getType())
+                    .getActualTypeArguments()[0];
             for (Object o : values) {
                 TypeReference elementTR;
                 //array of arrays
-                if(subtype instanceof ParameterizedType){
+                if (subtype instanceof ParameterizedType) {
                     elementTR = new TypeReference<Array>() {
                         @Override
-                        public java.lang.reflect.Type getType(){
+                        public java.lang.reflect.Type getType() {
                             return subtype;
                         }
                     };
-                }
-                //array of basic types
-                else{
+                } else {
+                    //array of basic types
                     elementTR = TypeReference.create((Class) subtype);
                 }
                 transformedList.add(instantiateType(elementTR, o));
@@ -358,7 +384,8 @@ public class TypeDecoder {
             }
         }
         if (constructorArg == null) {
-            throw new InstantiationException("Could not create type " + rc + " from arg " + value.toString() + " of type " + value.getClass());
+            throw new InstantiationException("Could not create type " + rc + " from arg "
+                    + value.toString() + " of type " + value.getClass());
         }
         Constructor cons = rc.getConstructor(new Class[]{constructorArg.getClass()});
         return (Type) cons.newInstance(constructorArg);

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -149,8 +149,7 @@ public class TypeDecoder {
         }
         return Type.MAX_BIT_LENGTH;
     }
-
-
+    
     static Type instantiateArrayType(TypeReference ref, Object value) throws
             NoSuchMethodException, IllegalAccessException, InvocationTargetException,
             InstantiationException, ClassNotFoundException {

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -43,6 +43,18 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         this.indexed = indexed;
     }
 
+    /**
+     * getSubTypeReference() is used by instantiateType to see what TypeReference
+     * is wrapped by this one. eg calling getSubTypeReference() on a TypeReference
+     * to DynamicArray[StaticArray3[Uint256]] would return a TypeReference to StaticArray3[Uint256]
+     *
+     * @return the type wrapped by this Array TypeReference, or null if not Array
+     */
+
+    TypeReference getSubTypeReference() {
+        return null;
+    }
+
     public int compareTo(TypeReference<T> o) {
         // taken from the blog post comments - this results in an errror if the
         // type parameter is left out.
@@ -56,6 +68,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     public boolean isIndexed() {
         return indexed;
     }
+
 
     /**
      * Workaround to ensure type does not come back as T due to erasure, this enables you to
@@ -150,11 +163,16 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
             if (arraySize == null || arraySize.equals("")) {
                 arrayWrappedType = new TypeReference<DynamicArray>(indexed) {
                     @Override
+                    TypeReference getSubTypeReference() {
+                        return baseTr;
+                    }
+
+                    @Override
                     public java.lang.reflect.Type getType() {
                         return new ParameterizedType() {
                             @Override
                             public java.lang.reflect.Type[] getActualTypeArguments() {
-                                return new java.lang.reflect.Type[]{baseTr.getType()};
+                                return new java.lang.reflect.Type[]{ baseTr.getType() };
                             }
 
                             @Override
@@ -180,6 +198,12 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                 }
                 arrayWrappedType = new TypeReference
                         .StaticArrayTypeReference<StaticArray>(arraySizeInt) {
+
+                    @Override
+                    TypeReference getSubTypeReference() {
+                        return baseTr;
+                    }
+
                     @Override
                     public boolean isIndexed() {
                         return indexed;
@@ -190,7 +214,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                         return new ParameterizedType() {
                             @Override
                             public java.lang.reflect.Type[] getActualTypeArguments() {
-                                return new java.lang.reflect.Type[]{baseTr.getType()};
+                                return new java.lang.reflect.Type[]{ baseTr.getType() };
                             }
 
                             @Override

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -1,7 +1,15 @@
 package org.web3j.abi;
 
+import org.web3j.abi.datatypes.DynamicArray;
+import org.web3j.abi.datatypes.Int;
+import org.web3j.abi.datatypes.StaticArray;
+import org.web3j.abi.datatypes.Uint;
+import org.web3j.abi.datatypes.generated.AbiTypes;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Type wrapper to get around limitations of Java's type erasure.
@@ -16,6 +24,7 @@ import java.lang.reflect.Type;
  */
 public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         implements Comparable<TypeReference<T>> {
+    protected static Pattern ARRAY_SUFFIX = Pattern.compile("\\[(\\d*)\\]$");
 
     private final Type type;
     private final boolean indexed;
@@ -66,12 +75,35 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     }
 
     public static <T extends org.web3j.abi.datatypes.Type> TypeReference<T> create(Class<T> cls) {
-        return new TypeReference<T>() {
-            @Override
-            public Type getType() {
+        return create(cls, false);
+    }
+    public static <T extends org.web3j.abi.datatypes.Type> TypeReference<T> create(Class<T> cls, boolean indexed) {
+        return new TypeReference<T>(indexed) {
+            public java.lang.reflect.Type getType() {
                 return cls;
             }
         };
+    }
+    /**
+     * This is a helper method that only works for atomic types (uint, bytes, etc). Array types must be wrapped by a java.lang.reflect.ParamaterizedType
+     * @param solidity_type
+     * @return
+     * @throws ClassNotFoundException
+     */
+
+    protected static Class getAtomicTypeClass(String solidity_type) throws ClassNotFoundException {
+        Matcher m = ARRAY_SUFFIX.matcher(solidity_type);
+        if (m.find()) {
+            throw new ClassNotFoundException("getTypeClass does not work with array types. See makeTypeRefernce()");
+        }
+        switch (solidity_type) {
+            case "int":
+                return Int.class;
+            case "uint":
+                return Uint.class;
+        }
+        Class c = AbiTypes.getType(solidity_type);
+        return c;
     }
 
     public abstract static class StaticArrayTypeReference<T extends org.web3j.abi.datatypes.Type>
@@ -87,5 +119,68 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         public int getSize() {
             return size;
         }
+    }
+    public static TypeReference makeTypeReference(String solidity_type) throws ClassNotFoundException {
+        return makeTypeReference(solidity_type,false);
+    }
+    public static TypeReference makeTypeReference(String solidity_type, final boolean indexed) throws ClassNotFoundException {
+        Matcher m = ARRAY_SUFFIX.matcher(solidity_type);
+        if(!m.find()) {
+            final Class tc = getAtomicTypeClass(solidity_type);
+            return create(tc, indexed);
+        }
+        String digits = m.group(1);
+        TypeReference baseTr = makeTypeReference(solidity_type.substring(0,solidity_type.length() - m.group(0).length()));
+        TypeReference<?> ref;
+        if (digits == null || digits.equals("")) {
+            ref = new TypeReference<DynamicArray>(indexed) {
+                @Override
+                public java.lang.reflect.Type getType(){
+                    return new ParameterizedType() {
+                        @Override
+                        public java.lang.reflect.Type[] getActualTypeArguments() {
+                            return new java.lang.reflect.Type[]{baseTr.getType()};
+                        }
+
+                        @Override
+                        public java.lang.reflect.Type getRawType() {
+                            return DynamicArray.class;
+                        }
+
+                        @Override
+                        public java.lang.reflect.Type getOwnerType() {
+                            return Class.class;
+                        }
+                    };
+                }
+            };
+        }
+        else {
+            final Class arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray" + digits);
+            ref = new TypeReference.StaticArrayTypeReference<StaticArray>(Integer.parseInt(digits)){
+                @Override
+                public boolean isIndexed(){
+                    return indexed;
+                }
+                @Override
+                public java.lang.reflect.Type getType(){
+                    return new ParameterizedType() {
+                        @Override
+                        public java.lang.reflect.Type[] getActualTypeArguments() {
+                            return new java.lang.reflect.Type[]{baseTr.getType()};
+                        }
+                        @Override
+                        public java.lang.reflect.Type getRawType() {
+                           return arrayclass;
+                        }
+                        @Override
+                        public java.lang.reflect.Type getOwnerType() {
+                            return Class.class;
+                        }
+                    };
+                }
+            };
+        }
+        return ref;
     }
 }

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -25,7 +25,7 @@ import org.web3j.abi.datatypes.generated.AbiTypes;
  */
 public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         implements Comparable<TypeReference<T>> {
-    protected static Pattern ARRAY_SUFFIX = Pattern.compile("\\[(\\d*)\\]$");
+    protected static Pattern ARRAY_SUFFIX = Pattern.compile("\\[(\\d*)]$");
 
     private final Type type;
     private final boolean indexed;
@@ -93,7 +93,8 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
      * Array types must be wrapped by a java.lang.reflect.ParamaterizedType
      */
 
-    protected static Class getAtomicTypeClass(String solidityType) throws ClassNotFoundException {
+    protected static Class<? extends org.web3j.abi.datatypes.Type>
+            getAtomicTypeClass(String solidityType) throws ClassNotFoundException {
         Matcher m = ARRAY_SUFFIX.matcher(solidityType);
         if (m.find()) {
             throw new ClassNotFoundException("getAtomicTypeClass does not work with array types."
@@ -132,11 +133,12 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
             throws ClassNotFoundException {
         Matcher m = ARRAY_SUFFIX.matcher(solidityType);
         if (!m.find()) {
-            final Class tc = getAtomicTypeClass(solidityType);
-            return create(tc, indexed);
+            final Class<? extends org.web3j.abi.datatypes.Type> typeClass =
+                    getAtomicTypeClass(solidityType);
+            return create(typeClass, indexed);
         }
         String arraySize = m.group(1);
-        TypeReference baseTr = makeTypeReference(solidityType.substring(0,solidityType.length()
+        TypeReference baseTr = makeTypeReference(solidityType.substring(0, solidityType.length()
                 - m.group(0).length()));
         TypeReference<?> ref;
         if (arraySize == null || arraySize.equals("")) {
@@ -146,7 +148,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                     return new ParameterizedType() {
                         @Override
                         public java.lang.reflect.Type[] getActualTypeArguments() {
-                            return new java.lang.reflect.Type[]{baseTr.getType()};
+                            return new java.lang.reflect.Type[]{ baseTr.getType() };
                         }
 
                         @Override
@@ -163,14 +165,15 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
             };
         } else {
             final Class arrayclass;
-            if (Integer.parseInt((arraySize)) <= StaticArray.MAX_SIZE_OF_STATIC_ARRAY) {
+            int arraySizeInt = Integer.parseInt(arraySize);
+            if (arraySizeInt <= StaticArray.MAX_SIZE_OF_STATIC_ARRAY) {
                 arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
                         + arraySize);
             } else {
-                arrayclass = Class.forName("org.web3j.abi.datatypes.StaticArray");
+                arrayclass = StaticArray.class;
             }
             ref = new TypeReference
-                    .StaticArrayTypeReference<StaticArray>(Integer.parseInt(arraySize)) {
+                    .StaticArrayTypeReference<StaticArray>(arraySizeInt) {
                 @Override
                 public boolean isIndexed() {
                     return indexed;
@@ -181,7 +184,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                     return new ParameterizedType() {
                         @Override
                         public java.lang.reflect.Type[] getActualTypeArguments() {
-                            return new java.lang.reflect.Type[]{baseTr.getType()};
+                            return new java.lang.reflect.Type[]{ baseTr.getType() };
                         }
 
                         @Override

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -135,11 +135,11 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
             final Class tc = getAtomicTypeClass(solidityType);
             return create(tc, indexed);
         }
-        String digits = m.group(1);
+        String arraySize = m.group(1);
         TypeReference baseTr = makeTypeReference(solidityType.substring(0,solidityType.length()
                 - m.group(0).length()));
         TypeReference<?> ref;
-        if (digits == null || digits.equals("")) {
+        if (arraySize == null || arraySize.equals("")) {
             ref = new TypeReference<DynamicArray>(indexed) {
                 @Override
                 public java.lang.reflect.Type getType() {
@@ -162,10 +162,15 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                 }
             };
         } else {
-            final Class arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
-                    + digits);
+            final Class arrayclass;
+            if (Integer.parseInt((arraySize)) <= StaticArray.MAX_SIZE_OF_STATIC_ARRAY) {
+                arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
+                        + arraySize);
+            } else {
+                arrayclass = Class.forName("org.web3j.abi.datatypes.StaticArray");
+            }
             ref = new TypeReference
-                    .StaticArrayTypeReference<StaticArray>(Integer.parseInt(digits)) {
+                    .StaticArrayTypeReference<StaticArray>(Integer.parseInt(arraySize)) {
                 @Override
                 public boolean isIndexed() {
                     return indexed;

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -96,7 +96,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     protected static Class getAtomicTypeClass(String solidityType) throws ClassNotFoundException {
         Matcher m = ARRAY_SUFFIX.matcher(solidityType);
         if (m.find()) {
-            throw new ClassNotFoundException("getTypeClass does not work with array types."
+            throw new ClassNotFoundException("getAtomicTypeClass does not work with array types."
                     + " See makeTypeRefernce()");
         }
         switch (solidityType) {

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -25,7 +25,7 @@ import org.web3j.abi.datatypes.generated.AbiTypes;
  */
 public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         implements Comparable<TypeReference<T>> {
-    protected static Pattern ARRAY_SUFFIX = Pattern.compile("\\[(\\d*)]$");
+    protected static Pattern ARRAY_SUFFIX = Pattern.compile("\\[(\\d*)]");
 
     private final Type type;
     private final boolean indexed;
@@ -131,75 +131,90 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
 
     public static TypeReference makeTypeReference(String solidityType, final boolean indexed)
             throws ClassNotFoundException {
-        Matcher m = ARRAY_SUFFIX.matcher(solidityType);
-        if (!m.find()) {
+        Matcher nextSquareBrackets = ARRAY_SUFFIX.matcher(solidityType);
+        if (!nextSquareBrackets.find()) {
             final Class<? extends org.web3j.abi.datatypes.Type> typeClass =
                     getAtomicTypeClass(solidityType);
             return create(typeClass, indexed);
         }
-        String arraySize = m.group(1);
-        TypeReference baseTr = makeTypeReference(solidityType.substring(0, solidityType.length()
-                - m.group(0).length()));
-        TypeReference<?> ref;
-        if (arraySize == null || arraySize.equals("")) {
-            ref = new TypeReference<DynamicArray>(indexed) {
-                @Override
-                public java.lang.reflect.Type getType() {
-                    return new ParameterizedType() {
-                        @Override
-                        public java.lang.reflect.Type[] getActualTypeArguments() {
-                            return new java.lang.reflect.Type[]{ baseTr.getType() };
-                        }
 
-                        @Override
-                        public java.lang.reflect.Type getRawType() {
-                            return DynamicArray.class;
-                        }
+        int lastReadStringPosition = nextSquareBrackets.start();
+        final Class<? extends org.web3j.abi.datatypes.Type> baseClass =
+                getAtomicTypeClass(solidityType.substring(0,lastReadStringPosition));
+        TypeReference arrayWrappedType = create(baseClass,indexed);
+        final int len = solidityType.length();
+        //for each [\d*], wrap the previous TypeReference in an array
+        while (lastReadStringPosition < len) {
+            String arraySize = nextSquareBrackets.group(1);
+            final TypeReference baseTr = arrayWrappedType;
+            if (arraySize == null || arraySize.equals("")) {
+                arrayWrappedType = new TypeReference<DynamicArray>(indexed) {
+                    @Override
+                    public java.lang.reflect.Type getType() {
+                        return new ParameterizedType() {
+                            @Override
+                            public java.lang.reflect.Type[] getActualTypeArguments() {
+                                return new java.lang.reflect.Type[]{baseTr.getType()};
+                            }
 
-                        @Override
-                        public java.lang.reflect.Type getOwnerType() {
-                            return Class.class;
-                        }
-                    };
-                }
-            };
-        } else {
-            final Class arrayclass;
-            int arraySizeInt = Integer.parseInt(arraySize);
-            if (arraySizeInt <= StaticArray.MAX_SIZE_OF_STATIC_ARRAY) {
-                arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
-                        + arraySize);
+                            @Override
+                            public java.lang.reflect.Type getRawType() {
+                                return DynamicArray.class;
+                            }
+
+                            @Override
+                            public java.lang.reflect.Type getOwnerType() {
+                                return Class.class;
+                            }
+                        };
+                    }
+                };
             } else {
-                arrayclass = StaticArray.class;
+                final Class arrayclass;
+                int arraySizeInt = Integer.parseInt(arraySize);
+                if (arraySizeInt <= StaticArray.MAX_SIZE_OF_STATIC_ARRAY) {
+                    arrayclass = Class.forName("org.web3j.abi.datatypes.generated.StaticArray"
+                            + arraySize);
+                } else {
+                    arrayclass = StaticArray.class;
+                }
+                arrayWrappedType = new TypeReference
+                        .StaticArrayTypeReference<StaticArray>(arraySizeInt) {
+                    @Override
+                    public boolean isIndexed() {
+                        return indexed;
+                    }
+
+                    @Override
+                    public java.lang.reflect.Type getType() {
+                        return new ParameterizedType() {
+                            @Override
+                            public java.lang.reflect.Type[] getActualTypeArguments() {
+                                return new java.lang.reflect.Type[]{baseTr.getType()};
+                            }
+
+                            @Override
+                            public java.lang.reflect.Type getRawType() {
+                                return arrayclass;
+                            }
+
+                            @Override
+                            public java.lang.reflect.Type getOwnerType() {
+                                return Class.class;
+                            }
+                        };
+                    }
+                };
             }
-            ref = new TypeReference
-                    .StaticArrayTypeReference<StaticArray>(arraySizeInt) {
-                @Override
-                public boolean isIndexed() {
-                    return indexed;
-                }
-
-                @Override
-                public java.lang.reflect.Type getType() {
-                    return new ParameterizedType() {
-                        @Override
-                        public java.lang.reflect.Type[] getActualTypeArguments() {
-                            return new java.lang.reflect.Type[]{ baseTr.getType() };
-                        }
-
-                        @Override
-                        public java.lang.reflect.Type getRawType() {
-                            return arrayclass;
-                        }
-
-                        @Override
-                        public java.lang.reflect.Type getOwnerType() {
-                            return Class.class;
-                        }
-                    };
-                }
-            };
+            lastReadStringPosition = nextSquareBrackets.end();
+            nextSquareBrackets = ARRAY_SUFFIX.matcher(solidityType);
+            //cant find any more [] and string isn't fully parsed
+            if (!nextSquareBrackets.find(lastReadStringPosition)
+                    && lastReadStringPosition != len) {
+                throw new ClassNotFoundException("Unable to make TypeReference from "
+                        + solidityType);
+            }
         }
-        return ref;
+        return arrayWrappedType;
     }
 }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -1,16 +1,12 @@
 package org.web3j.abi;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 
 import org.junit.Test;
 
-import org.web3j.abi.datatypes.Address;
-import org.web3j.abi.datatypes.Bool;
-import org.web3j.abi.datatypes.Bytes;
-import org.web3j.abi.datatypes.DynamicArray;
-import org.web3j.abi.datatypes.DynamicBytes;
-import org.web3j.abi.datatypes.StaticArray;
-import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.*;
 import org.web3j.abi.datatypes.generated.Bytes1;
 import org.web3j.abi.datatypes.generated.Bytes4;
 import org.web3j.abi.datatypes.generated.Bytes6;
@@ -35,6 +31,21 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeBool(
                 "0000000000000000000000000000000000000000000000000000000000000001", 0),
                 is(new Bool(true)));
+        try {
+            assertThat(TypeDecoder.instantiateType ("bool",true),
+                    is(new Bool(true)));
+            assertThat(TypeDecoder.instantiateType ("bool",1),
+                    is(new Bool(true)));
+            assertThat(TypeDecoder.instantiateType ("bool",false),
+                    is(new Bool(false)));
+            assertThat(TypeDecoder.instantiateType ("bool",0),
+                    is(new Bool(false)));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+
     }
 
     @Test
@@ -76,6 +87,13 @@ public class TypeDecoderTest {
                 ),
                 is(new Uint64(new BigInteger(
                         "0ffffffffffffffff", 16))));
+        try {
+            assertThat(TypeDecoder.instantiateType ("uint",123),
+                    is(new Uint(BigInteger.valueOf(123))));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -109,6 +127,16 @@ public class TypeDecoderTest {
                 Int256.class
                 ),
                 is(new Int256(BigInteger.valueOf(-1))));
+        try {
+            assertThat(TypeDecoder.instantiateType ("int",123),
+                    is(new Int(BigInteger.valueOf(123))));
+            assertThat(TypeDecoder.instantiateType ("int",-123),
+                    is(new Int(BigInteger.valueOf(-123))));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     /*
@@ -163,7 +191,8 @@ public class TypeDecoderTest {
 
     @Test
     public void testStaticBytes() {
-        Bytes6 staticBytes = new Bytes6(new byte[] { 0, 1, 2, 3, 4, 5 });
+        byte[] testbytes = new byte[] { 0, 1, 2, 3, 4, 5 };
+        Bytes6 staticBytes = new Bytes6(testbytes);
         assertThat(TypeDecoder.decodeBytes(
                 "0001020304050000000000000000000000000000000000000000000000000000", Bytes6.class),
                 is(staticBytes));
@@ -177,11 +206,19 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeBytes(
                 "6461766500000000000000000000000000000000000000000000000000000000", Bytes4.class),
                 is(dave));
+        try {
+            assertThat(TypeDecoder.instantiateType ("bytes6",testbytes),
+                    is(new Bytes6(testbytes)));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
     public void testDynamicBytes() {
-        DynamicBytes dynamicBytes = new DynamicBytes(new byte[] { 0, 1, 2, 3, 4, 5 });
+        byte[] testbytes = new byte[] { 0, 1, 2, 3, 4, 5 };
+        DynamicBytes dynamicBytes = new DynamicBytes(testbytes);
         assertThat(TypeDecoder.decodeDynamicBytes(
                 "0000000000000000000000000000000000000000000000000000000000000006"  // length
                         + "0001020304050000000000000000000000000000000000000000000000000000", 0),
@@ -227,6 +264,13 @@ public class TypeDecoderTest {
                         + "74206d6f6c6c697420616e696d20696420657374206c61626f72756d2e000000",
                 0),
                 is(loremIpsum));
+        try {
+            assertThat(TypeDecoder.instantiateType ("bytes",testbytes),
+                    is(new DynamicBytes(testbytes)));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -234,6 +278,16 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeAddress(
                 "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                 is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+        assertThat(TypeDecoder.decodeAddress(
+                "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+                is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+        try {
+            assertThat(TypeDecoder.instantiateType ("address","0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+                    is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -242,6 +296,13 @@ public class TypeDecoderTest {
                 "000000000000000000000000000000000000000000000000000000000000000d"  // length
                         + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000", 0),
                 is(new Utf8String("Hello, world!")));
+        try {
+            assertThat(TypeDecoder.instantiateType ("string","Hello, world!"),
+                    is(new Utf8String("Hello, world!")));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -267,6 +328,15 @@ public class TypeDecoderTest {
                 equalTo(new StaticArray2<>(Utf8String.class,
                         new Utf8String("Hello, world!"),
                         new Utf8String("world! Hello,"))));
+        try {
+            StaticArray2 arr = (StaticArray2) TypeDecoder.instantiateType ("uint256[2]",new long[]{10,Long.MAX_VALUE});
+            assert(arr instanceof  StaticArray2);
+            assertThat(arr.getValue().get(0), is(new Uint256(BigInteger.TEN)));
+            assertThat(arr.getValue().get(1), is(new Uint256(BigInteger.valueOf(Long.MAX_VALUE))));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -277,6 +347,19 @@ public class TypeDecoderTest {
                 new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(0) {},
                 0), is("invalid"));
     }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testEmptyStaticArrayInstantiateType() throws ClassNotFoundException {
+        try {
+            TypeDecoder.instantiateType ("uint256[0]",new long[]{});
+        }
+        catch (InvocationTargetException e) {}
+        catch (NoSuchMethodException e) {}
+        catch (InstantiationException e) {}
+        catch (IllegalAccessException e) {}
+    }
+
+
 
     @Test
     public void testDynamicArray() {
@@ -310,5 +393,15 @@ public class TypeDecoderTest {
                 equalTo(new DynamicArray<>(Utf8String.class,
                         new Utf8String("Hello, world!"),
                         new Utf8String("world! Hello,"))));
+
+        try {
+
+            DynamicArray arr = (DynamicArray) TypeDecoder.instantiateType("string[]",new String[]{"Hello, world!","world! Hello,"} );
+            assert(arr instanceof  DynamicArray);
+            assertThat(arr.getValue().get(0), is(new Utf8String("Hello, world!")));
+            assertThat(arr.getValue().get(1), is(new Utf8String("world! Hello,")));
+        } catch (Exception e){
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertThat;
 public class TypeDecoderTest {
 
     @Test
-    public void testBoolDecode() {
+    public void testBoolDecode() throws Exception {
         assertThat(TypeDecoder.decodeBool(
                 "0000000000000000000000000000000000000000000000000000000000000000", 0),
                 is(new Bool(false)));
@@ -40,21 +40,18 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeBool(
                 "0000000000000000000000000000000000000000000000000000000000000001", 0),
                 is(new Bool(true)));
-        try {
-            assertThat(TypeDecoder.instantiateType("bool",true),
-                    is(new Bool(true)));
-            assertThat(TypeDecoder.instantiateType("bool",1),
-                    is(new Bool(true)));
-            assertThat(TypeDecoder.instantiateType("bool",false),
-                    is(new Bool(false)));
-            assertThat(TypeDecoder.instantiateType("bool",0),
-                    is(new Bool(false)));
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        assertThat(TypeDecoder.instantiateType("bool", true),
+                is(new Bool(true)));
 
+        assertThat(TypeDecoder.instantiateType("bool", 1),
+                is(new Bool(true)));
+
+        assertThat(TypeDecoder.instantiateType("bool", false),
+                is(new Bool(false)));
+
+        assertThat(TypeDecoder.instantiateType("bool", 0),
+                is(new Bool(false)));
     }
 
     @Test
@@ -76,8 +73,7 @@ public class TypeDecoderTest {
     }
 
     @Test
-    public void testUintDecode() {
-
+    public void testUintDecode() throws Exception {
         assertThat(TypeDecoder.decodeNumeric(
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 Uint64.class
@@ -92,21 +88,17 @@ public class TypeDecoderTest {
 
         assertThat(TypeDecoder.decodeNumeric(
                 "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-                Uint64.class
+                Uint64. class
                 ),
                 is(new Uint64(new BigInteger(
                         "0ffffffffffffffff", 16))));
-        try {
-            assertThat(TypeDecoder.instantiateType("uint",123),
-                    is(new Uint(BigInteger.valueOf(123))));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        assertThat(TypeDecoder.instantiateType("uint", 123),
+                is(new Uint(BigInteger.valueOf(123))));
+
     }
 
     @Test
-    public void testIntDecode() {
+    public void testIntDecode() throws Exception {
         assertThat(TypeDecoder.decodeNumeric(
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 Int64.class
@@ -136,16 +128,13 @@ public class TypeDecoderTest {
                 Int256.class
                 ),
                 is(new Int256(BigInteger.valueOf(-1))));
-        try {
-            assertThat(TypeDecoder.instantiateType("int",123),
-                    is(new Int(BigInteger.valueOf(123))));
-            assertThat(TypeDecoder.instantiateType("int",-123),
-                    is(new Int(BigInteger.valueOf(-123))));
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        assertThat(TypeDecoder.instantiateType("int", 123),
+                is(new Int(BigInteger.valueOf(123))));
+
+        assertThat(TypeDecoder.instantiateType("int", -123),
+                is(new Int(BigInteger.valueOf(-123))));
+
     }
 
     /*
@@ -199,14 +188,14 @@ public class TypeDecoderTest {
     */
 
     @Test
-    public void testStaticBytes() {
-        byte[] testbytes = new byte[] { 0, 1, 2, 3, 4, 5 };
+    public void testStaticBytes() throws Exception {
+        byte[] testbytes = new byte[]{0, 1, 2, 3, 4, 5};
         Bytes6 staticBytes = new Bytes6(testbytes);
         assertThat(TypeDecoder.decodeBytes(
                 "0001020304050000000000000000000000000000000000000000000000000000", Bytes6.class),
                 is(staticBytes));
 
-        Bytes empty = new Bytes1(new byte[] { 0 });
+        Bytes empty = new Bytes1(new byte[]{0});
         assertThat(TypeDecoder.decodeBytes(
                 "0000000000000000000000000000000000000000000000000000000000000000", Bytes1.class),
                 is(empty));
@@ -215,34 +204,30 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeBytes(
                 "6461766500000000000000000000000000000000000000000000000000000000", Bytes4.class),
                 is(dave));
-        try {
-            assertThat(TypeDecoder.instantiateType("bytes6",testbytes),
-                    is(new Bytes6(testbytes)));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+
+        assertThat(TypeDecoder.instantiateType("bytes6", testbytes),
+                is(new Bytes6(testbytes)));
+
     }
 
     @Test
-    public void testDynamicBytes() {
-        byte[] testbytes = new byte[] { 0, 1, 2, 3, 4, 5 };
+    public void testDynamicBytes() throws Exception {
+        byte[] testbytes = new byte[]{0, 1, 2, 3, 4, 5};
         DynamicBytes dynamicBytes = new DynamicBytes(testbytes);
         assertThat(TypeDecoder.decodeDynamicBytes(
                 "0000000000000000000000000000000000000000000000000000000000000006"  // length
                         + "0001020304050000000000000000000000000000000000000000000000000000", 0),
                 is(dynamicBytes));
 
-        DynamicBytes empty = new DynamicBytes(new byte[] { 0 });
+        DynamicBytes empty = new DynamicBytes(new byte[]{0});
         assertThat(TypeDecoder.decodeDynamicBytes(
                 "0000000000000000000000000000000000000000000000000000000000000001"
                         + "0000000000000000000000000000000000000000000000000000000000000000", 0),
                 is(empty));
 
         DynamicBytes dave = new DynamicBytes("dave".getBytes());
-
         assertThat(TypeDecoder.decodeDynamicBytes(
-                        "0000000000000000000000000000000000000000000000000000000000000004"
+                "0000000000000000000000000000000000000000000000000000000000000004"
                         + "6461766500000000000000000000000000000000000000000000000000000000", 0),
                 is(dave));
 
@@ -273,85 +258,72 @@ public class TypeDecoderTest {
                         + "74206d6f6c6c697420616e696d20696420657374206c61626f72756d2e000000",
                 0),
                 is(loremIpsum));
-        try {
-            assertThat(TypeDecoder.instantiateType("bytes",testbytes),
-                    is(new DynamicBytes(testbytes)));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+
+        assertThat(TypeDecoder.instantiateType("bytes", testbytes),
+                is(new DynamicBytes(testbytes)));
     }
 
     @Test
-    public void testAddress() {
+    public void testAddress() throws Exception {
         assertThat(TypeDecoder.decodeAddress(
                 "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                 is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
-        assertThat(TypeDecoder.decodeAddress(
-                "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
-                is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
-        try {
-            assertThat(TypeDecoder.instantiateType("address",
-                    "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
-                    is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
-            assertThat(TypeDecoder.instantiateType("address",
-                    BigInteger.ONE),
-                    is(new Address("0x0000000000000000000000000000000000000001")));
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+        assertThat(TypeDecoder.decodeAddress(
+                "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+                is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+
+        assertThat(TypeDecoder.instantiateType("address",
+                "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+                is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+
+        assertThat(TypeDecoder.instantiateType("address",
+                BigInteger.ONE),
+                is(new Address("0x0000000000000000000000000000000000000001")));
     }
 
     @Test
-    public void testUtf8String() {
+    public void testUtf8String() throws Exception {
         assertThat(TypeDecoder.decodeUtf8String(
                 "000000000000000000000000000000000000000000000000000000000000000d"  // length
                         + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000", 0),
                 is(new Utf8String("Hello, world!")));
-        try {
-            assertThat(TypeDecoder.instantiateType("string","Hello, world!"),
-                    is(new Utf8String("Hello, world!")));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+
+        assertThat(TypeDecoder.instantiateType("string", "Hello, world!"),
+                is(new Utf8String("Hello, world!")));
     }
 
     @Test
-    public void testStaticArray() {
+    public void testStaticArray() throws Exception {
         assertThat(TypeDecoder.decodeStaticArray(
                 "000000000000000000000000000000000000000000000000000000000000000a"
-                + "0000000000000000000000000000000000000000000000007fffffffffffffff",
+                        + "0000000000000000000000000000000000000000000000007fffffffffffffff",
                 0,
-                new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) {},
+                new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) { },
                 2),
                 is(new StaticArray2<>(Uint256.class, new Uint256(BigInteger.TEN),
                         new Uint256(BigInteger.valueOf(Long.MAX_VALUE)))));
 
         assertThat(TypeDecoder.decodeStaticArray(
-                        "000000000000000000000000000000000000000000000000000000000000000d"
+                "000000000000000000000000000000000000000000000000000000000000000d"
                         + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000"
                         + "000000000000000000000000000000000000000000000000000000000000000d"
                         + "776f726c64212048656c6c6f2c00000000000000000000000000000000000000",
                 0,
-                new TypeReference.StaticArrayTypeReference<StaticArray<Utf8String>>(2){},
+                new TypeReference.StaticArrayTypeReference<StaticArray<Utf8String>>(2) { },
                 2
                 ),
                 equalTo(new StaticArray2<>(Utf8String.class,
                         new Utf8String("Hello, world!"),
                         new Utf8String("world! Hello,"))));
-        try {
-            StaticArray2 arr = (StaticArray2) TypeDecoder.instantiateType("uint256[2]",
-                    new long[]{10,Long.MAX_VALUE});
-            assert (arr instanceof  StaticArray2);
-            assertThat(arr.getValue().get(0), is(new Uint256(BigInteger.TEN)));
-            assertThat(arr.getValue().get(1), is(new Uint256(BigInteger.valueOf(Long.MAX_VALUE))));
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
-        }
+
+        StaticArray2 arr = (StaticArray2) TypeDecoder.instantiateType("uint256[2]",
+                new long[]{10, Long.MAX_VALUE});
+        assert (arr instanceof StaticArray2);
+
+        assertThat(arr.getValue().get(0), is(new Uint256(BigInteger.TEN)));
+
+        assertThat(arr.getValue().get(1), is(new Uint256(BigInteger.valueOf(Long.MAX_VALUE))));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -359,29 +331,18 @@ public class TypeDecoderTest {
         assertThat(TypeDecoder.decodeStaticArray(
                 "0000000000000000000000000000000000000000000000000000000000000000",
                 0,
-                new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(0) {},
+                new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(0) { },
                 0), is("invalid"));
     }
 
     @Test(expected = ClassNotFoundException.class)
-    public void testEmptyStaticArrayInstantiateType() throws ClassNotFoundException {
-        try {
-            TypeDecoder.instantiateType("uint256[0]",new long[]{});
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+    public void testEmptyStaticArrayInstantiateType() throws Exception {
+        TypeDecoder.instantiateType("uint256[0]", new long[]{});
     }
 
 
-
     @Test
-    public void testDynamicArray() {
+    public void testDynamicArray() throws Exception {
         assertThat(TypeDecoder.decodeDynamicArray(
                 "0000000000000000000000000000000000000000000000000000000000000000",  // length
                 0,
@@ -413,35 +374,28 @@ public class TypeDecoderTest {
                         new Utf8String("Hello, world!"),
                         new Utf8String("world! Hello,"))));
 
-        try {
+        DynamicArray arr = (DynamicArray) TypeDecoder.instantiateType("string[]",
+                new String[]{"Hello, world!", "world! Hello,"});
+        assert (arr instanceof DynamicArray);
 
-            DynamicArray arr = (DynamicArray) TypeDecoder.instantiateType("string[]",
-                    new String[]{"Hello, world!","world! Hello,"});
-            assert (arr instanceof  DynamicArray);
-            assertThat(arr.getValue().get(0), is(new Utf8String("Hello, world!")));
-            assertThat(arr.getValue().get(1), is(new Utf8String("world! Hello,")));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        assertThat(arr.getValue().get(0), is(new Utf8String("Hello, world!")));
+
+        assertThat(arr.getValue().get(1), is(new Utf8String("world! Hello,")));
     }
 
     @Test
-    public void multiDimArrays() {
+    public void multiDimArrays() throws Exception {
         byte[] bytes1d = new byte[]{1, 2, 3};
         byte[][] bytes2d = new byte[][]{bytes1d, bytes1d, bytes1d};
-        //byte[][][] byte3d = new byte[][][]{bytes2d, bytes2d, bytes2d};
+        assertThat(TypeDecoder.instantiateType("bytes", bytes1d), is(new DynamicBytes(bytes1d)));
 
-        try {
-            assertThat(TypeDecoder.instantiateType("bytes",bytes1d), is(new DynamicBytes(bytes1d)));
-            StaticArray3<DynamicArray<Uint256>> twoDim = (StaticArray3<DynamicArray<Uint256>>)
-                    TypeDecoder.instantiateType("uint256[][3]",bytes2d);
-            assert (twoDim instanceof StaticArray3);
-            DynamicArray<Uint256> row1 = twoDim.getValue().get(1);
-            assert (row1 instanceof DynamicArray);
-            assertThat(row1.getValue().get(2),is(new Uint256(3)));
+        StaticArray3<DynamicArray<Uint256>> twoDim = (StaticArray3<DynamicArray<Uint256>>)
+                TypeDecoder.instantiateType("uint256[][3]", bytes2d);
+        assert (twoDim instanceof StaticArray3);
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        DynamicArray<Uint256> row1 = twoDim.getValue().get(1);
+        assert (row1 instanceof DynamicArray);
+
+        assertThat(row1.getValue().get(2), is(new Uint256(3)));
     }
 }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -21,6 +21,7 @@ import org.web3j.abi.datatypes.generated.Bytes6;
 import org.web3j.abi.datatypes.generated.Int256;
 import org.web3j.abi.datatypes.generated.Int64;
 import org.web3j.abi.datatypes.generated.StaticArray2;
+import org.web3j.abi.datatypes.generated.StaticArray3;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint64;
 
@@ -415,6 +416,26 @@ public class TypeDecoderTest {
             assert (arr instanceof  DynamicArray);
             assertThat(arr.getValue().get(0), is(new Utf8String("Hello, world!")));
             assertThat(arr.getValue().get(1), is(new Utf8String("world! Hello,")));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void multiDimArrays() {
+        byte[] bytes1d = new byte[]{1, 2, 3};
+        byte[][] bytes2d = new byte[][]{bytes1d, bytes1d, bytes1d};
+        //byte[][][] byte3d = new byte[][][]{bytes2d, bytes2d, bytes2d};
+
+        try {
+            assertThat(TypeDecoder.instantiateType("bytes",bytes1d), is(new DynamicBytes(bytes1d)));
+            StaticArray3<DynamicArray<Uint256>> twoDim = (StaticArray3<DynamicArray<Uint256>>)
+                    TypeDecoder.instantiateType("uint256[][3]",bytes2d);
+            assert (twoDim instanceof StaticArray3);
+            DynamicArray<Uint256> row1 = twoDim.getValue().get(1);
+            assert (row1 instanceof DynamicArray);
+            assertThat(row1.getValue().get(2),is(new Uint256(3)));
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -6,7 +6,15 @@ import java.math.BigInteger;
 
 import org.junit.Test;
 
-import org.web3j.abi.datatypes.*;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Bool;
+import org.web3j.abi.datatypes.Bytes;
+import org.web3j.abi.datatypes.DynamicArray;
+import org.web3j.abi.datatypes.DynamicBytes;
+import org.web3j.abi.datatypes.Int;
+import org.web3j.abi.datatypes.StaticArray;
+import org.web3j.abi.datatypes.Uint;
+import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Bytes1;
 import org.web3j.abi.datatypes.generated.Bytes4;
 import org.web3j.abi.datatypes.generated.Bytes6;
@@ -32,13 +40,13 @@ public class TypeDecoderTest {
                 "0000000000000000000000000000000000000000000000000000000000000001", 0),
                 is(new Bool(true)));
         try {
-            assertThat(TypeDecoder.instantiateType ("bool",true),
+            assertThat(TypeDecoder.instantiateType("bool",true),
                     is(new Bool(true)));
-            assertThat(TypeDecoder.instantiateType ("bool",1),
+            assertThat(TypeDecoder.instantiateType("bool",1),
                     is(new Bool(true)));
-            assertThat(TypeDecoder.instantiateType ("bool",false),
+            assertThat(TypeDecoder.instantiateType("bool",false),
                     is(new Bool(false)));
-            assertThat(TypeDecoder.instantiateType ("bool",0),
+            assertThat(TypeDecoder.instantiateType("bool",0),
                     is(new Bool(false)));
 
         } catch (Exception e) {
@@ -88,7 +96,7 @@ public class TypeDecoderTest {
                 is(new Uint64(new BigInteger(
                         "0ffffffffffffffff", 16))));
         try {
-            assertThat(TypeDecoder.instantiateType ("uint",123),
+            assertThat(TypeDecoder.instantiateType("uint",123),
                     is(new Uint(BigInteger.valueOf(123))));
         } catch (Exception e) {
             e.printStackTrace();
@@ -128,9 +136,9 @@ public class TypeDecoderTest {
                 ),
                 is(new Int256(BigInteger.valueOf(-1))));
         try {
-            assertThat(TypeDecoder.instantiateType ("int",123),
+            assertThat(TypeDecoder.instantiateType("int",123),
                     is(new Int(BigInteger.valueOf(123))));
-            assertThat(TypeDecoder.instantiateType ("int",-123),
+            assertThat(TypeDecoder.instantiateType("int",-123),
                     is(new Int(BigInteger.valueOf(-123))));
 
         } catch (Exception e) {
@@ -207,7 +215,7 @@ public class TypeDecoderTest {
                 "6461766500000000000000000000000000000000000000000000000000000000", Bytes4.class),
                 is(dave));
         try {
-            assertThat(TypeDecoder.instantiateType ("bytes6",testbytes),
+            assertThat(TypeDecoder.instantiateType("bytes6",testbytes),
                     is(new Bytes6(testbytes)));
         } catch (Exception e) {
             e.printStackTrace();
@@ -265,7 +273,7 @@ public class TypeDecoderTest {
                 0),
                 is(loremIpsum));
         try {
-            assertThat(TypeDecoder.instantiateType ("bytes",testbytes),
+            assertThat(TypeDecoder.instantiateType("bytes",testbytes),
                     is(new DynamicBytes(testbytes)));
         } catch (Exception e) {
             e.printStackTrace();
@@ -282,7 +290,8 @@ public class TypeDecoderTest {
                 "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                 is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
         try {
-            assertThat(TypeDecoder.instantiateType ("address","0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+            assertThat(TypeDecoder.instantiateType("address",
+                    "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                     is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
         } catch (Exception e) {
             e.printStackTrace();
@@ -297,7 +306,7 @@ public class TypeDecoderTest {
                         + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000", 0),
                 is(new Utf8String("Hello, world!")));
         try {
-            assertThat(TypeDecoder.instantiateType ("string","Hello, world!"),
+            assertThat(TypeDecoder.instantiateType("string","Hello, world!"),
                     is(new Utf8String("Hello, world!")));
         } catch (Exception e) {
             e.printStackTrace();
@@ -329,8 +338,9 @@ public class TypeDecoderTest {
                         new Utf8String("Hello, world!"),
                         new Utf8String("world! Hello,"))));
         try {
-            StaticArray2 arr = (StaticArray2) TypeDecoder.instantiateType ("uint256[2]",new long[]{10,Long.MAX_VALUE});
-            assert(arr instanceof  StaticArray2);
+            StaticArray2 arr = (StaticArray2) TypeDecoder.instantiateType("uint256[2]",
+                    new long[]{10,Long.MAX_VALUE});
+            assert (arr instanceof  StaticArray2);
             assertThat(arr.getValue().get(0), is(new Uint256(BigInteger.TEN)));
             assertThat(arr.getValue().get(1), is(new Uint256(BigInteger.valueOf(Long.MAX_VALUE))));
         } catch (Exception e) {
@@ -351,12 +361,16 @@ public class TypeDecoderTest {
     @Test(expected = ClassNotFoundException.class)
     public void testEmptyStaticArrayInstantiateType() throws ClassNotFoundException {
         try {
-            TypeDecoder.instantiateType ("uint256[0]",new long[]{});
+            TypeDecoder.instantiateType("uint256[0]",new long[]{});
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
-        catch (InvocationTargetException e) {}
-        catch (NoSuchMethodException e) {}
-        catch (InstantiationException e) {}
-        catch (IllegalAccessException e) {}
     }
 
 
@@ -396,11 +410,12 @@ public class TypeDecoderTest {
 
         try {
 
-            DynamicArray arr = (DynamicArray) TypeDecoder.instantiateType("string[]",new String[]{"Hello, world!","world! Hello,"} );
-            assert(arr instanceof  DynamicArray);
+            DynamicArray arr = (DynamicArray) TypeDecoder.instantiateType("string[]",
+                    new String[]{"Hello, world!","world! Hello,"});
+            assert (arr instanceof  DynamicArray);
             assertThat(arr.getValue().get(0), is(new Utf8String("Hello, world!")));
             assertThat(arr.getValue().get(1), is(new Utf8String("world! Hello,")));
-        } catch (Exception e){
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -294,6 +294,10 @@ public class TypeDecoderTest {
             assertThat(TypeDecoder.instantiateType("address",
                     "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                     is(new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338")));
+            assertThat(TypeDecoder.instantiateType("address",
+                    BigInteger.ONE),
+                    is(new Address("0x0000000000000000000000000000000000000001")));
+
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -387,15 +387,23 @@ public class TypeDecoderTest {
     public void multiDimArrays() throws Exception {
         byte[] bytes1d = new byte[]{1, 2, 3};
         byte[][] bytes2d = new byte[][]{bytes1d, bytes1d, bytes1d};
+        final byte[][][] bytes3d = new byte[][][]{bytes2d, bytes2d, bytes2d};
+
         assertThat(TypeDecoder.instantiateType("bytes", bytes1d), is(new DynamicBytes(bytes1d)));
 
         StaticArray3<DynamicArray<Uint256>> twoDim = (StaticArray3<DynamicArray<Uint256>>)
                 TypeDecoder.instantiateType("uint256[][3]", bytes2d);
         assert (twoDim instanceof StaticArray3);
-
         DynamicArray<Uint256> row1 = twoDim.getValue().get(1);
         assert (row1 instanceof DynamicArray);
-
         assertThat(row1.getValue().get(2), is(new Uint256(3)));
+
+        StaticArray3<StaticArray3<DynamicArray<Uint256>>> threeDim =
+                (StaticArray3<StaticArray3<DynamicArray<Uint256>>>)
+                TypeDecoder.instantiateType("uint256[][3][3]", bytes3d);
+        assert (threeDim instanceof StaticArray3);
+        row1 = threeDim.getValue().get(1).getValue().get(1);
+        assert (row1 instanceof DynamicArray);
+        assertThat(row1.getValue().get(1), is(new Uint256(2)));
     }
 }

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -60,7 +60,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
-    public void testBuildTypeName() {
+    public void testBuildTypeName() throws Exception {
         assertThat(buildTypeName("uint256"),
                 is(ClassName.get(Uint256.class)));
         assertThat(buildTypeName("uint64"),


### PR DESCRIPTION
### What does this PR do?
Exposes methods to create TypeReference from solidity type (eg "uint256[5]") and Type from (solidity type, value Object). **This enables Function and Event encoding and decoding without translating ABI into java code with FunctionWrapperGenerator.** Includes support for static and dynamic arrays of multiple dimensions.

### Where should the reviewer start?
See the static utility methods
```
TypeReference.java: public static TypeReference makeTypeReference(String solidityType, final boolean indexed). Can handle complex array types like uint[][10].
TypeDecoder.java:   public static Type instantiateType(String solidityType, Object value)  [uses makeTypeReference() and common sense rules to coerce value to correct type]
FunctionEncoder.java: Function makeFunction(String fnname, List<String> solidityInputtypes, List<Object> arguments, List<String> solidityOutputTypes) [uses instantiateType]
```


### Why is it needed?
Currently there is no way to make function calls and decode events given an ABI without first translating the ABI to java code with FunctionWrapperGenerator and then compiling the java code. Our product, Streamr, needed to do this on the fly without compiling so we wrote these helper methods. This PR adds this functionality, which is similar to the functionality of web3 js lib.
