### PR TITLE
fixes #947 by adding eea feature in doc index and readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Features
 - Android compatible
 - Support for JP Morgan's Quorum via `web3j-quorum <https://github.com/web3j/quorum>`_
 - Support for `EEA Privacy features as described in EEA documentation <https://entethalliance.org/technical-documents/>`_
-and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
+  and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
 
 
 It has five runtime dependencies:

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,8 @@ Features
 - Command line tools
 - Android compatible
 - Support for JP Morgan's Quorum via `web3j-quorum <https://github.com/web3j/quorum>`_
+- Support for `EEA Privacy features as described in EEA documentation <https://entethalliance.org/technical-documents/>`_
+and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
 
 
 It has five runtime dependencies:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,8 @@ Features
 - Command line tools
 - Android compatible
 - Support for JP Morgan's Quorum via `web3j-quorum <https://github.com/web3j/quorum>`_
+- Support for `EEA Privacy features as described in EEA documentation <https://entethalliance.org/technical-documents/>`_
+and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
 
 
 Dependencies

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,7 @@ Features
 - Android compatible
 - Support for JP Morgan's Quorum via `web3j-quorum <https://github.com/web3j/quorum>`_
 - Support for `EEA Privacy features as described in EEA documentation <https://entethalliance.org/technical-documents/>`_
-and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
+  and implemented in `Pegasys Pantheon <https://docs.pantheon.pegasys.tech/en/stable/Reference/Pantheon-API-Methods/#eea-methods>`_.
 
 
 Dependencies


### PR DESCRIPTION
### What does this PR do?
This PR fixes #947 by adding the EEA Privacy feature (introduced in 4.3 release) info in the doc index and readme

### Where should the reviewer start?
Have a look at the doc index file and the readme at the root, in the feature list, a last line was added with links to the relevant resources.

### Why is it needed?
This change is a first step to update web3j doc to document eea module added in 4.3 release.