### PR TITLE
web3j.replayTransactionsFlowable doesnt exist

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -227,13 +227,18 @@ public class Transaction {
     // Parity returns a byte value, Geth returns a hex-encoded string
     // https://github.com/ethereum/go-ethereum/issues/3339
     public void setV(Object v) {
-        if (v instanceof String) {
-            this.v = Numeric.toBigInt((String) v).longValueExact();
-        } else if (v instanceof Integer) {
-            this.v = ((Integer) v).longValue();
-        } else {
-            this.v = (Long) v;
+        if(v==null){
+            this.v = 0l; // Rskj compliance workarround.
+        }else {
+            if (v instanceof String) {
+                this.v = Numeric.toBigInt((String) v).longValueExact();
+            } else if (v instanceof Integer) {
+                this.v = ((Integer) v).longValue();
+            } else {
+                this.v = (Long) v;
+            }
         }
+
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -227,18 +227,13 @@ public class Transaction {
     // Parity returns a byte value, Geth returns a hex-encoded string
     // https://github.com/ethereum/go-ethereum/issues/3339
     public void setV(Object v) {
-        if(v==null){
-            this.v = 0l; // Rskj compliance workarround.
-        }else {
-            if (v instanceof String) {
-                this.v = Numeric.toBigInt((String) v).longValueExact();
-            } else if (v instanceof Integer) {
-                this.v = ((Integer) v).longValue();
-            } else {
-                this.v = (Long) v;
-            }
+        if (v instanceof String) {
+            this.v = Numeric.toBigInt((String) v).longValueExact();
+        } else if (v instanceof Integer) {
+            this.v = ((Integer) v).longValue();
+        } else {
+            this.v = (Long) v;
         }
-
     }
 
     @Override

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -78,7 +78,7 @@ To replay a range of blocks from the blockchain::
 
 To replay the individual transactions contained within a range of blocks::
 
-   Subscription subscription = web3j.replayTransactionsFlowable(
+   Subscription subscription = web3j.replayPastTransactionsFlowable(
            <startBlockNumber>, <endBlockNumber>)
            .subscribe(tx -> {
                ...


### PR DESCRIPTION

### What does this PR do?

Changed `replayTransactionsFlowable` for `replayPastTransactionsFlowable` on the docs.

### Where should the reviewer start?

Check that the current available method is `replayPastTransactionsFlowable`

### Why is it needed?

The docs saids that for getting a transaction flowable indicating start and end block the developer should use the `web3j.replayTransactionsFlowable ` method.

The `web3j.replayTransactionsFlowable ` method does not exist in the latest release (4.2.0)

