### PR TITLE
Use openjdk for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false  # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 


### PR DESCRIPTION
### What does this PR do?
Fix the CI - there are issues using oraclejdk8

This PR changes the `travis.yaml` file to use openjdk8

### Where should the reviewer start?
`travis.yaml`

### Why is it needed?
So that the CI works!

