### PR TITLE
Base class for events

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -64,6 +64,7 @@ import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.RemoteCall;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
+import org.web3j.protocol.core.methods.response.BaseEventResponse;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.Contract;
@@ -275,6 +276,7 @@ public class SolidityFunctionWrapper extends Generator {
             throws ClassNotFoundException {
 
         List<MethodSpec> methodSpecs = new ArrayList<>();
+        List<String> eventNames = new ArrayList<>();
         for (AbiDefinition functionDefinition : functionDefinitions) {
             if (functionDefinition.getType().equals("function")) {
                 MethodSpec ms = buildFunction(functionDefinition);
@@ -282,6 +284,7 @@ public class SolidityFunctionWrapper extends Generator {
 
             } else if (functionDefinition.getType().equals("event")) {
                 methodSpecs.addAll(buildEventFunctions(functionDefinition, classBuilder));
+                eventNames.add(buildEventDefinitionName(functionDefinition.getName()));
             }
         }
 
@@ -997,7 +1000,7 @@ public class SolidityFunctionWrapper extends Generator {
         TypeSpec.Builder builder =
                 TypeSpec.classBuilder(className).addModifiers(Modifier.PUBLIC, Modifier.STATIC);
 
-        builder.addField(LOG, "log", Modifier.PUBLIC);
+        builder.superclass(BaseEventResponse.class);
         for (org.web3j.codegen.SolidityFunctionWrapper.NamedTypeName namedType :
                 indexedParameters) {
             TypeName typeName = getIndexedEventWrapperType(namedType.typeName);

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -44,6 +44,7 @@ import org.web3j.protocol.core.methods.response.AbiDefinition;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.web3j.codegen.SolidityFunctionWrapper.buildTypeName;
@@ -495,9 +496,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         + "    return transferEventFlowable(filter);\n"
                         + "  }\n"
                         + "\n"
-                        + "  public static class TransferEventResponse {\n"
-                        + "    public org.web3j.protocol.core.methods.response.Log log;\n"
-                        + "\n"
+                        + "  public static class TransferEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
                         + "    public byte[] id;\n"
                         + "\n"
                         + "    public java.lang.String from;\n"

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/BaseEventResponse.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/BaseEventResponse.java
@@ -1,0 +1,8 @@
+package org.web3j.protocol.core.methods.response;
+
+/**
+ * <p>Base-class of EventResponse objects. Carries the log object, shared by all event responses
+ */
+public class BaseEventResponse {
+    public Log log;
+}

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -688,14 +688,23 @@ public abstract class Contract extends ManagedTransaction {
     }
 
     protected EventValuesWithLog extractEventParametersWithLog(Event event, Log log) {
+        return staticExtractEventParametersWithLog(event,log);
+    }
+
+    protected static EventValuesWithLog staticExtractEventParametersWithLog(Event event, Log log) {
         final EventValues eventValues = staticExtractEventParameters(event, log);
         return (eventValues == null) ? null : new EventValuesWithLog(eventValues, log);
     }
 
     protected List<EventValuesWithLog> extractEventParametersWithLog(
             Event event, TransactionReceipt transactionReceipt) {
+        return staticExtractEventParametersWithLog(event, transactionReceipt);
+    }
+
+    protected static List<EventValuesWithLog> staticExtractEventParametersWithLog(
+            Event event, TransactionReceipt transactionReceipt) {
         return transactionReceipt.getLogs().stream()
-                .map(log -> extractEventParametersWithLog(event, log))
+                .map(log -> staticExtractEventParametersWithLog(event, log))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
In our use-case, we often face a need to store various events that are emitted by contracts in a single collection and perform some basic operations on them. It is complicated by the fact that the event objects do not have a shared ancestor, and leads to a lot of duplication. In this PR we propose that events classes have a base class called BaseEventResponse, with the Log member. No change to client code is required, as it is a public member just like before, only comes from a base-class.

Also, 'extract' methods are made static as they do not require access to the instance fields, and we often had to create dummy instances of the contract solely to call these methods.
