### PR TITLE
Support kotlin format in tuples

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/TupleGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/TupleGenerator.java
@@ -89,6 +89,15 @@ public class TupleGenerator extends Generator {
                             .addStatement("return $N", value)
                             .build();
             methodSpecs.add(getterSpec);
+
+            MethodSpec getterSpec2 = MethodSpec.methodBuilder(
+                    "component"+i)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(typeVariableName)
+                    .addStatement("return $N", value)
+                    .build();
+            methodSpecs.add(getterSpec2);
+
         }
 
         MethodSpec constructorSpec = constructorBuilder.build();

--- a/codegen/src/main/java/org/web3j/codegen/TupleGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/TupleGenerator.java
@@ -54,6 +54,7 @@ public class TupleGenerator extends Generator {
     }
 
     private TypeSpec createTuple(int size) {
+        String javadoc = "@deprecated use 'component$L' method instead";
         String className = CLASS_NAME + size;
         TypeSpec.Builder typeSpecBuilder =
                 TypeSpec.classBuilder(className)
@@ -84,6 +85,8 @@ public class TupleGenerator extends Generator {
 
             MethodSpec getterSpec =
                     MethodSpec.methodBuilder("get" + Strings.capitaliseFirstLetter(value))
+                            .addAnnotation(Deprecated.class)
+                            .addJavadoc(javadoc, i)
                             .addModifiers(Modifier.PUBLIC)
                             .returns(typeVariableName)
                             .addStatement("return $N", value)

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple1.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple1.java
@@ -21,6 +21,10 @@ public final class Tuple1<T1> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     @Override
     public int getSize() {
         return SIZE;

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple1.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple1.java
@@ -17,6 +17,9 @@ public final class Tuple1<T1> implements Tuple {
         this.value1 = value1;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple10.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple10.java
@@ -48,7 +48,15 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -56,7 +64,15 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -64,7 +80,15 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -72,7 +96,15 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -80,7 +112,15 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple10.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple10.java
@@ -44,6 +44,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         this.value10 = value10;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -52,6 +55,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -60,6 +66,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -68,6 +77,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -76,6 +88,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -84,6 +99,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -92,6 +110,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -100,6 +121,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -108,6 +132,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -116,6 +143,9 @@ public final class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements T
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple11.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple11.java
@@ -51,7 +51,15 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -59,7 +67,15 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -67,7 +83,15 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -75,7 +99,15 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -83,11 +115,23 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
         return value10;
     }
 
+    public T10 component10() {
+        return value10;
+    }
+
     public T11 getValue11() {
+        return value11;
+    }
+
+    public T11 component11() {
         return value11;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple11.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple11.java
@@ -47,6 +47,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         this.value11 = value11;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -55,6 +58,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -63,6 +69,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -71,6 +80,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -79,6 +91,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -87,6 +102,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -95,6 +113,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -103,6 +124,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -111,6 +135,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -119,6 +146,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -127,6 +157,9 @@ public final class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> impleme
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple12.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple12.java
@@ -54,7 +54,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -62,7 +70,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -70,7 +86,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -78,7 +102,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -86,7 +118,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -94,7 +134,15 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple12.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple12.java
@@ -50,6 +50,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         this.value12 = value12;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -58,6 +61,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -66,6 +72,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -74,6 +83,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -82,6 +94,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -90,6 +105,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -98,6 +116,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -106,6 +127,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -114,6 +138,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -122,6 +149,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -130,6 +160,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -138,6 +171,9 @@ public final class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> im
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple13.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple13.java
@@ -57,7 +57,15 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -65,7 +73,15 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -73,7 +89,15 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -81,7 +105,15 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -89,7 +121,15 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -97,11 +137,23 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
         return value12;
     }
 
+    public T12 component12() {
+        return value12;
+    }
+
     public T13 getValue13() {
+        return value13;
+    }
+
+    public T13 component13() {
         return value13;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple13.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple13.java
@@ -53,6 +53,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value13 = value13;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -61,6 +64,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -69,6 +75,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -77,6 +86,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -85,6 +97,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -93,6 +108,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -101,6 +119,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -109,6 +130,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -117,6 +141,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -125,6 +152,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -133,6 +163,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -141,6 +174,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -149,6 +185,9 @@ public final class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple14.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple14.java
@@ -60,7 +60,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -68,7 +76,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -76,7 +92,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -84,7 +108,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -92,7 +124,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -100,7 +140,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -108,7 +156,15 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple14.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple14.java
@@ -56,6 +56,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value14 = value14;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -64,6 +67,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -72,6 +78,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -80,6 +89,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -88,6 +100,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -96,6 +111,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -104,6 +122,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -112,6 +133,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -120,6 +144,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -128,6 +155,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -136,6 +166,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -144,6 +177,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -152,6 +188,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -160,6 +199,9 @@ public final class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple15.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple15.java
@@ -63,7 +63,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -71,7 +79,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -79,7 +95,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -87,7 +111,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -95,7 +127,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -103,7 +143,15 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -111,11 +159,23 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
         return value14;
     }
 
+    public T14 component14() {
+        return value14;
+    }
+
     public T15 getValue15() {
+        return value15;
+    }
+
+    public T15 component15() {
         return value15;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple15.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple15.java
@@ -59,6 +59,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value15 = value15;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -67,6 +70,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -75,6 +81,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -83,6 +92,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -91,6 +103,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -99,6 +114,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -107,6 +125,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -115,6 +136,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -123,6 +147,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -131,6 +158,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -139,6 +169,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -147,6 +180,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -155,6 +191,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -163,6 +202,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -171,6 +213,9 @@ public final class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple16.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple16.java
@@ -66,7 +66,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -74,7 +82,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -82,7 +98,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -90,7 +114,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -98,7 +130,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -106,7 +146,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -114,7 +162,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 
@@ -122,7 +178,15 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    public T15 component15() {
+        return value15;
+    }
+
     public T16 getValue16() {
+        return value16;
+    }
+
+    public T16 component16() {
         return value16;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple16.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple16.java
@@ -62,6 +62,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value16 = value16;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -70,6 +73,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -78,6 +84,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -86,6 +95,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -94,6 +106,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -102,6 +117,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -110,6 +128,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -118,6 +139,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -126,6 +150,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -134,6 +161,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -142,6 +172,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -150,6 +183,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -158,6 +194,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -166,6 +205,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -174,6 +216,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }
@@ -182,6 +227,9 @@ public final class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    /**
+     * @deprecated use 'component16' method instead */
+    @Deprecated
     public T16 getValue16() {
         return value16;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple17.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple17.java
@@ -69,7 +69,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -77,7 +85,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -85,7 +101,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -93,7 +117,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -101,7 +133,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -109,7 +149,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -117,7 +165,15 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 
@@ -125,11 +181,23 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    public T15 component15() {
+        return value15;
+    }
+
     public T16 getValue16() {
         return value16;
     }
 
+    public T16 component16() {
+        return value16;
+    }
+
     public T17 getValue17() {
+        return value17;
+    }
+
+    public T17 component17() {
         return value17;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple17.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple17.java
@@ -65,6 +65,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value17 = value17;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -73,6 +76,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -81,6 +87,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -89,6 +98,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -97,6 +109,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -105,6 +120,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -113,6 +131,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -121,6 +142,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -129,6 +153,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -137,6 +164,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -145,6 +175,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -153,6 +186,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -161,6 +197,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -169,6 +208,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -177,6 +219,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }
@@ -185,6 +230,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    /**
+     * @deprecated use 'component16' method instead */
+    @Deprecated
     public T16 getValue16() {
         return value16;
     }
@@ -193,6 +241,9 @@ public final class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value16;
     }
 
+    /**
+     * @deprecated use 'component17' method instead */
+    @Deprecated
     public T17 getValue17() {
         return value17;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple18.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple18.java
@@ -72,7 +72,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -80,7 +88,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -88,7 +104,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -96,7 +120,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -104,7 +136,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -112,7 +152,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -120,7 +168,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 
@@ -128,7 +184,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    public T15 component15() {
+        return value15;
+    }
+
     public T16 getValue16() {
+        return value16;
+    }
+
+    public T16 component16() {
         return value16;
     }
 
@@ -136,7 +200,15 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    public T17 component17() {
+        return value17;
+    }
+
     public T18 getValue18() {
+        return value18;
+    }
+
+    public T18 component18() {
         return value18;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple18.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple18.java
@@ -68,6 +68,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value18 = value18;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -76,6 +79,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -84,6 +90,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -92,6 +101,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -100,6 +112,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -108,6 +123,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -116,6 +134,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -124,6 +145,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -132,6 +156,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -140,6 +167,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -148,6 +178,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -156,6 +189,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -164,6 +200,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -172,6 +211,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -180,6 +222,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }
@@ -188,6 +233,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    /**
+     * @deprecated use 'component16' method instead */
+    @Deprecated
     public T16 getValue16() {
         return value16;
     }
@@ -196,6 +244,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value16;
     }
 
+    /**
+     * @deprecated use 'component17' method instead */
+    @Deprecated
     public T17 getValue17() {
         return value17;
     }
@@ -204,6 +255,9 @@ public final class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    /**
+     * @deprecated use 'component18' method instead */
+    @Deprecated
     public T18 getValue18() {
         return value18;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple19.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple19.java
@@ -75,7 +75,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -83,7 +91,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -91,7 +107,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -99,7 +123,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -107,7 +139,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -115,7 +155,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -123,7 +171,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 
@@ -131,7 +187,15 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    public T15 component15() {
+        return value15;
+    }
+
     public T16 getValue16() {
+        return value16;
+    }
+
+    public T16 component16() {
         return value16;
     }
 
@@ -139,11 +203,23 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    public T17 component17() {
+        return value17;
+    }
+
     public T18 getValue18() {
         return value18;
     }
 
+    public T18 component18() {
+        return value18;
+    }
+
     public T19 getValue19() {
+        return value19;
+    }
+
+    public T19 component19() {
         return value19;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple19.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple19.java
@@ -71,6 +71,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value19 = value19;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -79,6 +82,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -87,6 +93,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -95,6 +104,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -103,6 +115,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -111,6 +126,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -119,6 +137,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -127,6 +148,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -135,6 +159,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -143,6 +170,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -151,6 +181,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -159,6 +192,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -167,6 +203,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -175,6 +214,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -183,6 +225,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }
@@ -191,6 +236,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    /**
+     * @deprecated use 'component16' method instead */
+    @Deprecated
     public T16 getValue16() {
         return value16;
     }
@@ -199,6 +247,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value16;
     }
 
+    /**
+     * @deprecated use 'component17' method instead */
+    @Deprecated
     public T17 getValue17() {
         return value17;
     }
@@ -207,6 +258,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    /**
+     * @deprecated use 'component18' method instead */
+    @Deprecated
     public T18 getValue18() {
         return value18;
     }
@@ -215,6 +269,9 @@ public final class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value18;
     }
 
+    /**
+     * @deprecated use 'component19' method instead */
+    @Deprecated
     public T19 getValue19() {
         return value19;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple2.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple2.java
@@ -24,7 +24,15 @@ public final class Tuple2<T1, T2> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple2.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple2.java
@@ -20,6 +20,9 @@ public final class Tuple2<T1, T2> implements Tuple {
         this.value2 = value2;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -28,6 +31,9 @@ public final class Tuple2<T1, T2> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple20.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple20.java
@@ -78,7 +78,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -86,7 +94,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -94,7 +110,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -102,7 +126,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 
@@ -110,7 +142,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    public T9 component9() {
+        return value9;
+    }
+
     public T10 getValue10() {
+        return value10;
+    }
+
+    public T10 component10() {
         return value10;
     }
 
@@ -118,7 +158,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    public T11 component11() {
+        return value11;
+    }
+
     public T12 getValue12() {
+        return value12;
+    }
+
+    public T12 component12() {
         return value12;
     }
 
@@ -126,7 +174,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    public T13 component13() {
+        return value13;
+    }
+
     public T14 getValue14() {
+        return value14;
+    }
+
+    public T14 component14() {
         return value14;
     }
 
@@ -134,7 +190,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    public T15 component15() {
+        return value15;
+    }
+
     public T16 getValue16() {
+        return value16;
+    }
+
+    public T16 component16() {
         return value16;
     }
 
@@ -142,7 +206,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    public T17 component17() {
+        return value17;
+    }
+
     public T18 getValue18() {
+        return value18;
+    }
+
+    public T18 component18() {
         return value18;
     }
 
@@ -150,7 +222,15 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value19;
     }
 
+    public T19 component19() {
+        return value19;
+    }
+
     public T20 getValue20() {
+        return value20;
+    }
+
+    public T20 component20() {
         return value20;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple20.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple20.java
@@ -74,6 +74,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         this.value20 = value20;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -82,6 +85,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -90,6 +96,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -98,6 +107,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -106,6 +118,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -114,6 +129,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -122,6 +140,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -130,6 +151,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -138,6 +162,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }
@@ -146,6 +173,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value9;
     }
 
+    /**
+     * @deprecated use 'component10' method instead */
+    @Deprecated
     public T10 getValue10() {
         return value10;
     }
@@ -154,6 +184,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value10;
     }
 
+    /**
+     * @deprecated use 'component11' method instead */
+    @Deprecated
     public T11 getValue11() {
         return value11;
     }
@@ -162,6 +195,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value11;
     }
 
+    /**
+     * @deprecated use 'component12' method instead */
+    @Deprecated
     public T12 getValue12() {
         return value12;
     }
@@ -170,6 +206,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value12;
     }
 
+    /**
+     * @deprecated use 'component13' method instead */
+    @Deprecated
     public T13 getValue13() {
         return value13;
     }
@@ -178,6 +217,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value13;
     }
 
+    /**
+     * @deprecated use 'component14' method instead */
+    @Deprecated
     public T14 getValue14() {
         return value14;
     }
@@ -186,6 +228,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value14;
     }
 
+    /**
+     * @deprecated use 'component15' method instead */
+    @Deprecated
     public T15 getValue15() {
         return value15;
     }
@@ -194,6 +239,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value15;
     }
 
+    /**
+     * @deprecated use 'component16' method instead */
+    @Deprecated
     public T16 getValue16() {
         return value16;
     }
@@ -202,6 +250,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value16;
     }
 
+    /**
+     * @deprecated use 'component17' method instead */
+    @Deprecated
     public T17 getValue17() {
         return value17;
     }
@@ -210,6 +261,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value17;
     }
 
+    /**
+     * @deprecated use 'component18' method instead */
+    @Deprecated
     public T18 getValue18() {
         return value18;
     }
@@ -218,6 +272,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value18;
     }
 
+    /**
+     * @deprecated use 'component19' method instead */
+    @Deprecated
     public T19 getValue19() {
         return value19;
     }
@@ -226,6 +283,9 @@ public final class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T1
         return value19;
     }
 
+    /**
+     * @deprecated use 'component20' method instead */
+    @Deprecated
     public T20 getValue20() {
         return value20;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple3.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple3.java
@@ -27,11 +27,23 @@ public final class Tuple3<T1, T2, T3> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
         return value2;
     }
 
+    public T2 component2() {
+        return value2;
+    }
+
     public T3 getValue3() {
+        return value3;
+    }
+
+    public T3 component3() {
         return value3;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple3.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple3.java
@@ -23,6 +23,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple {
         this.value3 = value3;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -31,6 +34,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -39,6 +45,9 @@ public final class Tuple3<T1, T2, T3> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple4.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple4.java
@@ -30,7 +30,15 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -38,7 +46,15 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple4.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple4.java
@@ -26,6 +26,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         this.value4 = value4;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -34,6 +37,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -42,6 +48,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -50,6 +59,9 @@ public final class Tuple4<T1, T2, T3, T4> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple5.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple5.java
@@ -33,7 +33,15 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -41,11 +49,23 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
         return value4;
     }
 
+    public T4 component4() {
+        return value4;
+    }
+
     public T5 getValue5() {
+        return value5;
+    }
+
+    public T5 component5() {
         return value5;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple5.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple5.java
@@ -29,6 +29,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         this.value5 = value5;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -37,6 +40,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -45,6 +51,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -53,6 +62,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -61,6 +73,9 @@ public final class Tuple5<T1, T2, T3, T4, T5> implements Tuple {
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple6.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple6.java
@@ -36,7 +36,15 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -44,7 +52,15 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -52,7 +68,15 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple6.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple6.java
@@ -32,6 +32,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         this.value6 = value6;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -40,6 +43,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -48,6 +54,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -56,6 +65,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -64,6 +76,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -72,6 +87,9 @@ public final class Tuple6<T1, T2, T3, T4, T5, T6> implements Tuple {
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple7.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple7.java
@@ -39,7 +39,15 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -47,7 +55,15 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -55,11 +71,23 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
         return value6;
     }
 
+    public T6 component6() {
+        return value6;
+    }
+
     public T7 getValue7() {
+        return value7;
+    }
+
+    public T7 component7() {
         return value7;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple7.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple7.java
@@ -35,6 +35,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         this.value7 = value7;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -43,6 +46,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -51,6 +57,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -59,6 +68,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -67,6 +79,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -75,6 +90,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -83,6 +101,9 @@ public final class Tuple7<T1, T2, T3, T4, T5, T6, T7> implements Tuple {
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple8.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple8.java
@@ -42,7 +42,15 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -50,7 +58,15 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -58,7 +74,15 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -66,7 +90,15 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
+        return value8;
+    }
+
+    public T8 component8() {
         return value8;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple8.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple8.java
@@ -38,6 +38,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         this.value8 = value8;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -46,6 +49,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -54,6 +60,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -62,6 +71,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -70,6 +82,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -78,6 +93,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -86,6 +104,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -94,6 +115,9 @@ public final class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> implements Tuple {
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple9.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple9.java
@@ -45,7 +45,15 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value1;
     }
 
+    public T1 component1() {
+        return value1;
+    }
+
     public T2 getValue2() {
+        return value2;
+    }
+
+    public T2 component2() {
         return value2;
     }
 
@@ -53,7 +61,15 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value3;
     }
 
+    public T3 component3() {
+        return value3;
+    }
+
     public T4 getValue4() {
+        return value4;
+    }
+
+    public T4 component4() {
         return value4;
     }
 
@@ -61,7 +77,15 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value5;
     }
 
+    public T5 component5() {
+        return value5;
+    }
+
     public T6 getValue6() {
+        return value6;
+    }
+
+    public T6 component6() {
         return value6;
     }
 
@@ -69,11 +93,23 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value7;
     }
 
+    public T7 component7() {
+        return value7;
+    }
+
     public T8 getValue8() {
         return value8;
     }
 
+    public T8 component8() {
+        return value8;
+    }
+
     public T9 getValue9() {
+        return value9;
+    }
+
+    public T9 component9() {
         return value9;
     }
 

--- a/tuples/src/main/java/org/web3j/tuples/generated/Tuple9.java
+++ b/tuples/src/main/java/org/web3j/tuples/generated/Tuple9.java
@@ -41,6 +41,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         this.value9 = value9;
     }
 
+    /**
+     * @deprecated use 'component1' method instead */
+    @Deprecated
     public T1 getValue1() {
         return value1;
     }
@@ -49,6 +52,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value1;
     }
 
+    /**
+     * @deprecated use 'component2' method instead */
+    @Deprecated
     public T2 getValue2() {
         return value2;
     }
@@ -57,6 +63,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value2;
     }
 
+    /**
+     * @deprecated use 'component3' method instead */
+    @Deprecated
     public T3 getValue3() {
         return value3;
     }
@@ -65,6 +74,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value3;
     }
 
+    /**
+     * @deprecated use 'component4' method instead */
+    @Deprecated
     public T4 getValue4() {
         return value4;
     }
@@ -73,6 +85,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value4;
     }
 
+    /**
+     * @deprecated use 'component5' method instead */
+    @Deprecated
     public T5 getValue5() {
         return value5;
     }
@@ -81,6 +96,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value5;
     }
 
+    /**
+     * @deprecated use 'component6' method instead */
+    @Deprecated
     public T6 getValue6() {
         return value6;
     }
@@ -89,6 +107,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value6;
     }
 
+    /**
+     * @deprecated use 'component7' method instead */
+    @Deprecated
     public T7 getValue7() {
         return value7;
     }
@@ -97,6 +118,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value7;
     }
 
+    /**
+     * @deprecated use 'component8' method instead */
+    @Deprecated
     public T8 getValue8() {
         return value8;
     }
@@ -105,6 +129,9 @@ public final class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> implements Tuple {
         return value8;
     }
 
+    /**
+     * @deprecated use 'component9' method instead */
+    @Deprecated
     public T9 getValue9() {
         return value9;
     }


### PR DESCRIPTION
We use web3j in both our Java and Kotlin code. There exists a built-in format for tuples in Kotlin, which prettifies the decomposing adssignment, and it is nice to have it in web3j code: 
val (a,b,c) = myContract.methodReturnTupple().send();

This required adding "componentN()" methods to Tuple class. The original getValueN()) methods were left as-is for backward-compatibility and they can still be used in java and Kotlin.