### PR TITLE
Support encoding a function without actually calling it

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -62,6 +62,7 @@ import org.web3j.protocol.ObjectMapperFactory;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.RemoteFunctionCall;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 import org.web3j.protocol.core.methods.response.Log;
@@ -859,7 +860,7 @@ public class SolidityFunctionWrapper extends Generator {
             } else {
                 nativeReturnTypeName = getWrapperType(typeName);
             }
-            methodBuilder.returns(buildRemoteCall(nativeReturnTypeName));
+            methodBuilder.returns(buildRemoteFunctionCall(nativeReturnTypeName));
 
             methodBuilder.addStatement(
                     "final $T function = "
@@ -916,8 +917,8 @@ public class SolidityFunctionWrapper extends Generator {
                                     .build();
 
                     methodBuilder.addStatement(
-                            "return new $T(\n$L)",
-                            buildRemoteCall(nativeReturnTypeName),
+                            "return new $T(function,\n$L)",
+                            buildRemoteFunctionCall(nativeReturnTypeName),
                             callableType);
                 } else {
                     methodBuilder.addStatement(
@@ -936,7 +937,7 @@ public class SolidityFunctionWrapper extends Generator {
                                     "org.web3j.tuples.generated", "Tuple" + returnTypes.size()),
                             returnTypes.toArray(new TypeName[returnTypes.size()]));
 
-            methodBuilder.returns(buildRemoteCall(parameterizedTupleType));
+            methodBuilder.returns(buildRemoteFunctionCall(parameterizedTupleType));
 
             buildVariableLengthReturnFunctionConstructor(
                     methodBuilder, functionName, inputParams, outputParameterTypes);
@@ -947,6 +948,11 @@ public class SolidityFunctionWrapper extends Generator {
 
     private static ParameterizedTypeName buildRemoteCall(TypeName typeName) {
         return ParameterizedTypeName.get(ClassName.get(RemoteCall.class), typeName);
+    }
+
+    private static ParameterizedTypeName buildRemoteFunctionCall(TypeName typeName) {
+        return ParameterizedTypeName.get(
+                ClassName.get(RemoteFunctionCall.class), typeName);
     }
 
     private void buildTransactionFunction(
@@ -968,7 +974,7 @@ public class SolidityFunctionWrapper extends Generator {
 
         String functionName = functionDefinition.getName();
 
-        methodBuilder.returns(buildRemoteCall(TypeName.get(TransactionReceipt.class)));
+        methodBuilder.returns(buildRemoteFunctionCall(TypeName.get(TransactionReceipt.class)));
 
         methodBuilder.addStatement(
                 "final $T function = new $T(\n$N, \n$T.<$T>asList($L), \n$T"
@@ -1379,7 +1385,8 @@ public class SolidityFunctionWrapper extends Generator {
                                         .build())
                         .build();
 
-        methodBuilder.addStatement("return new $T(\n$L)", buildRemoteCall(tupleType), callableType);
+        methodBuilder.addStatement(
+                "return new $T(function,\n$L)", buildRemoteFunctionCall(tupleType), callableType);
     }
 
     private static CodeBlock buildVariableLengthEventInitializer(

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -188,7 +188,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
                         + "      FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
@@ -232,7 +232,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param, java.math.BigInteger weiValue) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param, java.math.BigInteger weiValue) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
                         + "      FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
@@ -257,7 +257,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<java.math.BigInteger> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.math.BigInteger> functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}));\n"
@@ -281,11 +281,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<java.util.List> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteCall<java.util.List>(\n"
+                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
                         + "      new java.util.concurrent.Callable<java.util.List>() {\n"
                         + "        @java.lang.Override\n"
                         + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
@@ -313,13 +313,13 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<java.util.List> functionName(java.util.List<java.math.BigInteger> param) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.util.List<java.math.BigInteger> param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint8>(\n"
                         + "              org.web3j.abi.datatypes.generated.Uint8.class,\n"
                         + "              org.web3j.abi.Utils.typeMap(param, org.web3j.abi.datatypes.generated.Uint8.class))), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteCall<java.util.List>(\n"
+                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
                         + "      new java.util.concurrent.Callable<java.util.List>() {\n"
                         + "        @java.lang.Override\n"
                         + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
@@ -347,14 +347,14 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<java.util.List> functionName(java.util.List<java.util.List<java.math.BigInteger>> param) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.util.List<java.util.List<java.math.BigInteger>> param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.DynamicArray>(\n"
                         + "              org.web3j.abi.datatypes.DynamicArray.class,\n"
                         + "              org.web3j.abi.Utils.typeMap(param, org.web3j.abi.datatypes.DynamicArray.class,\n"
                         + "      org.web3j.abi.datatypes.generated.Uint8.class))), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteCall<java.util.List>(\n"
+                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
                         + "      new java.util.concurrent.Callable<java.util.List>() {\n"
                         + "        @java.lang.Override\n"
                         + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
@@ -408,12 +408,12 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>> functionName(java.math.BigInteger param1, java.math.BigInteger param2) {\n"
+                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>> functionName(java.math.BigInteger param1, java.math.BigInteger param2) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param1), \n"
                         + "      new org.web3j.abi.datatypes.generated.Uint32(param2)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int32>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>>(\n"
+                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>>(function,\n"
                         + "      new java.util.concurrent.Callable<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>>() {\n"
                         + "        @java.lang.Override\n"
                         + "        public org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger> call() throws java.lang.Exception {\n"

--- a/core/src/main/java/org/web3j/protocol/core/RemoteFunctionCall.java
+++ b/core/src/main/java/org/web3j/protocol/core/RemoteFunctionCall.java
@@ -1,0 +1,42 @@
+package org.web3j.protocol.core;
+
+import org.web3j.abi.FunctionEncoder;
+import org.web3j.abi.FunctionReturnDecoder;
+import org.web3j.abi.datatypes.Function;
+import org.web3j.abi.datatypes.Type;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * A wrapper for a callable function.
+ * Can also return the raw encoded function
+ *
+ * @param <T> Our return type.
+ */
+public class RemoteFunctionCall<T> extends RemoteCall<T> {
+
+    private final Function function;
+
+    public RemoteFunctionCall(Function function, Callable<T> callable) {
+        super(callable);
+        this.function = function;
+    }
+
+    /**
+     * return an encoded function, so it can be manually signed and transmitted
+     * @return the function call, encoded.
+     */
+    public String encodeFunctionCall() {
+        return FunctionEncoder.encode(function);
+    }
+
+    /**
+     * decode a method response
+     * @param response
+     * @return
+     */
+    public List<Type> decodeFunctionResponse(String response) {
+        return FunctionReturnDecoder.decode(response, function.getOutputParameters());
+    }
+}

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -38,6 +38,7 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.RemoteFunctionCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
@@ -352,26 +353,26 @@ public abstract class Contract extends ManagedTransaction {
         return receipt;
     }
 
-    protected <T extends Type> RemoteCall<T> executeRemoteCallSingleValueReturn(Function function) {
-        return new RemoteCall<>(() -> executeCallSingleValueReturn(function));
+    protected <T extends Type> RemoteFunctionCall<T> executeRemoteCallSingleValueReturn(Function function) {
+        return new RemoteFunctionCall<>(function,() -> executeCallSingleValueReturn(function));
     }
 
-    protected <T> RemoteCall<T> executeRemoteCallSingleValueReturn(
+    protected <T> RemoteFunctionCall<T> executeRemoteCallSingleValueReturn(
             Function function, Class<T> returnType) {
-        return new RemoteCall<>(() -> executeCallSingleValueReturn(function, returnType));
+        return new RemoteFunctionCall<>(function,() -> executeCallSingleValueReturn(function, returnType));
     }
 
-    protected RemoteCall<List<Type>> executeRemoteCallMultipleValueReturn(Function function) {
-        return new RemoteCall<>(() -> executeCallMultipleValueReturn(function));
+    protected RemoteFunctionCall<List<Type>> executeRemoteCallMultipleValueReturn(Function function) {
+        return new RemoteFunctionCall<>(function,() -> executeCallMultipleValueReturn(function));
     }
 
-    protected RemoteCall<TransactionReceipt> executeRemoteCallTransaction(Function function) {
-        return new RemoteCall<>(() -> executeTransaction(function));
+    protected RemoteFunctionCall<TransactionReceipt> executeRemoteCallTransaction(Function function) {
+        return new RemoteFunctionCall<>(function,() -> executeTransaction(function));
     }
 
-    protected RemoteCall<TransactionReceipt> executeRemoteCallTransaction(
+    protected RemoteFunctionCall<TransactionReceipt> executeRemoteCallTransaction(
             Function function, BigInteger weiValue) {
-        return new RemoteCall<>(() -> executeTransaction(function, weiValue));
+        return new RemoteFunctionCall<>(function,() -> executeTransaction(function, weiValue));
     }
 
     private static <T extends Contract> T create(


### PR DESCRIPTION
There is an easy way in Web3.js to perform an 'encode with selector' operation with the contract object, like this:
let encodedAbi = myContract.methods.myMethod(myParameter).encodeABI()

Unfortunately, this was not possible with web3j, as encoding and performing the call were highly coupled. This PR wraps the returned 'RemoteCall' object with a 'RemoteFunctionCall' that allows accessing and encoding the function if needed, without breaking the existing API.