### PR TITLE
Estimated gas provider

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -197,26 +197,6 @@ public abstract class Contract extends ManagedTransaction {
     }
 
     /**
-     * Allow {@code gasPrice} to be set.
-     *
-     * @param newPrice gas price to use for subsequent transactions
-     * @deprecated use ContractGasProvider
-     */
-    public void setGasPrice(BigInteger newPrice) {
-        this.gasProvider = new StaticGasProvider(newPrice, gasProvider.getGasLimit());
-    }
-
-    /**
-     * Get the current {@code gasPrice} value this contract uses when executing transactions.
-     *
-     * @return the gas price set on this contract
-     * @deprecated use ContractGasProvider
-     */
-    public BigInteger getGasPrice() {
-        return gasProvider.getGasPrice();
-    }
-
-    /**
      * Check that the contract deployed at the address associated with this smart contract wrapper
      * is in fact the contract you believe it is.
      *
@@ -358,13 +338,15 @@ public abstract class Contract extends ManagedTransaction {
             String data, BigInteger weiValue, String funcName, boolean constructor)
             throws TransactionException, IOException {
 
+        BigInteger gasPrice = gasProvider.getGasPrice();
+        BigInteger gasLimit = gasProvider.getGasLimit(transactionManager.getFromAddress(), gasPrice, contractAddress, weiValue, data);
         TransactionReceipt receipt =
                 send(
                         contractAddress,
                         data,
                         weiValue,
-                        gasProvider.getGasPrice(funcName),
-                        gasProvider.getGasLimit(funcName),
+                        gasPrice,
+                        gasLimit,
                         constructor);
 
         if (!receipt.isStatusOK()) {

--- a/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
@@ -12,16 +12,27 @@
  */
 package org.web3j.tx.gas;
 
+import java.io.IOException;
 import java.math.BigInteger;
 
 public interface ContractGasProvider {
-    BigInteger getGasPrice(String contractFunc);
 
     @Deprecated
-    BigInteger getGasPrice();
+    BigInteger getGasPrice(String contractFunc) throws IOException;
 
+    BigInteger getGasPrice() throws IOException;
+
+    @Deprecated
     BigInteger getGasLimit(String contractFunc);
 
     @Deprecated
     BigInteger getGasLimit();
+
+    BigInteger getGasLimit(
+            String fromAddress,
+            BigInteger gasPrice,
+            String contractAddress,
+            BigInteger weiValue,
+            String data
+    ) throws IOException;
 }

--- a/core/src/main/java/org/web3j/tx/gas/EstimatedGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/EstimatedGasProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.request.Transaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+public class EstimatedGasProvider implements ContractGasProvider {
+
+    private final Web3j web3j;
+
+    public EstimatedGasProvider(Web3j web3j) {
+        this.web3j = web3j;
+    }
+
+    @Override
+    public BigInteger getGasPrice(String contractFunc) throws IOException{
+        return getGasPrice();
+    }
+
+    @Override
+    public BigInteger getGasPrice() throws IOException {
+        return web3j.ethGasPrice().send().getGasPrice();
+    }
+
+    @Override
+    public BigInteger getGasLimit(
+            String fromAddress,
+            BigInteger gasPrice,
+            String contractAddress,
+            BigInteger weiValue,
+            String data
+    ) throws IOException {
+        Transaction estimatedTransaction = new Transaction(
+                fromAddress,
+                BigInteger.ZERO,
+                gasPrice,
+                BigInteger.ZERO,
+                contractAddress,
+                weiValue,
+                data);
+        return web3j.ethEstimateGas(estimatedTransaction).send().getAmountUsed();
+    }
+
+    @Override
+    public BigInteger getGasLimit(String contractFunc) {
+        return null;
+    }
+
+    @Override
+    public BigInteger getGasLimit() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
@@ -42,4 +42,9 @@ public class StaticGasProvider implements ContractGasProvider {
     public BigInteger getGasLimit() {
         return gasLimit;
     }
+
+    @Override
+    public BigInteger getGasLimit(String fromAddress, BigInteger gasPrice, String contractAddress, BigInteger weiValue, String data) {
+        return gasLimit;
+    }
 }

--- a/core/src/test/java/org/web3j/tx/ContractTest.java
+++ b/core/src/test/java/org/web3j/tx/ContractTest.java
@@ -374,14 +374,6 @@ public class ContractTest extends ManagedTransactionTester {
     }
 
     @Test
-    public void testSetGetGasPrice() {
-        assertEquals(ManagedTransaction.GAS_PRICE, contract.getGasPrice());
-        BigInteger newPrice = ManagedTransaction.GAS_PRICE.multiply(BigInteger.valueOf(2));
-        contract.setGasPrice(newPrice);
-        assertEquals(newPrice, contract.getGasPrice());
-    }
-
-    @Test
     public void testStaticGasProvider() throws IOException, TransactionException {
         StaticGasProvider gasProvider = new StaticGasProvider(BigInteger.TEN, BigInteger.ONE);
         TransactionManager txManager = mock(TransactionManager.class);


### PR DESCRIPTION
### What does this PR do?
Creates an EstimatedGasProvider class that provides (arguably) the most common strategy for determining the gas price and gas limit in Ethereum, i.e. asking the node for both values. This is also the behaviour that all Web3.js customers are used to.

This does require a change to the existing ContractGasProvider interface, which does not seem logical as 'contract function name' is not what usually defines the gas price or limit.

### Where should the reviewer start?
See if EstimatedGasProvider makes more sense than the DefaultGasProvider. 

### Why is it needed?
Dapp developers must have a way to estimate the gas cost that is built into the tools they use. Currently, the provided default gives a hard-coded value, which is:
GAS_LIMIT = 4_300_000
GAS_PRICE = 22_000_000_000
That equals to $20.98 on Ethereum mainnet
