### PR TITLE
Interactive ethCall and ethSendTransaction

### DIFF
--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -191,7 +191,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.tx.interactions.EthTransactionInteraction functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
                         + "      FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
@@ -235,7 +235,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> functionName(java.math.BigInteger param, java.math.BigInteger weiValue) {\n"
+                "public org.web3j.tx.interactions.EthTransactionInteraction functionName(java.math.BigInteger param, java.math.BigInteger weiValue) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
                         + "      FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
@@ -260,7 +260,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<java.math.BigInteger> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.tx.interactions.EthCallInteraction<java.math.BigInteger> functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}));\n"
@@ -284,19 +284,11 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.math.BigInteger param) {\n"
+                "public org.web3j.tx.interactions.EthCallInteraction<java.util.List> functionName(java.math.BigInteger param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
-                        + "      new java.util.concurrent.Callable<java.util.List>() {\n"
-                        + "        @java.lang.Override\n"
-                        + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
-                        + "        public java.util.List call() throws java.lang.Exception {\n"
-                        + "          java.util.List<org.web3j.abi.datatypes.Type> result = (java.util.List<org.web3j.abi.datatypes.Type>) executeCallSingleValueReturn(function, java.util.List.class);\n"
-                        + "          return convertToNative(result);\n"
-                        + "        }\n"
-                        + "      });\n"
+                        + "  return executeInteractiveCallSingleValueReturn(function,java.util.List.class, (rawResponse)-> convertToNative((List<Type>)rawResponse));\n"
                         + "}\n";
 
         assertThat(methodSpec.toString(), is(expected));
@@ -316,21 +308,13 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.util.List<java.math.BigInteger> param) {\n"
+                "public org.web3j.tx.interactions.EthCallInteraction<java.util.List> functionName(java.util.List<java.math.BigInteger> param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint8>(\n"
                         + "              org.web3j.abi.datatypes.generated.Uint8.class,\n"
                         + "              org.web3j.abi.Utils.typeMap(param, org.web3j.abi.datatypes.generated.Uint8.class))), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
-                        + "      new java.util.concurrent.Callable<java.util.List>() {\n"
-                        + "        @java.lang.Override\n"
-                        + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
-                        + "        public java.util.List call() throws java.lang.Exception {\n"
-                        + "          java.util.List<org.web3j.abi.datatypes.Type> result = (java.util.List<org.web3j.abi.datatypes.Type>) executeCallSingleValueReturn(function, java.util.List.class);\n"
-                        + "          return convertToNative(result);\n"
-                        + "        }\n"
-                        + "      });\n"
+                        + "  return executeInteractiveCallSingleValueReturn(function,java.util.List.class, (rawResponse)-> convertToNative((List<Type>)rawResponse));\n"
                         + "}\n";
 
         assertThat(methodSpec.toString(), is(expected));
@@ -350,22 +334,14 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<java.util.List> functionName(java.util.List<java.util.List<java.math.BigInteger>> param) {\n"
+                "public org.web3j.tx.interactions.EthCallInteraction<java.util.List> functionName(java.util.List<java.util.List<java.math.BigInteger>> param) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.DynamicArray>(\n"
                         + "              org.web3j.abi.datatypes.DynamicArray.class,\n"
                         + "              org.web3j.abi.Utils.typeMap(param, org.web3j.abi.datatypes.DynamicArray.class,\n"
                         + "      org.web3j.abi.datatypes.generated.Uint8.class))), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<java.util.List>(function,\n"
-                        + "      new java.util.concurrent.Callable<java.util.List>() {\n"
-                        + "        @java.lang.Override\n"
-                        + "        @java.lang.SuppressWarnings(\"unchecked\")\n"
-                        + "        public java.util.List call() throws java.lang.Exception {\n"
-                        + "          java.util.List<org.web3j.abi.datatypes.Type> result = (java.util.List<org.web3j.abi.datatypes.Type>) executeCallSingleValueReturn(function, java.util.List.class);\n"
-                        + "          return convertToNative(result);\n"
-                        + "        }\n"
-                        + "      });\n"
+                        + "  return executeInteractiveCallSingleValueReturn(function,java.util.List.class, (rawResponse)-> convertToNative((List<Type>)rawResponse));\n"
                         + "}\n";
 
         assertThat(methodSpec.toString(), is(expected));
@@ -405,21 +381,15 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         MethodSpec methodSpec = solidityFunctionWrapper.buildFunction(functionDefinition);
 
         String expected =
-                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>> functionName(java.math.BigInteger param1, java.math.BigInteger param2) {\n"
+                "public org.web3j.tx.interactions.EthCallInteraction<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>> functionName(java.math.BigInteger param1, java.math.BigInteger param2) {\n"
                         + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
                         + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param1), \n"
                         + "      new org.web3j.abi.datatypes.generated.Uint32(param2)), \n"
                         + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}, new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int32>() {}));\n"
-                        + "  return new org.web3j.protocol.core.RemoteFunctionCall<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>>(function,\n"
-                        + "      new java.util.concurrent.Callable<org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>>() {\n"
-                        + "        @java.lang.Override\n"
-                        + "        public org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger> call() throws java.lang.Exception {\n"
-                        + "          java.util.List<org.web3j.abi.datatypes.Type> results = executeCallMultipleValueReturn(function);\n"
-                        + "          return new org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>(\n"
-                        + "              (java.math.BigInteger) results.get(0).getValue(), \n"
-                        + "              (java.math.BigInteger) results.get(1).getValue());\n"
-                        + "        }\n"
-                        + "      });\n"
+                        + "  return executeInteractiveCallMultipleValueReturn(function, (results) ->\n"
+                        + "      new org.web3j.tuples.generated.Tuple2<java.math.BigInteger, java.math.BigInteger>(\n"
+                        + "          (java.math.BigInteger) results.get(0).getValue(), \n"
+                        + "          (java.math.BigInteger) results.get(1).getValue()));\n"
                         + "}\n";
 
         assertThat(methodSpec.toString(), is(expected));

--- a/codegen/src/test/java/org/web3j/codegen/TruffleJsonFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/TruffleJsonFunctionWrapperGeneratorTest.java
@@ -50,7 +50,8 @@ public class TruffleJsonFunctionWrapperGeneratorTest extends TempFileProvider {
                             Collections.singletonList(sourceFile));
             JavaCompiler.CompilationTask task =
                     compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
-            assertTrue("Generated contract contains compile time error", task.call());
+            boolean response = task.call();
+            assertTrue("Generated contract contains compile time error", response);
         }
     }
 

--- a/core/src/main/java/org/web3j/ens/contracts/generated/ENS.java
+++ b/core/src/main/java/org/web3j/ens/contracts/generated/ENS.java
@@ -24,6 +24,7 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.Contract;
 import org.web3j.tx.TransactionManager;
 import org.web3j.tx.gas.ContractGasProvider;
+import org.web3j.tx.interactions.EthTransactionInteraction;
 
 /**
  * <p>Auto generated code.
@@ -99,7 +100,7 @@ public class ENS extends Contract {
         return executeRemoteCallSingleValueReturn(function, String.class);
     }
 
-    public RemoteCall<TransactionReceipt> setSubnodeOwner(byte[] node, byte[] label, String owner) {
+    public EthTransactionInteraction setSubnodeOwner(byte[] node, byte[] label, String owner) {
         final Function function = new Function(
                 FUNC_SETSUBNODEOWNER, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -109,7 +110,7 @@ public class ENS extends Contract {
         return executeRemoteCallTransaction(function);
     }
 
-    public RemoteCall<TransactionReceipt> setTTL(byte[] node, BigInteger ttl) {
+    public EthTransactionInteraction setTTL(byte[] node, BigInteger ttl) {
         final Function function = new Function(
                 FUNC_SETTTL, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -125,7 +126,7 @@ public class ENS extends Contract {
         return executeRemoteCallSingleValueReturn(function, BigInteger.class);
     }
 
-    public RemoteCall<TransactionReceipt> setResolver(byte[] node, String resolver) {
+    public EthTransactionInteraction setResolver(byte[] node, String resolver) {
         final Function function = new Function(
                 FUNC_SETRESOLVER, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -134,7 +135,7 @@ public class ENS extends Contract {
         return executeRemoteCallTransaction(function);
     }
 
-    public RemoteCall<TransactionReceipt> setOwner(byte[] node, String owner) {
+    public EthTransactionInteraction setOwner(byte[] node, String owner) {
         final Function function = new Function(
                 FUNC_SETOWNER, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 

--- a/core/src/main/java/org/web3j/ens/contracts/generated/PublicResolver.java
+++ b/core/src/main/java/org/web3j/ens/contracts/generated/PublicResolver.java
@@ -30,6 +30,7 @@ import org.web3j.tuples.generated.Tuple2;
 import org.web3j.tx.Contract;
 import org.web3j.tx.TransactionManager;
 import org.web3j.tx.gas.ContractGasProvider;
+import org.web3j.tx.interactions.EthTransactionInteraction;
 
 /**
  * <p>Auto generated code.
@@ -118,7 +119,7 @@ public class PublicResolver extends Contract {
         return executeRemoteCallSingleValueReturn(function, Boolean.class);
     }
 
-    public RemoteCall<TransactionReceipt> setText(byte[] node, String key, String value) {
+    public EthTransactionInteraction setText(byte[] node, String key, String value) {
         final Function function = new Function(
                 FUNC_SETTEXT, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -133,7 +134,7 @@ public class PublicResolver extends Contract {
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
                 new org.web3j.abi.datatypes.generated.Uint256(contentTypes)), 
                 Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}, new TypeReference<DynamicBytes>() {}));
-        return new RemoteCall<Tuple2<BigInteger, byte[]>>(
+        return RemoteCall.fromCallable(
                 new Callable<Tuple2<BigInteger, byte[]>>() {
                     @Override
                     public Tuple2<BigInteger, byte[]> call() throws Exception {
@@ -145,7 +146,7 @@ public class PublicResolver extends Contract {
                 });
     }
 
-    public RemoteCall<TransactionReceipt> setPubkey(byte[] node, byte[] x, byte[] y) {
+    public EthTransactionInteraction setPubkey(byte[] node, byte[] x, byte[] y) {
         final Function function = new Function(
                 FUNC_SETPUBKEY, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -177,7 +178,7 @@ public class PublicResolver extends Contract {
         return executeRemoteCallSingleValueReturn(function, String.class);
     }
 
-    public RemoteCall<TransactionReceipt> setABI(byte[] node, BigInteger contentType, byte[] data) {
+    public EthTransactionInteraction setABI(byte[] node, BigInteger contentType, byte[] data) {
         final Function function = new Function(
                 FUNC_SETABI, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -194,7 +195,7 @@ public class PublicResolver extends Contract {
         return executeRemoteCallSingleValueReturn(function, String.class);
     }
 
-    public RemoteCall<TransactionReceipt> setName(byte[] node, String name) {
+    public EthTransactionInteraction setName(byte[] node, String name) {
         final Function function = new Function(
                 FUNC_SETNAME, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -203,7 +204,7 @@ public class PublicResolver extends Contract {
         return executeRemoteCallTransaction(function);
     }
 
-    public RemoteCall<TransactionReceipt> setContent(byte[] node, byte[] hash) {
+    public EthTransactionInteraction setContent(byte[] node, byte[] hash) {
         final Function function = new Function(
                 FUNC_SETCONTENT, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
@@ -216,7 +217,7 @@ public class PublicResolver extends Contract {
         final Function function = new Function(FUNC_PUBKEY, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)), 
                 Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>() {}, new TypeReference<Bytes32>() {}));
-        return new RemoteCall<Tuple2<byte[], byte[]>>(
+        return RemoteCall.fromCallable(
                 new Callable<Tuple2<byte[], byte[]>>() {
                     @Override
                     public Tuple2<byte[], byte[]> call() throws Exception {
@@ -228,7 +229,7 @@ public class PublicResolver extends Contract {
                 });
     }
 
-    public RemoteCall<TransactionReceipt> setAddr(byte[] node, String addr) {
+    public EthTransactionInteraction setAddr(byte[] node, String addr) {
         final Function function = new Function(
                 FUNC_SETADDR, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 

--- a/core/src/main/java/org/web3j/protocol/core/RemoteCall.java
+++ b/core/src/main/java/org/web3j/protocol/core/RemoteCall.java
@@ -24,13 +24,7 @@ import org.web3j.utils.Async;
  *
  * @param <T> Our return type.
  */
-public class RemoteCall<T> {
-
-    private Callable<T> callable;
-
-    public RemoteCall(Callable<T> callable) {
-        this.callable = callable;
-    }
+public interface RemoteCall<T> {
 
     /**
      * Perform request synchronously.
@@ -38,16 +32,14 @@ public class RemoteCall<T> {
      * @return result of enclosed function
      * @throws Exception if the function throws an exception
      */
-    public T send() throws Exception {
-        return callable.call();
-    }
+    T send() throws Exception;
 
     /**
      * Perform request asynchronously with a future.
      *
      * @return a future containing our function
      */
-    public CompletableFuture<T> sendAsync() {
+    default CompletableFuture<T> sendAsync() {
         return Async.run(this::send);
     }
 
@@ -56,7 +48,11 @@ public class RemoteCall<T> {
      *
      * @return an flowable
      */
-    public Flowable<T> flowable() {
+    default Flowable<T> flowable() {
         return Flowable.fromCallable(this::send);
+    }
+
+    static <T> RemoteCall<T> fromCallable(Callable<T> callable) {
+        return callable::call;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/core/RemoteFunctionCall.java
+++ b/core/src/main/java/org/web3j/protocol/core/RemoteFunctionCall.java
@@ -12,44 +12,17 @@
  */
 package org.web3j.protocol.core;
 
-import java.util.List;
-import java.util.concurrent.Callable;
-
-import org.web3j.abi.FunctionEncoder;
-import org.web3j.abi.FunctionReturnDecoder;
-import org.web3j.abi.datatypes.Function;
-import org.web3j.abi.datatypes.Type;
-
 /**
  * A wrapper for a callable function. Can also return the raw encoded function
  *
  * @param <T> Our return type.
  */
-public class RemoteFunctionCall<T> extends RemoteCall<T> {
-
-    private final Function function;
-
-    public RemoteFunctionCall(Function function, Callable<T> callable) {
-        super(callable);
-        this.function = function;
-    }
+public interface RemoteFunctionCall<T> extends RemoteCall<T> {
 
     /**
      * return an encoded function, so it can be manually signed and transmitted
      *
      * @return the function call, encoded.
      */
-    public String encodeFunctionCall() {
-        return FunctionEncoder.encode(function);
-    }
-
-    /**
-     * decode a method response
-     *
-     * @param response
-     * @return
-     */
-    public List<Type> decodeFunctionResponse(String response) {
-        return FunctionReturnDecoder.decode(response, function.getOutputParameters());
-    }
+    String encodeFunctionCall();
 }

--- a/core/src/main/java/org/web3j/protocol/core/Request.java
+++ b/core/src/main/java/org/web3j/protocol/core/Request.java
@@ -17,11 +17,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.reactivex.Flowable;
-
 import org.web3j.protocol.Web3jService;
 
-public class Request<S, T extends Response> {
+public class Request<S, T extends Response> implements RemoteCall<T> {
     private static AtomicLong nextId = new AtomicLong(0);
 
     private String jsonrpc = "2.0";
@@ -77,15 +75,13 @@ public class Request<S, T extends Response> {
         this.id = id;
     }
 
+    @Override
     public T send() throws IOException {
         return web3jService.send(this, responseType);
     }
 
+    @Override
     public CompletableFuture<T> sendAsync() {
         return web3jService.sendAsync(this, responseType);
-    }
-
-    public Flowable<T> flowable() {
-        return new RemoteCall<>(this::send).flowable();
     }
 }

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetTransactionReceipt.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetTransactionReceipt.java
@@ -22,10 +22,9 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import org.web3j.protocol.ObjectMapperFactory;
-import org.web3j.protocol.core.Response;
 
 /** eth_getTransactionReceipt. */
-public class EthGetTransactionReceipt extends Response<TransactionReceipt> {
+public class EthGetTransactionReceipt extends TransactionReceiptContainer<TransactionReceipt> {
 
     public Optional<TransactionReceipt> getTransactionReceipt() {
         return Optional.ofNullable(getResult());

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceiptContainer.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceiptContainer.java
@@ -10,22 +10,14 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.protocol.core.methods.response;
 
-public class Pair<TFirst, TSecond> {
-    private final TFirst first;
-    private final TSecond second;
+import java.util.Optional;
 
-    public TFirst getFirst() {
-        return first;
-    }
+import org.web3j.protocol.core.Response;
 
-    public TSecond getSecond() {
-        return second;
-    }
-
-    public Pair(TFirst first, TSecond second) {
-        this.first = first;
-        this.second = second;
-    }
+/** eth_getTransactionReceipt. */
+public abstract class TransactionReceiptContainer<T extends TransactionReceipt>
+        extends Response<T> {
+    public abstract Optional<T> getTransactionReceipt();
 }

--- a/core/src/main/java/org/web3j/protocol/exceptions/EthCallException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/EthCallException.java
@@ -10,22 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.protocol.exceptions;
 
-public class Pair<TFirst, TSecond> {
-    private final TFirst first;
-    private final TSecond second;
+import org.web3j.protocol.core.Response;
 
-    public TFirst getFirst() {
-        return first;
+public class EthCallException extends RpcErrorResponseException {
+    String revertReason;
+
+    public EthCallException(Response.Error error, String revertReson) {
+        super(error);
     }
 
-    public TSecond getSecond() {
-        return second;
-    }
-
-    public Pair(TFirst first, TSecond second) {
-        this.first = first;
-        this.second = second;
+    public String getRevertReason() {
+        return revertReason;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/exceptions/RpcErrorResponseException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/RpcErrorResponseException.java
@@ -10,22 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.protocol.exceptions;
 
-public class Pair<TFirst, TSecond> {
-    private final TFirst first;
-    private final TSecond second;
+import org.web3j.protocol.core.Response;
 
-    public TFirst getFirst() {
-        return first;
+public class RpcErrorResponseException extends Exception {
+    Response.Error response;
+
+    public RpcErrorResponseException(Response.Error error) {
+        super(error.getMessage());
     }
 
-    public TSecond getSecond() {
-        return second;
-    }
-
-    public Pair(TFirst first, TSecond second) {
-        this.first = first;
-        this.second = second;
+    public Response.Error getResponse() {
+        return response;
     }
 }

--- a/core/src/main/java/org/web3j/protocol/exceptions/TransactionException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/TransactionException.java
@@ -13,12 +13,13 @@
 package org.web3j.protocol.exceptions;
 
 import java.util.Optional;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Transaction timeout exception indicates that we have breached some threshold waiting for a
  * transaction to execute.
  */
-public class TransactionException extends Exception {
+public class TransactionException extends TimeoutException {
 
     private Optional<String> transactionHash = Optional.empty();
 
@@ -32,7 +33,7 @@ public class TransactionException extends Exception {
     }
 
     public TransactionException(Throwable cause) {
-        super(cause);
+        super();
     }
 
     /**

--- a/core/src/main/java/org/web3j/tx/ManagedTransaction.java
+++ b/core/src/main/java/org/web3j/tx/ManagedTransaction.java
@@ -20,7 +20,11 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.EthCallException;
+import org.web3j.protocol.exceptions.RpcErrorResponseException;
 import org.web3j.protocol.exceptions.TransactionException;
+import org.web3j.tx.interactions.EthTransactionInteraction;
+import org.web3j.tx.interactions.EthTransactionReceiptInteraction;
 
 /** Generic transaction manager. */
 public abstract class ManagedTransaction {
@@ -95,11 +99,10 @@ public abstract class ManagedTransaction {
         return ethGasPrice.getGasPrice();
     }
 
-    protected TransactionReceipt send(
+    protected EthTransactionReceiptInteraction send(
             String to, String data, BigInteger value, BigInteger gasPrice, BigInteger gasLimit)
-            throws IOException, TransactionException {
-
-        return transactionManager.executeTransaction(gasPrice, gasLimit, to, data, value);
+            throws IOException, RpcErrorResponseException {
+        return transactionManager.submitTransaction(gasPrice, gasLimit, to, data, value);
     }
 
     protected TransactionReceipt send(
@@ -109,15 +112,25 @@ public abstract class ManagedTransaction {
             BigInteger gasPrice,
             BigInteger gasLimit,
             boolean constructor)
-            throws IOException, TransactionException {
+            throws IOException, TransactionException, InterruptedException {
 
         return transactionManager.executeTransaction(
                 gasPrice, gasLimit, to, data, value, constructor);
     }
 
     protected String call(String to, String data, DefaultBlockParameter defaultBlockParameter)
-            throws IOException {
+            throws IOException, EthCallException {
 
         return transactionManager.sendCall(to, data, defaultBlockParameter);
+    }
+
+    /**
+     * Submit a transaction to network. This method returns RemoteCall that can be sent to
+     * immediately get transactionHash
+     */
+    EthTransactionInteraction submitTransaction(
+            String to, String data, BigInteger value, BigInteger gasPrice, BigInteger gasLimit) {
+        return new EthTransactionInteraction(
+                transactionManager, gasPrice, gasLimit, to, data, value);
     }
 }

--- a/core/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/TransactionManager.java
@@ -19,7 +19,11 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.EthCallException;
+import org.web3j.protocol.exceptions.RpcErrorResponseException;
 import org.web3j.protocol.exceptions.TransactionException;
+import org.web3j.tx.interactions.EthCallInteraction;
+import org.web3j.tx.interactions.EthTransactionReceiptInteraction;
 import org.web3j.tx.response.PollingTransactionReceiptProcessor;
 import org.web3j.tx.response.TransactionReceiptProcessor;
 
@@ -55,13 +59,24 @@ public abstract class TransactionManager {
         this(new PollingTransactionReceiptProcessor(web3j, sleepDuration, attempts), fromAddress);
     }
 
+    /**
+     * Use {@link #submitTransaction(BigInteger, BigInteger, String, String, BigInteger)} instead
+     * Code should be changed to submitTransaction().waitForReceipt() to get same result as before
+     */
+    @Deprecated
     protected TransactionReceipt executeTransaction(
             BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
-            throws IOException, TransactionException {
+            throws IOException, TransactionException, InterruptedException, EthCallException {
 
         return executeTransaction(gasPrice, gasLimit, to, data, value, false);
     }
 
+    /**
+     * @deprecated use {@link #submitTransaction(BigInteger, BigInteger, String, String, BigInteger,
+     *     boolean)} instead Code should be changed to submitTransaction().waitForReceipt() to get
+     *     same result as before
+     */
+    @Deprecated
     protected TransactionReceipt executeTransaction(
             BigInteger gasPrice,
             BigInteger gasLimit,
@@ -69,7 +84,7 @@ public abstract class TransactionManager {
             String data,
             BigInteger value,
             boolean constructor)
-            throws IOException, TransactionException {
+            throws IOException, TransactionException, InterruptedException {
 
         EthSendTransaction ethSendTransaction =
                 sendTransaction(gasPrice, gasLimit, to, data, value, constructor);
@@ -82,24 +97,106 @@ public abstract class TransactionManager {
         return sendTransaction(gasPrice, gasLimit, to, data, value, false);
     }
 
-    public abstract EthSendTransaction sendTransaction(
+    public EthSendTransaction sendTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger nonce,
+            BigInteger value)
+            throws IOException {
+        return sendTransaction(gasPrice, gasLimit, to, data, value, nonce, false);
+    }
+
+    public EthSendTransaction sendTransaction(
             BigInteger gasPrice,
             BigInteger gasLimit,
             String to,
             String data,
             BigInteger value,
             boolean constructor)
+            throws IOException {
+        return sendTransaction(gasPrice, gasLimit, to, data, null, value, constructor);
+    }
+
+    public abstract EthSendTransaction sendTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger nonce,
+            BigInteger value,
+            boolean constructor)
             throws IOException;
 
     public abstract String sendCall(
-            String to, String data, DefaultBlockParameter defaultBlockParameter) throws IOException;
+            String to, String data, DefaultBlockParameter defaultBlockParameter)
+            throws IOException, EthCallException;
+
+    public EthTransactionReceiptInteraction submitTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger nonce)
+            throws IOException, RpcErrorResponseException {
+        return submitTransaction(gasPrice, gasLimit, to, data, value, nonce, false);
+    }
+
+    public EthTransactionReceiptInteraction submitTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger nonce,
+            boolean constructor)
+            throws IOException, RpcErrorResponseException {
+        EthSendTransaction ethSendTransaction =
+                sendTransaction(gasPrice, gasLimit, to, data, nonce, value, constructor);
+        if (ethSendTransaction.hasError()) {
+            if (ethSendTransaction.hasError()) {
+                throw new RpcErrorResponseException(ethSendTransaction.getError());
+            }
+        }
+        return new EthTransactionReceiptInteraction(
+                gasLimit, ethSendTransaction, this.transactionReceiptProcessor);
+    }
+
+    public EthTransactionReceiptInteraction submitTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException, RpcErrorResponseException {
+        return submitTransaction(gasPrice, gasLimit, to, data, value, null, constructor);
+    }
+
+    public EthTransactionReceiptInteraction submitTransaction(
+            BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
+            throws IOException, RpcErrorResponseException {
+        return submitTransaction(gasPrice, gasLimit, to, data, value, false);
+    }
+
+    public EthCallInteraction<String> sendInteractiveCall(String to, String data) {
+        return sendInteractiveCall(to, data, a -> a);
+    }
+
+    public <T> EthCallInteraction<T> sendInteractiveCall(
+            String to, String data, EthCallInteraction.CallResponseParser<T> responseParser) {
+        return new EthCallInteraction<T>(data, to, this, responseParser);
+    }
 
     public String getFromAddress() {
         return fromAddress;
     }
 
+    @Deprecated
     private TransactionReceipt processResponse(EthSendTransaction transactionResponse)
-            throws IOException, TransactionException {
+            throws IOException, TransactionException, InterruptedException {
         if (transactionResponse.hasError()) {
             throw new RuntimeException(
                     "Error processing transaction request: "

--- a/core/src/main/java/org/web3j/tx/exceptions/FailedReceiptException.java
+++ b/core/src/main/java/org/web3j/tx/exceptions/FailedReceiptException.java
@@ -10,16 +10,23 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.tx.response;
+package org.web3j.tx.exceptions;
 
-import java.util.Optional;
-
-import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
-/** Transaction receipt processor callback. */
-public interface Callback {
-    void success(TransactionReceipt transactionReceipt, Optional<Response.Error> error);
+/**
+ * Exception thrown when transaction receipt is received with return code 0x0 The transaction
+ * receipt can still be received using the {@link FailedReceiptException#getTransactionReceipt()}
+ */
+public class FailedReceiptException extends Exception {
+    private final TransactionReceipt transactionReceipt;
 
-    void exception(Exception exception);
+    public FailedReceiptException(String message, TransactionReceipt transactionReceipt) {
+        super(message);
+        this.transactionReceipt = transactionReceipt;
+    }
+
+    public TransactionReceipt getTransactionReceipt() {
+        return transactionReceipt;
+    }
 }

--- a/core/src/main/java/org/web3j/tx/interactions/EthCallInteraction.java
+++ b/core/src/main/java/org/web3j/tx/interactions/EthCallInteraction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.interactions;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.RemoteFunctionCall;
+import org.web3j.protocol.exceptions.EthCallException;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.exceptions.ContractCallException;
+
+/**
+ * This class is created for making a ethCall. Before sending the call the block number at which the
+ * call is to be executed can be set.
+ *
+ * @param <T> Type of response returned by the call
+ */
+public class EthCallInteraction<T> implements RemoteFunctionCall<T> {
+    public interface CallResponseParser<T> {
+        T processSendResponse(String data) throws ContractCallException;
+    }
+
+    protected final String data;
+    protected final String to;
+    protected final TransactionManager transactionManager;
+    private DefaultBlockParameter blockParameter = DefaultBlockParameterName.LATEST;
+    private final CallResponseParser<T> callResponseParser;
+
+    public EthCallInteraction(
+            String data,
+            String to,
+            TransactionManager transactionManager,
+            CallResponseParser<T> callResponseParser) {
+        this.data = data;
+        this.to = to;
+        this.transactionManager = transactionManager;
+        this.callResponseParser = callResponseParser;
+    }
+
+    /** Set the block number at which the call is to be executed. */
+    public EthCallInteraction<T> atBlockNumber(BigInteger blockNumber) {
+        blockParameter = DefaultBlockParameter.valueOf(blockNumber);
+        return this;
+    }
+
+    /** Set the block number at which the call is to be executed. */
+    public EthCallInteraction<T> atBlockNumber(long blockNumber) {
+        return atBlockNumber(BigInteger.valueOf(blockNumber));
+    }
+
+    public T send() throws IOException, EthCallException {
+        String s = transactionManager.sendCall(to, data, blockParameter);
+        if (s == null) {
+            throw new EthCallException(null, "Empty value (0x) returned from contract");
+        }
+        return callResponseParser.processSendResponse(s);
+    }
+
+    @Override
+    public String encodeFunctionCall() {
+        return data;
+    }
+
+    /**
+     * decode a method response
+     *
+     * @param rawResponse
+     * @return
+     */
+    public T decodeRawResponse(String rawResponse) {
+        return callResponseParser.processSendResponse(data);
+    }
+}

--- a/core/src/main/java/org/web3j/tx/interactions/EthTransactionInteraction.java
+++ b/core/src/main/java/org/web3j/tx/interactions/EthTransactionInteraction.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.interactions;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.web3j.protocol.core.RemoteFunctionCall;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.RpcErrorResponseException;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.exceptions.FailedReceiptException;
+import org.web3j.tx.response.TransactionCallBack;
+import org.web3j.utils.Async;
+
+/**
+ * Interactions before submitting a transaction You can override - gasPrice and gasLimit instead of
+ * using from the gasProvicer - nonce
+ */
+public final class EthTransactionInteraction implements RemoteFunctionCall<TransactionReceipt> {
+    private static final Logger logger = LoggerFactory.getLogger(EthTransactionInteraction.class);
+    private BigInteger gasPrice;
+    private BigInteger gasLimit;
+    private final String data;
+    private final BigInteger weiValue;
+    private final String to;
+    private final TransactionManager transactionManager;
+    private BigInteger nonce = null;
+
+    public EthTransactionInteraction(
+            TransactionManager transactionManager,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger weiValue) {
+        this.transactionManager = transactionManager;
+        this.gasLimit = gasLimit;
+        this.gasPrice = gasPrice;
+        this.data = data;
+        this.weiValue = weiValue;
+        this.to = to;
+    }
+
+    public void setGasPriceInGWei(float price) {
+        gasPrice =
+                (BigDecimal.valueOf(price * 1_000_000_000).setScale(0, RoundingMode.FLOOR))
+                        .toBigInteger();
+    }
+
+    public EthTransactionInteraction gasPrice(BigInteger gasPrice) {
+        this.gasPrice = gasPrice;
+        return this;
+    }
+
+    public EthTransactionInteraction gasLimit(BigInteger gasLimit) {
+        this.gasLimit = gasLimit;
+        return this;
+    }
+
+    public EthTransactionInteraction nonce(BigInteger nonce) {
+        this.nonce = nonce;
+        return this;
+    }
+
+    public EthTransactionReceiptInteraction submit() throws IOException, RpcErrorResponseException {
+        return transactionManager.submitTransaction(gasPrice, gasLimit, to, data, weiValue, nonce);
+    }
+
+    /**
+     * This should be deprecated so that send() should not be used for getting TransactionReceipt
+     * directly. Later the deprecation will be remed and the function should return an instance of
+     * EthTransactionReceiptInteraction
+     *
+     * @deprecated Deprecated in favor of {@link #submit()} then calling {@link
+     *     EthTransactionReceiptInteraction#waitForReceipt()} for transaction receipt
+     */
+    @Deprecated
+    public TransactionReceipt send()
+            throws IOException, InterruptedException, TimeoutException, FailedReceiptException,
+                    RpcErrorResponseException {
+        return transactionManager
+                .submitTransaction(gasPrice, gasLimit, to, data, weiValue, nonce)
+                .waitForReceipt();
+    }
+
+    /**
+     * Perform the
+     *
+     * @param callBack
+     */
+    public void submitAsync(TransactionCallBack callBack) {
+        Async.submit(
+                () -> {
+                    submit(callBack);
+                });
+    }
+
+    public String getTxData() {
+        return data;
+    }
+    /**
+     * same as send() but the code about what to do after send is passed as parameter. Note that
+     * this methods blocks the current thread until the all the operation is not complete.
+     *
+     * @param callBack
+     */
+    public void submit(TransactionCallBack callBack) {
+        try {
+            EthTransactionReceiptInteraction send = this.submit();
+            String transactionHash = send.getTransactionHash();
+            try {
+                callBack.transactionHash(transactionHash);
+            } catch (Exception ex) {
+                logger.error("Unexpected exception on transactionHash callback", ex);
+            }
+            // send For callback will not throw exception.
+            send.send(callBack);
+
+        } catch (Exception ex) {
+            callBack.exception(ex);
+        }
+    }
+
+    public String encodeFunctionCall() {
+        return data;
+    }
+}

--- a/core/src/main/java/org/web3j/tx/interactions/EthTransactionReceiptInteraction.java
+++ b/core/src/main/java/org/web3j/tx/interactions/EthTransactionReceiptInteraction.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.interactions;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.web3j.crypto.Pair;
+import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.exceptions.FailedReceiptException;
+import org.web3j.tx.response.TransactionReceiptCallback;
+import org.web3j.tx.response.TransactionReceiptProcessor;
+import org.web3j.utils.Async;
+import org.web3j.utils.Numeric;
+
+/**
+ * This class instance is returned after a successful submission of transaction. It contains the
+ * transactionHash of the transaction and {@link #waitForReceipt()} can be called to get full detail
+ * of the transaction after it appears in a block.
+ */
+public class EthTransactionReceiptInteraction implements RemoteCall<TransactionReceipt> {
+
+    Logger logger = LoggerFactory.getLogger(EthTransactionReceiptInteraction.class);
+    private final EthSendTransaction ethSendTransaction;
+    private final TransactionReceiptProcessor transactionReceiptProcessor;
+    private final BigInteger gasLimit;
+
+    public EthTransactionReceiptInteraction(
+            BigInteger gasLimit,
+            EthSendTransaction ethSendTransaction,
+            TransactionReceiptProcessor transactionReceiptProcessor) {
+        this.ethSendTransaction = ethSendTransaction;
+        this.transactionReceiptProcessor = transactionReceiptProcessor;
+        ;
+        this.gasLimit = gasLimit;
+    }
+
+    @Override
+    public TransactionReceipt send()
+            throws InterruptedException, IOException, TimeoutException, FailedReceiptException {
+        return waitForReceipt();
+    }
+
+    /**
+     * Send Async request and expect callback. This method returns immediately submitting the task
+     * to a background thread. All the callbacks are handled by another thread.
+     *
+     * @param callback
+     */
+    public void sendAsync(TransactionReceiptCallback callback) {
+        Async.submit(
+                () -> {
+                    try {
+                        send(callback);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+    }
+
+    /**
+     * Use a callback mechanism to handle events. Note that everything will be blocking and all the
+     * callbacks will be called on current thread.
+     *
+     * @param callback
+     */
+    public void send(TransactionReceiptCallback callback) throws InterruptedException {
+        try {
+            Pair<? extends TransactionReceipt, Optional<Response.Error>> optionalPair =
+                    waitAndProcessResponse();
+            try {
+                callback.success(optionalPair.getFirst(), optionalPair.getSecond());
+                // this is important!
+                // Once I had a condition where success function threw Runtime exception.
+                // then the exception handler was called,
+                // This means both onSuccess and onFailure condition are called.
+            } catch (Exception ex) {
+                logger.error("Callback function threw Unexpected Exception", ex);
+            }
+        } catch (IOException | TimeoutException e) {
+            callback.exception(e);
+        }
+    }
+
+    public TransactionReceipt waitForReceipt()
+            throws IOException, TimeoutException, InterruptedException, FailedReceiptException {
+        Pair<? extends TransactionReceipt, Optional<Response.Error>> optionalPair =
+                waitAndProcessResponse();
+        if (optionalPair.getSecond().isPresent()) {
+            throw new FailedReceiptException(
+                    optionalPair.getSecond().get().getMessage(), optionalPair.getFirst());
+        } else return optionalPair.getFirst();
+    }
+
+    public boolean hasError() {
+        return ethSendTransaction.hasError();
+    }
+
+    public Response.Error getError() {
+        return ethSendTransaction.getError();
+    }
+
+    public String getTransactionHash() {
+        return ethSendTransaction.getTransactionHash();
+    }
+
+    private Pair<? extends TransactionReceipt, Optional<Response.Error>> waitAndProcessResponse()
+            throws TimeoutException, InterruptedException, IOException {
+        Pair<? extends TransactionReceipt, Optional<Response.Error>> optionalPair =
+                transactionReceiptProcessor.waitForTransactionReceiptResponse(
+                        ethSendTransaction.getTransactionHash());
+        if (!optionalPair.getSecond().isPresent() && !optionalPair.getFirst().isStatusOK()) {
+            TransactionReceipt first = optionalPair.getFirst();
+            Response.Error error = new Response.Error();
+            error.setCode(Numeric.decodeQuantity(first.getStatus()).intValue());
+            error.setData(first.getStatus());
+            if (gasLimit.equals(first.getGasUsed())) {
+                error.setMessage(
+                        "Transaction has failed with status: "
+                                + first.getStatus()
+                                + ".(not enough gas?)");
+            } else {
+                error.setMessage(
+                        "Transaction has failed with status: "
+                                + first.getStatus()
+                                + ". Gas used: "
+                                + first.getGasUsed());
+            }
+            return new Pair<>(first, Optional.of(error));
+        }
+        return optionalPair;
+    }
+}

--- a/core/src/main/java/org/web3j/tx/response/NoOpProcessor.java
+++ b/core/src/main/java/org/web3j/tx/response/NoOpProcessor.java
@@ -13,8 +13,11 @@
 package org.web3j.tx.response;
 
 import java.io.IOException;
+import java.util.Optional;
 
+import org.web3j.crypto.Pair;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionException;
 
@@ -26,6 +29,12 @@ public class NoOpProcessor extends TransactionReceiptProcessor {
 
     public NoOpProcessor(Web3j web3j) {
         super(web3j);
+    }
+
+    @Override
+    public Pair<TransactionReceipt, Optional<Response.Error>> waitForTransactionReceiptResponse(
+            String transactionHash) {
+        return new Pair<>(new EmptyTransactionReceipt(transactionHash), Optional.empty());
     }
 
     @Override

--- a/core/src/main/java/org/web3j/tx/response/TransactionCallBack.java
+++ b/core/src/main/java/org/web3j/tx/response/TransactionCallBack.java
@@ -10,22 +10,8 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.tx.response;
 
-public class Pair<TFirst, TSecond> {
-    private final TFirst first;
-    private final TSecond second;
-
-    public TFirst getFirst() {
-        return first;
-    }
-
-    public TSecond getSecond() {
-        return second;
-    }
-
-    public Pair(TFirst first, TSecond second) {
-        this.first = first;
-        this.second = second;
-    }
+public interface TransactionCallBack extends TransactionReceiptCallback {
+    void transactionHash(String hash);
 }

--- a/core/src/main/java/org/web3j/tx/response/TransactionReceiptCallback.java
+++ b/core/src/main/java/org/web3j/tx/response/TransactionReceiptCallback.java
@@ -10,22 +10,6 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.tx.response;
 
-public class Pair<TFirst, TSecond> {
-    private final TFirst first;
-    private final TSecond second;
-
-    public TFirst getFirst() {
-        return first;
-    }
-
-    public TSecond getSecond() {
-        return second;
-    }
-
-    public Pair(TFirst first, TSecond second) {
-        this.first = first;
-        this.second = second;
-    }
-}
+public interface TransactionReceiptCallback extends Callback {}

--- a/core/src/main/java/org/web3j/utils/Async.java
+++ b/core/src/main/java/org/web3j/utils/Async.java
@@ -12,12 +12,7 @@
  */
 package org.web3j.utils;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /** Async task facilitation. */
 public class Async {
@@ -42,6 +37,10 @@ public class Async {
                 },
                 executor);
         return result;
+    }
+
+    public static void submit(Runnable r) {
+        executor.submit(r);
     }
 
     private static int getCpuCount() {

--- a/core/src/test/java/org/web3j/tx/ReadonlyTransactionManagerTest.java
+++ b/core/src/test/java/org/web3j/tx/ReadonlyTransactionManagerTest.java
@@ -21,6 +21,7 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.EthCall;
+import org.web3j.protocol.exceptions.EthCallException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -36,7 +37,7 @@ public class ReadonlyTransactionManagerTest {
     EthCall response = mock(EthCall.class);
 
     @Test
-    public void sendCallTest() throws IOException {
+    public void sendCallTest() throws IOException, EthCallException {
         when(response.getValue()).thenReturn("test");
         when(service.send(any(), any())).thenReturn(response);
         ReadonlyTransactionManager readonlyTransactionManager =

--- a/integration-tests/src/test/java/org/web3j/generated/Arrays.java
+++ b/integration-tests/src/test/java/org/web3j/generated/Arrays.java
@@ -64,30 +64,21 @@ public class Arrays extends Contract {
                         org.web3j.abi.Utils.typeMap(input, org.web3j.abi.datatypes.generated.StaticArray2.class,
                 org.web3j.abi.datatypes.generated.Uint256.class))), 
                 java.util.Arrays.<TypeReference<?>>asList(new TypeReference<DynamicArray<Uint256>>() {}));
-        return new RemoteCall<List>(
-                new Callable<List>() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public List call() throws Exception {
+        return ()-> {
                         List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
                         return convertToNative(result);
-                    }
-                });
+                    };
     }
 
     public RemoteCall<List> returnArray() {
-        final Function function = new Function(FUNC_RETURNARRAY, 
-                java.util.Arrays.<Type>asList(), 
-                java.util.Arrays.<TypeReference<?>>asList(new TypeReference<DynamicArray<Address>>() {}));
-        return new RemoteCall<List>(
-                new Callable<List>() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public List call() throws Exception {
-                        List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
-                        return convertToNative(result);
-                    }
-                });
+        final Function function = new Function(FUNC_RETURNARRAY,
+                java.util.Arrays.<Type>asList(),
+                java.util.Arrays.<TypeReference<?>>asList(new TypeReference<DynamicArray<Address>>() {
+                }));
+        return () -> {
+            List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
+            return convertToNative(result);
+        };
     }
 
     public RemoteCall<List> multiFixed(List<List<BigInteger>> input) {
@@ -97,15 +88,10 @@ public class Arrays extends Contract {
                         org.web3j.abi.Utils.typeMap(input, org.web3j.abi.datatypes.generated.StaticArray2.class,
                 org.web3j.abi.datatypes.generated.Uint256.class))), 
                 java.util.Arrays.<TypeReference<?>>asList(new TypeReference<DynamicArray<Uint256>>() {}));
-        return new RemoteCall<List>(
-                new Callable<List>() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public List call() throws Exception {
+        return () -> {
                         List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
                         return convertToNative(result);
-                    }
-                });
+                    };
     }
 
     public RemoteCall<List> fixedReverse(List<BigInteger> input) {
@@ -114,15 +100,10 @@ public class Arrays extends Contract {
                         org.web3j.abi.datatypes.generated.Uint256.class,
                         org.web3j.abi.Utils.typeMap(input, org.web3j.abi.datatypes.generated.Uint256.class))), 
                 java.util.Arrays.<TypeReference<?>>asList(new TypeReference<StaticArray10<Uint256>>() {}));
-        return new RemoteCall<List>(
-                new Callable<List>() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public List call() throws Exception {
+        return () -> {
                         List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
                         return convertToNative(result);
-                    }
-                });
+                    };
     }
 
     public RemoteCall<List> dynamicReverse(List<BigInteger> input) {
@@ -131,15 +112,10 @@ public class Arrays extends Contract {
                         org.web3j.abi.datatypes.generated.Uint256.class,
                         org.web3j.abi.Utils.typeMap(input, org.web3j.abi.datatypes.generated.Uint256.class))), 
                 java.util.Arrays.<TypeReference<?>>asList(new TypeReference<DynamicArray<Uint256>>() {}));
-        return new RemoteCall<List>(
-                new Callable<List>() {
-                    @Override
-                    @SuppressWarnings("unchecked")
-                    public List call() throws Exception {
+        return () -> {
                         List<Type> result = (List<Type>) executeCallSingleValueReturn(function, List.class);
                         return convertToNative(result);
-                    }
-                });
+                    };
     }
 
     public static RemoteCall<Arrays> deploy(Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {

--- a/integration-tests/src/test/java/org/web3j/generated/ShipIt.java
+++ b/integration-tests/src/test/java/org/web3j/generated/ShipIt.java
@@ -56,10 +56,7 @@ public class ShipIt extends Contract {
         final Function function = new Function(FUNC_SHIPMENTS, 
                 Arrays.<Type>asList(new org.web3j.abi.datatypes.Address(param0)), 
                 Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}, new TypeReference<Address>() {}, new TypeReference<Uint256>() {}, new TypeReference<Uint256>() {}, new TypeReference<Uint8>() {}, new TypeReference<Uint256>() {}, new TypeReference<Utf8String>() {}, new TypeReference<Bytes32>() {}));
-        return new RemoteCall<Tuple8<String, String, BigInteger, BigInteger, BigInteger, BigInteger, String, byte[]>>(
-                new Callable<Tuple8<String, String, BigInteger, BigInteger, BigInteger, BigInteger, String, byte[]>>() {
-                    @Override
-                    public Tuple8<String, String, BigInteger, BigInteger, BigInteger, BigInteger, String, byte[]> call() throws Exception {
+        return () ->{
                         List<Type> results = executeCallMultipleValueReturn(function);
                         return new Tuple8<String, String, BigInteger, BigInteger, BigInteger, BigInteger, String, byte[]>(
                                 (String) results.get(0).getValue(), 
@@ -70,8 +67,8 @@ public class ShipIt extends Contract {
                                 (BigInteger) results.get(5).getValue(), 
                                 (String) results.get(6).getValue(), 
                                 (byte[]) results.get(7).getValue());
-                    }
-                });
+                    };
+
     }
 
     public static RemoteCall<ShipIt> deploy(Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {

--- a/integration-tests/src/test/java/org/web3j/protocol/scenarios/FastRawTransactionManagerIT.java
+++ b/integration-tests/src/test/java/org/web3j/protocol/scenarios/FastRawTransactionManagerIT.java
@@ -12,12 +12,10 @@
  */
 package org.web3j.protocol.scenarios;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
@@ -28,7 +26,9 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.RpcErrorResponseException;
 import org.web3j.tx.FastRawTransactionManager;
 import org.web3j.tx.Transfer;
 import org.web3j.tx.response.Callback;
@@ -104,7 +104,9 @@ public class FastRawTransactionManagerIT extends Scenario {
                                 web3j,
                                 new Callback() {
                                     @Override
-                                    public void accept(TransactionReceipt transactionReceipt) {
+                                    public void success(
+                                            TransactionReceipt transactionReceipt,
+                                            Optional<Response.Error> error) {
                                         transactionReceipts.add(transactionReceipt);
                                     }
 
@@ -138,8 +140,8 @@ public class FastRawTransactionManagerIT extends Scenario {
         assertTrue(transactionReceipts.isEmpty());
     }
 
-    private RemoteCall<TransactionReceipt> createTransaction(
-            Transfer transfer, BigInteger gasPrice) {
+    private RemoteCall<TransactionReceipt> createTransaction(Transfer transfer, BigInteger gasPrice)
+            throws IOException, RpcErrorResponseException {
         return transfer.sendFunds(
                 BOB.getAddress(),
                 BigDecimal.valueOf(1.0),


### PR DESCRIPTION
### Inspiration
 - There's no way (other than using `ethSendTransaction`)  to get transactionHash right after transaction submission.
   Contract functions only return `transactionReceipt` which requires the transaction to appear in a block.
 - Thre's no way (other than using `ethCall`) to execute a view function with a blockParameter.
   Contract View functions have no way to pass blockParameter to the call.
 - Every contract function throws a plain `Exception` (You won't know what they are unless you dig deep into web3j code).

### Notes for reviewer
-  package `org.web3j.tx.interactions` contains the classes that will be returned for calls and transactions.
-  `org.web3j.tx.TransactionManager` and `org.web3j.tx.ManagedTransactions` have additional methods to send interactive calls and transactions.
- Changes on `Contract` class , codegen package and tests all revolve around the above change.
### Changes that will be apparant to the user of library
##### Interactions with `view` functions.
-  `erc20Contract.getBalance("0xabcd").send();` // like before
-  `erc20Contract.getBalance("0xabcd").atBlockHight(100).send()`

##### Interactions with non `view` functions.


-  `receipt = erc20Contract.transfer().send()`  is deprecated. came effect can be achieved using `erc20Contract.transfer(...).submit().waitForReceipt()`

- ```
    erc20Contract.transfer().send(new SendTransactionCallback{
    
        // callback after receiving transactionHash
        transactionHash(String transactionHash){
        }
        
        // callback aftter the tranasction appears in a block
        success(TransactionReceipt receipt,Optional<Response.Error> error){
        }
        
        // callback for failure
        exception(Exception ex){
        }
     });
     ```
     ```
  // example usage in webApps
   public function doTransaction() throws IOExcpetion{
       submitTransaction = erc20Contract.transfer("0",BigDecimal.ZERO).send();
       submitTransaction.sendAsync(new TransactionReceiptCallback{ //
    
       // we got the receipt we might also have an error.
       success(TransactionRecipt receipt, Optional<Response.Error> error){
    
       }
       // we didn't get receipt
       error(Exception ex){

      }})
     // return transaction hash to the client
     return submitTransaction.getTransacitonHash();
  }
  ```

##### Exceptions
Everybody hates a plain `java.lang.Exception`, so
- `contract.viewFunction().send()` or `contract.transactionFunction().send()` will throw only `IOException`
- when waiting for receipt, `contract.transact().send().send()` will throw `IOExcpeiton`, `TransactionException`, `FailedTransactionReceipt` or `InterruptedException` 