### PR TITLE
Bump bouncycastle version to 1.61

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.bouncycastleVersion = '1.60'
+    ext.bouncycastleVersion = '1.61'
     ext.jacksonVersion = '2.8.5'
     ext.javapoetVersion = '1.7.0'
     ext.jnr_unixsocketVersion = '0.21'


### PR DESCRIPTION
### What does this PR do?
It updates the bouncycastle version to the latest `1.61`

### Where should the reviewer start?
`build.gradle`

### Why is it needed?
Bouncycastle 1.61 is binary incompatible with 1.60. It's a good practice to keep dependencies up to date.

We have transitive dependencies on both, 1.60 brought only by web3j. This fix, once released, will make our CI green and stable again.