### PR TITLE
remove paddedCell in spotless config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,6 @@ allprojects {
             trimTrailingWhitespace()
             endWithNewline()
             licenseHeaderFile "${rootDir}/gradle/spotless.java.license"
-            paddedCell()
         }
         groovyGradle {
             target '*.gradle'

--- a/console/src/main/java/org/web3j/console/Runner.java
+++ b/console/src/main/java/org/web3j/console/Runner.java
@@ -24,9 +24,7 @@ import static org.web3j.console.project.ProjectCreator.COMMAND_NEW;
 import static org.web3j.console.project.ProjectImporter.COMMAND_IMPORT;
 import static org.web3j.utils.Collection.tail;
 
-/**
- * Main entry point for running command line utilities.
- */
+/** Main entry point for running command line utilities. */
 public class Runner {
 
     private static final String USAGE = "Usage: web3j version|wallet|solidity|new|import ...";

--- a/console/src/main/java/org/web3j/console/project/InteractiveImporter.java
+++ b/console/src/main/java/org/web3j/console/project/InteractiveImporter.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
 import java.io.InputStream;
@@ -5,8 +17,7 @@ import java.io.OutputStream;
 
 class InteractiveImporter extends InteractiveOptions {
 
-    InteractiveImporter() {
-    }
+    InteractiveImporter() {}
 
     InteractiveImporter(final InputStream inputStream, final OutputStream outputStream) {
         super(inputStream, outputStream);
@@ -16,7 +27,4 @@ class InteractiveImporter extends InteractiveOptions {
         System.out.println("Please enter the path to your solidity file/folder (Required Field): ");
         return getUserInput();
     }
-
 }
-
-

--- a/console/src/main/java/org/web3j/console/project/Project.java
+++ b/console/src/main/java/org/web3j/console/project/Project.java
@@ -20,8 +20,7 @@ import static org.web3j.codegen.Console.exitError;
 
 public class Project {
 
-    private Project(final Builder builder) {
-    }
+    private Project(final Builder builder) {}
 
     public static Builder builder() {
         return new Builder();
@@ -55,12 +54,13 @@ public class Project {
             if (!isWindows()) {
                 setExecutable(pathToDirectory, "gradlew");
                 executeCommand(
-                        new File(pathToDirectory), new String[]{"bash", "-c", "./gradlew build -q"});
+                        new File(pathToDirectory),
+                        new String[] {"bash", "-c", "./gradlew build -q"});
             } else {
                 setExecutable(pathToDirectory, "gradlew.bat");
                 executeCommand(
                         new File(pathToDirectory),
-                        new String[]{"cmd.exe", "/c", "gradlew.bat build -q"});
+                        new String[] {"cmd.exe", "/c", "gradlew.bat build -q"});
             }
         }
 

--- a/console/src/main/java/org/web3j/console/project/ProjectCreator.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectCreator.java
@@ -27,7 +27,6 @@ public class ProjectCreator {
     public static final String COMMAND_NEW = "new";
     static final String COMMAND_INTERACTIVE = "interactive";
 
-
     final ProjectStructure projectStructure;
     final TemplateProvider templateProvider;
 

--- a/console/src/main/java/org/web3j/console/project/ProjectCreatorCLIRunner.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectCreatorCLIRunner.java
@@ -1,46 +1,54 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
 import java.io.IOException;
-import org.web3j.console.project.utills.InputVerifier;
+
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+
+import org.web3j.console.project.utills.InputVerifier;
 
 import static org.web3j.codegen.Console.exitError;
 import static org.web3j.console.project.ProjectCreator.COMMAND_NEW;
 import static picocli.CommandLine.Help.Visibility.ALWAYS;
 
-
-@Command(
-        name = COMMAND_NEW,
-        mixinStandardHelpOptions = true,
-        version = "4.0",
-        sortOptions = false
-)
+@Command(name = COMMAND_NEW, mixinStandardHelpOptions = true, version = "4.0", sortOptions = false)
 public class ProjectCreatorCLIRunner implements Runnable {
     @Option(
             names = {"-o", "--outputDir"},
             description = "destination base directory.",
             required = false,
-            showDefaultValue = ALWAYS
-    )
+            showDefaultValue = ALWAYS)
     String root = System.getProperty("user.dir");
+
     @Option(
             names = {"-p", "--package"},
             description = "base package name.",
-            required = true
-    )
+            required = true)
     String packageName;
+
     @Option(
             names = {"-n", "--project name"},
             description = "project name.",
-            required = true
-    )
+            required = true)
     String projectName;
-
 
     @Override
     public void run() {
-        if (InputVerifier.requiredArgsAreNotEmpty(projectName, packageName) && InputVerifier.classNameIsValid(projectName) && InputVerifier.packageNameIsValid(packageName)) {
+        if (InputVerifier.requiredArgsAreNotEmpty(projectName, packageName)
+                && InputVerifier.classNameIsValid(projectName)
+                && InputVerifier.packageNameIsValid(packageName)) {
             try {
                 new ProjectCreator(root, packageName, projectName).generate();
             } catch (final IOException e) {
@@ -48,7 +56,4 @@ public class ProjectCreatorCLIRunner implements Runnable {
             }
         }
     }
-
-
 }
-

--- a/console/src/main/java/org/web3j/console/project/ProjectImporter.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectImporter.java
@@ -15,8 +15,8 @@ package org.web3j.console.project;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
 import picocli.CommandLine;
 
 import static org.web3j.codegen.Console.exitError;
@@ -41,22 +41,22 @@ public class ProjectImporter extends ProjectCreator {
     public static void main(String[] args) {
         if (args.length > 0 && args[0].equals(COMMAND_IMPORT)) {
             args = tail(args);
-             if (args.length > 0 && args[0].equals(COMMAND_INTERACTIVE)) {
-                     final InteractiveImporter options = new InteractiveImporter();
-                     final List<String> stringOptions = new ArrayList<>();
-                     stringOptions.add("-n");
-                     stringOptions.add(options.getProjectName());
-                     stringOptions.add("-p");
-                     stringOptions.add(options.getPackageName());
-                     stringOptions.add("-s");
-                     stringOptions.add(options.getSolidityProjectPath());
-                     options.getProjectDestination()
-                             .ifPresent(
-                                     projectDest -> {
-                                         stringOptions.add("-o");
-                                         stringOptions.add(projectDest);
-                                     });
-                     args = stringOptions.toArray(new String[0]);
+            if (args.length > 0 && args[0].equals(COMMAND_INTERACTIVE)) {
+                final InteractiveImporter options = new InteractiveImporter();
+                final List<String> stringOptions = new ArrayList<>();
+                stringOptions.add("-n");
+                stringOptions.add(options.getProjectName());
+                stringOptions.add("-p");
+                stringOptions.add(options.getPackageName());
+                stringOptions.add("-s");
+                stringOptions.add(options.getSolidityProjectPath());
+                options.getProjectDestination()
+                        .ifPresent(
+                                projectDest -> {
+                                    stringOptions.add("-o");
+                                    stringOptions.add(projectDest);
+                                });
+                args = stringOptions.toArray(new String[0]);
             }
         }
 

--- a/console/src/main/java/org/web3j/console/project/ProjectImporterCLIRunner.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectImporterCLIRunner.java
@@ -1,15 +1,26 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
-import org.web3j.console.project.utills.InputVerifier;
 import picocli.CommandLine;
+
+import org.web3j.console.project.utills.InputVerifier;
 
 import static org.web3j.codegen.Console.exitError;
 import static org.web3j.console.project.ProjectImporter.COMMAND_IMPORT;
 
-@CommandLine.Command(
-        name = COMMAND_IMPORT)
+@CommandLine.Command(name = COMMAND_IMPORT)
 public class ProjectImporterCLIRunner extends ProjectCreatorCLIRunner {
-
 
     @CommandLine.Option(
             names = {"-s", "--solidity path"},
@@ -19,7 +30,9 @@ public class ProjectImporterCLIRunner extends ProjectCreatorCLIRunner {
 
     @Override
     public void run() {
-        if (InputVerifier.requiredArgsAreNotEmpty(projectName, packageName, solidityImportPath) && InputVerifier.classNameIsValid(projectName) && InputVerifier.packageNameIsValid(packageName)) {
+        if (InputVerifier.requiredArgsAreNotEmpty(projectName, packageName, solidityImportPath)
+                && InputVerifier.classNameIsValid(projectName)
+                && InputVerifier.packageNameIsValid(packageName)) {
             try {
                 new ProjectImporter(root, packageName, projectName, solidityImportPath).generate();
             } catch (final Exception e) {
@@ -28,4 +41,3 @@ public class ProjectImporterCLIRunner extends ProjectCreatorCLIRunner {
         }
     }
 }
-

--- a/console/src/main/java/org/web3j/console/project/ProjectWriter.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectWriter.java
@@ -21,7 +21,8 @@ import java.nio.file.StandardCopyOption;
 
 class ProjectWriter {
 
-    final void writeResourceFile(final String file, final String fileName, final String writeLocation)
+    final void writeResourceFile(
+            final String file, final String fileName, final String writeLocation)
             throws IOException {
         Files.write(Paths.get(writeLocation + File.separator + fileName), getBytes(file));
     }
@@ -30,7 +31,8 @@ class ProjectWriter {
         return file.getBytes();
     }
 
-    final void copyResourceFile(final InputStream file, final String destinationPath) throws IOException {
+    final void copyResourceFile(final InputStream file, final String destinationPath)
+            throws IOException {
         Files.copy(file, Paths.get(destinationPath), StandardCopyOption.REPLACE_EXISTING);
     }
 
@@ -39,5 +41,4 @@ class ProjectWriter {
             Files.walkFileTree(file.toPath(), new ProjectVisitor(destination));
         }
     }
-
 }

--- a/console/src/main/java/org/web3j/console/project/TemplateProvider.java
+++ b/console/src/main/java/org/web3j/console/project/TemplateProvider.java
@@ -30,7 +30,8 @@ public class TemplateProvider {
 
     private TemplateProvider(
             final String mainJavaClass,
-            final String solidityProject, final String gradleBuild,
+            final String solidityProject,
+            final String gradleBuild,
             final String gradleSettings,
             final String gradlewWrapperSettings,
             final String gradlewBatScript,
@@ -151,7 +152,8 @@ public class TemplateProvider {
         TemplateProvider build() {
             return new TemplateProvider(
                     projectNameReplacement.apply(packageNameReplacement.apply(mainJavaClass)),
-                    solidityProject, packageNameReplacement.apply(gradleBuild),
+                    solidityProject,
+                    packageNameReplacement.apply(gradleBuild),
                     projectNameReplacement.apply(gradleSettings),
                     gradlewWrapperSettings,
                     gradlewBatScript,
@@ -172,10 +174,8 @@ public class TemplateProvider {
                 final StringBuilder stringBuilder = new StringBuilder();
                 while ((temp = reader.readLine()) != null) {
                     stringBuilder.append(temp).append("\n");
-
                 }
                 return stringBuilder.toString();
-
             }
         }
     }

--- a/console/src/main/java/org/web3j/console/project/utills/InputVerifier.java
+++ b/console/src/main/java/org/web3j/console/project/utills/InputVerifier.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project.utills;
 
 import javax.lang.model.SourceVersion;
@@ -13,14 +25,13 @@ public class InputVerifier {
         return true;
     }
 
-   public static boolean classNameIsValid(final String className) {
+    public static boolean classNameIsValid(final String className) {
         if (!SourceVersion.isIdentifier(className) || SourceVersion.isKeyword(className)) {
             System.out.println(className + " is not valid name.");
             return false;
         }
         return true;
     }
-
 
     public static boolean packageNameIsValid(final String packageName) {
         String[] splitPackageName = packageName.split("[.]");
@@ -32,6 +43,4 @@ public class InputVerifier {
         }
         return true;
     }
-
-
 }

--- a/console/src/test/java/org/web3j/console/project/InteractiveImporterTest.java
+++ b/console/src/test/java/org/web3j/console/project/InteractiveImporterTest.java
@@ -1,26 +1,40 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import org.web3j.TempFileProvider;
 
 import static org.junit.Assert.assertEquals;
 
-
 public class InteractiveImporterTest extends TempFileProvider {
-    private static final String FORMATTED_SOLIDITY_PATH = "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
+    private static final String FORMATTED_SOLIDITY_PATH =
+            "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
     private InputStream inputStream;
 
     @Before
     public void init() {
-        final String input = "Test\norg.com\n" + FORMATTED_SOLIDITY_PATH + "\n" + tempDirPath + "\n";
+        final String input =
+                "Test\norg.com\n" + FORMATTED_SOLIDITY_PATH + "\n" + tempDirPath + "\n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
-
     }
 
     @Test
@@ -31,7 +45,4 @@ public class InteractiveImporterTest extends TempFileProvider {
         assertEquals(FORMATTED_SOLIDITY_PATH, options.getSolidityProjectPath());
         assertEquals(Optional.of(tempDirPath), options.getProjectDestination());
     }
-
 }
-
-

--- a/console/src/test/java/org/web3j/console/project/InteractiveOptionsTest.java
+++ b/console/src/test/java/org/web3j/console/project/InteractiveOptionsTest.java
@@ -16,8 +16,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import org.web3j.TempFileProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -27,7 +29,6 @@ public class InteractiveOptionsTest extends TempFileProvider {
     private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private InputStream inputStream;
 
-
     @Before
     public void init() {
         final String input = "Test\norg.com\n" + tempDirPath + "\n";
@@ -35,7 +36,6 @@ public class InteractiveOptionsTest extends TempFileProvider {
         System.setIn(inputStream);
         System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
-
     }
 
     @Test

--- a/console/src/test/java/org/web3j/console/project/ProjectCreatorCLIRunnerTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectCreatorCLIRunnerTest.java
@@ -1,8 +1,21 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
 import org.junit.Test;
-import org.web3j.TempFileProvider;
 import picocli.CommandLine;
+
+import org.web3j.TempFileProvider;
 
 public class ProjectCreatorCLIRunnerTest extends TempFileProvider {
     @Test(expected = CommandLine.MissingParameterException.class)
@@ -28,5 +41,4 @@ public class ProjectCreatorCLIRunnerTest extends TempFileProvider {
         final CommandLine commandLine = new CommandLine(projectCreatorCLIRunner);
         commandLine.parseArgs(args);
     }
-
 }

--- a/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
@@ -16,10 +16,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.web3j.console.WalletTester;
 import picocli.CommandLine;
+
+import org.web3j.console.WalletTester;
 
 import static org.junit.Assert.assertTrue;
 
@@ -33,7 +35,6 @@ public class ProjectCreatorTest extends WalletTester {
 
         System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
-
     }
 
     @Test
@@ -61,9 +62,12 @@ public class ProjectCreatorTest extends WalletTester {
     public void runTestWhenArgumentsAreNotEmpty() {
         final String[] args = {"new", "-p", "org.com", "-n", "Test", "-o" + tempDirPath};
         ProjectCreator.main(args);
-        assertTrue(outContent.toString().contains("Project created with name: Test at location: /var/folders/6x/vzg_hr7x4nz2z043t2_wtjsc0000gn/T/TempFileProvider3473379777787806210/Test"));
+        assertTrue(
+                outContent
+                        .toString()
+                        .contains(
+                                "Project created with name: Test at location: /var/folders/6x/vzg_hr7x4nz2z043t2_wtjsc0000gn/T/TempFileProvider3473379777787806210/Test"));
     }
-
 
     @Test
     public void createNewProjectInteractive() {
@@ -73,7 +77,6 @@ public class ProjectCreatorTest extends WalletTester {
         final String[] args = {"new", "interactive"};
         ProjectCreator.main(args);
         assertTrue(outContent.toString().contains("Project created with name:"));
-
     }
 
     @Test
@@ -83,6 +86,9 @@ public class ProjectCreatorTest extends WalletTester {
         System.setIn(inputStream);
         final String[] args = {"new", "interactive"};
         ProjectCreator.main(args);
-        assertTrue(outContent.toString().contains("Please make sure the required parameters are not empty."));
+        assertTrue(
+                outContent
+                        .toString()
+                        .contains("Please make sure the required parameters are not empty."));
     }
 }

--- a/console/src/test/java/org/web3j/console/project/ProjectImporterCLIRunnerTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectImporterCLIRunnerTest.java
@@ -1,8 +1,21 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project;
 
 import org.junit.Test;
-import org.web3j.TempFileProvider;
 import picocli.CommandLine;
+
+import org.web3j.TempFileProvider;
 
 public class ProjectImporterCLIRunnerTest extends TempFileProvider {
     @Test(expected = CommandLine.MissingParameterException.class)
@@ -24,9 +37,10 @@ public class ProjectImporterCLIRunnerTest extends TempFileProvider {
     @Test(expected = CommandLine.OverwrittenOptionException.class)
     public void testWhenDuplicateArgsArePassed() {
         final ProjectImporterCLIRunner projectImporterCLIRunner = new ProjectImporterCLIRunner();
-        final String[] args = {"-p=org.org", "-n=test", "-n=OverrideTest", "-o=" + tempDirPath ,"-s=test"};
+        final String[] args = {
+            "-p=org.org", "-n=test", "-n=OverrideTest", "-o=" + tempDirPath, "-s=test"
+        };
         final CommandLine commandLine = new CommandLine(projectImporterCLIRunner);
         commandLine.parseArgs(args);
     }
-
 }

--- a/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
@@ -17,10 +17,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.web3j.TempFileProvider;
 import picocli.CommandLine;
+
+import org.web3j.TempFileProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +37,6 @@ public class ProjectImporterTest extends TempFileProvider {
 
         System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
-
     }
 
     @Test
@@ -55,8 +56,8 @@ public class ProjectImporterTest extends TempFileProvider {
         assertTrue(
                 errContent
                         .toString()
-                        .contains("Missing required options [--solidity path=<solidityImportPath>, --package=<packageName>, --project name=<projectName>]"));
-
+                        .contains(
+                                "Missing required options [--solidity path=<solidityImportPath>, --package=<packageName>, --project name=<projectName>]"));
     }
 
     @Test
@@ -75,9 +76,8 @@ public class ProjectImporterTest extends TempFileProvider {
                         + File.separator
                         + "Solidity";
 
-
         final String[] args = {
-                "-p=org.com", "-n=Test", "-o=" + tempDirPath, "-s=" + formattedSolidityTestProject
+            "-p=org.com", "-n=Test", "-o=" + tempDirPath, "-s=" + formattedSolidityTestProject
         };
         ProjectImporter.main(args);
         assertTrue(outContent.toString().contains("Project created with name:"));
@@ -85,14 +85,14 @@ public class ProjectImporterTest extends TempFileProvider {
 
     @Test
     public void createImportProjectInteractive() {
-        String formattedPath = "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
+        String formattedPath =
+                "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
         final String input = "Test\norg.com\n" + formattedPath + "\n" + tempDirPath + "\n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
         final String[] args = {"import", "interactive"};
         ProjectImporter.main(args);
         assertTrue(outContent.toString().contains("Project created with name:"));
-
     }
 
     @Test
@@ -102,6 +102,9 @@ public class ProjectImporterTest extends TempFileProvider {
         System.setIn(inputStream);
         final String[] args = {"import", "interactive"};
         ProjectImporter.main(args);
-        assertTrue(outContent.toString().contains("Please make sure the required parameters are not empty."));
+        assertTrue(
+                outContent
+                        .toString()
+                        .contains("Please make sure the required parameters are not empty."));
     }
 }

--- a/console/src/test/java/org/web3j/console/project/ProjectTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectTest.java
@@ -23,7 +23,8 @@ import org.web3j.TempFileProvider;
 import static org.junit.Assert.assertTrue;
 
 public class ProjectTest extends TempFileProvider {
-    private final ProjectStructure projectStructure = new ProjectStructure(tempDirPath, "test", "test");
+    private final ProjectStructure projectStructure =
+            new ProjectStructure(tempDirPath, "test", "test");
     private final TemplateProvider templateProviderNew =
             new TemplateProvider.Builder()
                     .loadGradlewBatScript("gradlew.bat.template")
@@ -38,8 +39,7 @@ public class ProjectTest extends TempFileProvider {
                     .withProjectNameReplacement(s -> s.replaceAll("<project_name>", "test"))
                     .build();
 
-    public ProjectTest() throws IOException {
-    }
+    public ProjectTest() throws IOException {}
 
     @Before
     public void setUpProject() {
@@ -74,9 +74,9 @@ public class ProjectTest extends TempFileProvider {
                         .exists();
         final boolean gradleWrapperSettings =
                 new File(
-                        projectStructure.getWrapperPath()
-                                + File.separator
-                                + "gradle-wrapper.properties")
+                                projectStructure.getWrapperPath()
+                                        + File.separator
+                                        + "gradle-wrapper.properties")
                         .exists();
         final boolean gradleWrapperJar =
                 new File(projectStructure.getWrapperPath() + File.separator + "gradle-wrapper.jar")

--- a/console/src/test/java/org/web3j/console/project/ProjectWriterTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectWriterTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertTrue;
 
 public class ProjectWriterTest extends TempFileProvider {
 
-    private final static ProjectWriter projectWriter = new ProjectWriter();
-    private final static TemplateProvider templateProvider =
+    private static final ProjectWriter projectWriter = new ProjectWriter();
+    private static final TemplateProvider templateProvider =
             new TemplateProvider.Builder().loadGradleJar("gradle-wrapper.jar").build();
 
     @Test
@@ -52,13 +52,13 @@ public class ProjectWriterTest extends TempFileProvider {
                 tempDirPath + File.separator + "tempSolidityDestination");
         assertTrue(
                 new File(
-                        tempDirPath
-                                + File.separator
-                                + "tempSolidityDestination"
-                                + File.separator
-                                + "tempSolidityDir"
-                                + File.separator
-                                + "Greeter.sol")
+                                tempDirPath
+                                        + File.separator
+                                        + "tempSolidityDestination"
+                                        + File.separator
+                                        + "tempSolidityDir"
+                                        + File.separator
+                                        + "Greeter.sol")
                         .exists());
     }
 }

--- a/console/src/test/java/org/web3j/console/project/utills/InputVerifierTest.java
+++ b/console/src/test/java/org/web3j/console/project/utills/InputVerifierTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.console.project.utills;
 
 import org.junit.Test;
@@ -10,39 +22,38 @@ public class InputVerifierTest {
     public void requiredArgumentsAreEmptyTest() {
         final String[] args = {"", "", ""};
         assertFalse(InputVerifier.requiredArgsAreNotEmpty(args));
-
     }
 
     @Test
     public void requiredArgsAreNotEmptyTest() {
-        final String[] args = {"TestProjectName", "test.package.name",};
+        final String[] args = {
+            "TestProjectName", "test.package.name",
+        };
         assertTrue(InputVerifier.requiredArgsAreNotEmpty(args));
     }
+
     @Test
-    public void classNameIsValidTest()
-    {
+    public void classNameIsValidTest() {
         assertTrue(InputVerifier.classNameIsValid("ClassNameTest"));
     }
-    @Test
-    public void classNameIsNotValidWhenFirstCharacterIsNumberTest()
-    {
-        assertFalse(InputVerifier.classNameIsValid("1BadClassName"));
 
-    }
     @Test
-    public void ClassNameIsNotValidWhenFirstCharacterIsSymbol()
-    {
+    public void classNameIsNotValidWhenFirstCharacterIsNumberTest() {
+        assertFalse(InputVerifier.classNameIsValid("1BadClassName"));
+    }
+
+    @Test
+    public void ClassNameIsNotValidWhenFirstCharacterIsSymbol() {
         assertFalse(InputVerifier.classNameIsValid("!BadClassName"));
     }
+
     @Test
-    public void packageNameIsValidTest()
-    {
+    public void packageNameIsValidTest() {
         assertTrue(InputVerifier.packageNameIsValid("org.com"));
     }
+
     @Test
-    public void packageNameIsNotValidTest()
-    {
+    public void packageNameIsNotValidTest() {
         assertFalse(InputVerifier.packageNameIsValid("1.com"));
     }
-
 }


### PR DESCRIPTION
### What does this PR do?
Fixes spotlessCheck. Looks like the `paddedCell` directive makes spotless behave weirdly. Specifically, it allows java files to be committed to master without a license header

### Where should the reviewer start?
the main `build.gradle`
the rest of the changes are generated by spotlessApply task

### Why is it needed?
maintain code quality

