### PR TITLE
Web3j new and import small functionalliy change

### DIFF
--- a/console/src/main/java/org/web3j/console/project/ProjectCreator.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectCreator.java
@@ -53,7 +53,7 @@ public class ProjectCreator {
     public static void main(String[] args) {
         if (args.length > 0 && args[0].equals(COMMAND_NEW)) {
             args = tail(args);
-            if (args.length > 0 && args[0].equals(COMMAND_INTERACTIVE)) {
+            if (args.length == 0) {
                 final InteractiveOptions options = new InteractiveOptions();
                 final List<String> stringOptions = new ArrayList<>();
                 stringOptions.add("-n");

--- a/console/src/main/java/org/web3j/console/project/ProjectImporter.java
+++ b/console/src/main/java/org/web3j/console/project/ProjectImporter.java
@@ -41,7 +41,7 @@ public class ProjectImporter extends ProjectCreator {
     public static void main(String[] args) {
         if (args.length > 0 && args[0].equals(COMMAND_IMPORT)) {
             args = tail(args);
-            if (args.length > 0 && args[0].equals(COMMAND_INTERACTIVE)) {
+            if (args.length == 0) {
                 final InteractiveImporter options = new InteractiveImporter();
                 final List<String> stringOptions = new ArrayList<>();
                 stringOptions.add("-n");

--- a/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
@@ -49,15 +49,15 @@ public class ProjectCreatorTest extends WalletTester {
     }
 
     @Test
-    public void runTestWhenArgumentsAreEmpty() {
-        final String[] args = {"-n= ", "-p= "};
+    public void testWithPicoCliWhenArgumentsAreEmpty() {
+        final String[] args = {"new", "-n= ", "-p= "};
         ProjectCreator.main(args);
         assertEquals(
                 outContent.toString(), "Please make sure the required parameters are not empty.\n");
     }
 
     @Test
-    public void runTestWhenArgumentsAreNotEmpty() {
+    public void testWithPicoCliWhenArgumentsAreCorrect() {
         final String[] args = {"new", "-p", "org.com", "-n", "Test", "-o" + tempDirPath};
         ProjectCreator.main(args);
         assertEquals(
@@ -66,7 +66,7 @@ public class ProjectCreatorTest extends WalletTester {
     }
 
     @Test
-    public void createNewProjectInteractive() {
+    public void testWhenInteractiveAndArgumentsAreCorrect() {
         final String input = "Test\norg.com\n" + tempDirPath + "\n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
@@ -76,7 +76,7 @@ public class ProjectCreatorTest extends WalletTester {
     }
 
     @Test
-    public void createNewProjectInteractiveWhenArgsAreEmpty() {
+    public void testWhenInteractiveAndArgumentsAreEmpty() {
         final String input = " \n \n \n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);

--- a/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectCreatorTest.java
@@ -23,6 +23,7 @@ import picocli.CommandLine;
 
 import org.web3j.console.WalletTester;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ProjectCreatorTest extends WalletTester {
@@ -49,24 +50,19 @@ public class ProjectCreatorTest extends WalletTester {
 
     @Test
     public void runTestWhenArgumentsAreEmpty() {
-        final String[] args = {"", ""};
+        final String[] args = {"-n= ", "-p= "};
         ProjectCreator.main(args);
-        assertTrue(
-                errContent
-                        .toString()
-                        .contains(
-                                "Missing required options [--package=<packageName>, --project name=<projectName>]"));
+        assertEquals(
+                outContent.toString(), "Please make sure the required parameters are not empty.\n");
     }
 
     @Test
     public void runTestWhenArgumentsAreNotEmpty() {
         final String[] args = {"new", "-p", "org.com", "-n", "Test", "-o" + tempDirPath};
         ProjectCreator.main(args);
-        assertTrue(
-                outContent
-                        .toString()
-                        .contains(
-                                "Project created with name: Test at location: /var/folders/6x/vzg_hr7x4nz2z043t2_wtjsc0000gn/T/TempFileProvider3473379777787806210/Test"));
+        assertEquals(
+                outContent.toString(),
+                "Project created with name: Test at location: /var/folders/6x/vzg_hr7x4nz2z043t2_wtjsc0000gn/T/TempFileProvider3473379777787806210/Test");
     }
 
     @Test
@@ -74,7 +70,7 @@ public class ProjectCreatorTest extends WalletTester {
         final String input = "Test\norg.com\n" + tempDirPath + "\n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
-        final String[] args = {"new", "interactive"};
+        final String[] args = {"new"};
         ProjectCreator.main(args);
         assertTrue(outContent.toString().contains("Project created with name:"));
     }
@@ -84,7 +80,7 @@ public class ProjectCreatorTest extends WalletTester {
         final String input = " \n \n \n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
-        final String[] args = {"new", "interactive"};
+        final String[] args = {"new"};
         ProjectCreator.main(args);
         assertTrue(
                 outContent

--- a/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
@@ -12,22 +12,27 @@
  */
 package org.web3j.console.project;
 
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
 import picocli.CommandLine;
 
-import org.web3j.TempFileProvider;
+import org.web3j.console.project.utills.ClassExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class ProjectImporterTest extends TempFileProvider {
+public class ProjectImporterTest extends ClassExecutor {
     private ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     private InputStream inputStream;
@@ -50,15 +55,7 @@ public class ProjectImporterTest extends TempFileProvider {
     }
 
     @Test
-    public void testWithPicoCliWhenArgumentsAreEmpty() {
-        final String[] args = {"import", "-p= ", "-n= ", "-s= "};
-        ProjectImporter.main(args);
-        assertEquals(
-                outContent.toString(), "Please make sure the required parameters are not empty.\n");
-    }
-
-    @Test
-    public void testWithPicoCliWhenArgumentsAreCorrect() {
+    public void testWithPicoCliWhenArgumentsAreCorrect() throws IOException, InterruptedException {
 
         final String formattedSolidityTestProject =
                 File.separator
@@ -77,20 +74,46 @@ public class ProjectImporterTest extends TempFileProvider {
         final String[] args = {
             "-p=org.com", "-n=Test", "-o=" + tempDirPath, "-s=" + formattedSolidityTestProject
         };
-        ProjectImporter.main(args);
-        assertTrue(outContent.toString().contains("Project created with name:"));
+        int exitCode =
+                executeClassAsSubProcessAndReturnProcess(
+                                ProjectImporter.class, Collections.emptyList(), Arrays.asList(args))
+                        .inheritIO()
+                        .start()
+                        .waitFor();
+        assertEquals(0, exitCode);
     }
 
     @Test
-    public void testWhenInteractiveAndArgumentsAreCorrect() {
+    public void testWithPicoCliWhenArgumentsAreEmpty() {
+        final String[] args = {"import", "-p= ", "-n= ", "-s= "};
+        ProjectImporter.main(args);
+        assertEquals(
+                outContent.toString(), "Please make sure the required parameters are not empty.\n");
+    }
+
+    @Test
+    public void testWhenInteractiveAndArgumentsAreCorrect()
+            throws IOException, InterruptedException {
         String formattedPath =
                 "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
-        final String input = "Test\norg.com\n" + formattedPath + "\n" + tempDirPath + "\n";
-        inputStream = new ByteArrayInputStream(input.getBytes());
-        System.setIn(inputStream);
         final String[] args = {"import"};
-        ProjectImporter.main(args);
-        assertTrue(outContent.toString().contains("Project created with name:"));
+        Process process =
+                executeClassAsSubProcessAndReturnProcess(
+                                ProjectImporter.class, Collections.emptyList(), Arrays.asList(args))
+                        .start();
+        BufferedWriter writer =
+                new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));
+        writer.write("test", 0, "test".length());
+        writer.newLine();
+        writer.write("org.com", 0, "org.com".length());
+        writer.newLine();
+        writer.write(formattedPath, 0, formattedPath.length());
+        writer.newLine();
+        writer.write(tempDirPath, 0, tempDirPath.length());
+        writer.newLine();
+        writer.close();
+        process.waitFor();
+        assertEquals(0, process.exitValue());
     }
 
     @Test

--- a/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
@@ -50,15 +50,16 @@ public class ProjectImporterTest extends TempFileProvider {
     }
 
     @Test
-    public void runTestWhenArgumentsAreEmpty() {
-        final String[] args = {"-p= ", "-n= ", "-s= "};
+    public void testWithPicoCliWhenArgumentsAreEmpty() {
+        final String[] args = {"import", "-p= ", "-n= ", "-s= "};
         ProjectImporter.main(args);
         assertEquals(
                 outContent.toString(), "Please make sure the required parameters are not empty.\n");
     }
 
     @Test
-    public void runTestWhenArgumentsAreNotEmpty() {
+    public void testWithPicoCliWhenArgumentsAreCorrect() {
+
         final String formattedSolidityTestProject =
                 File.separator
                         + "web3j"
@@ -81,7 +82,7 @@ public class ProjectImporterTest extends TempFileProvider {
     }
 
     @Test
-    public void createImportProjectInteractive() {
+    public void testWhenInteractiveAndArgumentsAreCorrect() {
         String formattedPath =
                 "/web3j/console/src/test/resources/Solidity".replaceAll("/", File.separator);
         final String input = "Test\norg.com\n" + formattedPath + "\n" + tempDirPath + "\n";
@@ -93,7 +94,7 @@ public class ProjectImporterTest extends TempFileProvider {
     }
 
     @Test
-    public void runTestWhenArgumentsAreNewInteractive() {
+    public void testWhenInteractiveAndArgumentsAreEmpty() {
         final String input = " \n \n \n \n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);

--- a/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectImporterTest.java
@@ -51,13 +51,10 @@ public class ProjectImporterTest extends TempFileProvider {
 
     @Test
     public void runTestWhenArgumentsAreEmpty() {
-        final String[] args = {"", "", ""};
+        final String[] args = {"-p= ", "-n= ", "-s= "};
         ProjectImporter.main(args);
-        assertTrue(
-                errContent
-                        .toString()
-                        .contains(
-                                "Missing required options [--solidity path=<solidityImportPath>, --package=<packageName>, --project name=<projectName>]"));
+        assertEquals(
+                outContent.toString(), "Please make sure the required parameters are not empty.\n");
     }
 
     @Test
@@ -90,7 +87,7 @@ public class ProjectImporterTest extends TempFileProvider {
         final String input = "Test\norg.com\n" + formattedPath + "\n" + tempDirPath + "\n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
-        final String[] args = {"import", "interactive"};
+        final String[] args = {"import"};
         ProjectImporter.main(args);
         assertTrue(outContent.toString().contains("Project created with name:"));
     }
@@ -100,7 +97,7 @@ public class ProjectImporterTest extends TempFileProvider {
         final String input = " \n \n \n \n";
         inputStream = new ByteArrayInputStream(input.getBytes());
         System.setIn(inputStream);
-        final String[] args = {"import", "interactive"};
+        final String[] args = {"import"};
         ProjectImporter.main(args);
         assertTrue(
                 outContent

--- a/console/src/test/java/org/web3j/console/project/ProjectTest.java
+++ b/console/src/test/java/org/web3j/console/project/ProjectTest.java
@@ -13,7 +13,6 @@
 package org.web3j.console.project;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,27 +22,27 @@ import org.web3j.TempFileProvider;
 import static org.junit.Assert.assertTrue;
 
 public class ProjectTest extends TempFileProvider {
-    private final ProjectStructure projectStructure =
-            new ProjectStructure(tempDirPath, "test", "test");
-    private final TemplateProvider templateProviderNew =
-            new TemplateProvider.Builder()
-                    .loadGradlewBatScript("gradlew.bat.template")
-                    .loadGradlewScript("gradlew.template")
-                    .loadMainJavaClass("Template.java")
-                    .loadGradleBuild("build.gradle.template")
-                    .loadGradleSettings("settings.gradle.template")
-                    .loadGradlewWrapperSettings("gradlew-wrapper.properties.template")
-                    .loadGradleJar("gradle-wrapper.jar")
-                    .loadSolidityGreeter("Greeter.sol")
-                    .withPackageNameReplacement(s -> s.replaceAll("<package_name>", "test"))
-                    .withProjectNameReplacement(s -> s.replaceAll("<project_name>", "test"))
-                    .build();
-
-    public ProjectTest() throws IOException {}
+    private ProjectStructure projectStructure;
+    private TemplateProvider templateProviderNew;
 
     @Before
-    public void setUpProject() {
-        new Project.Builder()
+    public void setUpProject() throws Exception {
+        setUp();
+        projectStructure = new ProjectStructure(tempDirPath, "test", "test");
+        templateProviderNew =
+                new TemplateProvider.Builder()
+                        .loadGradlewBatScript("gradlew.bat.template")
+                        .loadGradlewScript("gradlew.template")
+                        .loadMainJavaClass("Template.java")
+                        .loadGradleBuild("build.gradle.template")
+                        .loadGradleSettings("settings.gradle.template")
+                        .loadGradlewWrapperSettings("gradlew-wrapper.properties.template")
+                        .loadGradleJar("gradle-wrapper.jar")
+                        .loadSolidityGreeter("Greeter.sol")
+                        .withPackageNameReplacement(s -> s.replaceAll("<package_name>", "test"))
+                        .withProjectNameReplacement(s -> s.replaceAll("<project_name>", "test"))
+                        .build();
+        Project.builder()
                 .withTemplateProvider(templateProviderNew)
                 .withProjectStructure(projectStructure)
                 .build();

--- a/console/src/test/java/org/web3j/console/project/utills/ClassExecutor.java
+++ b/console/src/test/java/org/web3j/console/project/utills/ClassExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.console.project.utills;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.web3j.TempFileProvider;
+
+public class ClassExecutor extends TempFileProvider {
+    public ProcessBuilder executeClassAsSubProcessAndReturnProcess(
+            Class classToExecute, List<String> jvmArgs, List<String> args)
+            throws IOException, InterruptedException {
+        String javaHome = System.getProperty("java.home");
+        String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
+        String classPath = System.getProperty("java.class.path");
+        String className = classToExecute.getName();
+
+        List<String> command = new ArrayList<>();
+        command.add(javaBin);
+        command.addAll(jvmArgs);
+        command.add("-cp");
+        command.add(classPath);
+        command.add(className);
+        command.addAll(args);
+        return new ProcessBuilder(command);
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Instead of using `web3j new interactive` by default `web3j new` will be interactive. Same goes for web3j import.

### Where should the reviewer start?
ProjectCreator, ProjectImporter and relative test files 

### Why is it needed?
It looks better.
