### PR TITLE
Solve web3j.ethLogFlowable is invalid

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
@@ -51,7 +51,10 @@ public class EthFilter extends Filter<EthFilter> {
         return toBlock;
     }
 
-    public List<String> getAddress() {
+    public Object getAddress() {
+        if (address != null && address.size() == 1) {
+            return address.get(0);
+        }
         return address;
     }
 


### PR DESCRIPTION
I think the right code of getAddress is :

```
public Object getAddress() {
        if (address != null && address.size() == 1) {
            return address.get(0);
        }
        return address;
}
```

When I used the web3j.ethLogFlowable method, I found that if address was one, the listener was invalid; later, by comparing Remix log, I found that if address was one,
the log is :

```
{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],"fromBlock":"earliest","toBlock":"latest","address":"0x9254E62FBCA63769DFd4Cc8e23f630F0785610CE"}],"id":0}
```
if address was more:

```
{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],"fromBlock":"earliest","toBlock":"latest","address":["0x9254E62FBCA63769DFd4Cc8e23f630F0785610CE","0x9254E62FBCA63769DFd4Cc8e23f630F0785610CE"]}],"id":0}
```

Sample:

```java
public class TestEvent {

    public static void main(String[] args) {
        Web3j web3j = Web3j.build(new HttpService("http://127.0.0.1:7545"));


        Event event = new Event("Transfer",
                Arrays.<TypeReference<?>>asList(new TypeReference<Address>(true) {
                                                },
                        new TypeReference<Address>(true) {
                        }, new TypeReference<Uint256>() {
                        }));
        List<String> list=new ArrayList<>();
        list.add("0x9254E62FBCA63769DFd4Cc8e23f630F0785610CE");
//        list.add("0x9254E62FBCA63769DFd4Cc8e23f630F0785610CE");
        EthFilter filter = new EthFilter(DefaultBlockParameterName.EARLIEST,
                DefaultBlockParameterName.LATEST, list);
        filter.addSingleTopic(EventEncoder.encode(event));
        Flowable<TransferEventResponse> flowable = web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<Log, TransferEventResponse>() {
            @Override
            public TransferEventResponse apply(Log log) {
                EventValuesWithLog eventValues = extractEventParametersWithLog(event, log);
                TransferEventResponse typedResponse = new TransferEventResponse();
                typedResponse.log = log;
                typedResponse._from = (String) eventValues.getIndexedValues().get(0).getValue();
                typedResponse._to = (String) eventValues.getIndexedValues().get(1).getValue();
                typedResponse._value = (BigInteger) eventValues.getNonIndexedValues().get(0).getValue();
                return typedResponse;
            }
        });
        flowable.subscribe();
    }

    public static class TransferEventResponse {
        public Log log;

        public String _from;

        public String _to;

        public BigInteger _value;
    }

    static EventValuesWithLog extractEventParametersWithLog(Event event, Log log) {
        final EventValues eventValues = Contract.staticExtractEventParameters(event, log);
        return (eventValues == null) ? null : new EventValuesWithLog(eventValues, log);
    }

    public static class EventValuesWithLog {
        private final EventValues eventValues;
        private final Log log;

        private EventValuesWithLog(EventValues eventValues, Log log) {
            this.eventValues = eventValues;
            this.log = log;
        }

        public List<Type> getIndexedValues() {
            return eventValues.getIndexedValues();
        }

        public List<Type> getNonIndexedValues() {
            return eventValues.getNonIndexedValues();
        }

        public Log getLog() {
            return log;
        }
    }
}
```

Of course, maybe I have a problem with it.