### PR TITLE
bytes, bytes1..32 fix; chainId is not restrictly required anymore (issues #1054, #1063)

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -48,7 +48,7 @@ public class StructuredDataEncoder {
     final String arrayTypeRegex = "^([a-zA-Z_$][a-zA-Z_$0-9]*)((\\[([1-9]\\d*)?\\])+)$";
     final Pattern arrayTypePattern = Pattern.compile(arrayTypeRegex);
 
-    final String bytesTypeRegex = "^bytes[0-9]?[0-9]?$";
+    final String bytesTypeRegex = "^bytes[0-9][0-9]?$";
     final Pattern bytesTypePattern = Pattern.compile(bytesTypeRegex);
 
     // This regex tries to extract the dimensions from the
@@ -248,6 +248,9 @@ public class StructuredDataEncoder {
                 encTypes.add("bytes32");
                 byte[] hashedValue = Numeric.hexStringToByteArray(sha3String((String) value));
                 encValues.add(hashedValue);
+            } else if (field.getType().equals("bytes")) {
+                encTypes.add(("bytes32"));
+                encValues.add(sha3(Numeric.hexStringToByteArray((String)value)));
             } else if (types.containsKey(field.getType())) {
                 // User Defined Type
                 byte[] hashedValue =

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -363,7 +363,7 @@ public class StructuredDataEncoder {
         ObjectMapper oMapper = new ObjectMapper();
         HashMap<String, Object> data =
                 oMapper.convertValue(jsonMessageObject.getDomain(), HashMap.class);
-
+ 
         if (data.get("chainId") != null) {
             data.put("chainId", ((HashMap<String, Object>) data.get("chainId")).get("value"));
         } else {

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -369,7 +369,7 @@ public class StructuredDataEncoder {
         } else {
             data.remove("chainId");
         }
-        
+
         data.put(
                 "verifyingContract",
                 ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -48,6 +48,9 @@ public class StructuredDataEncoder {
     final String arrayTypeRegex = "^([a-zA-Z_$][a-zA-Z_$0-9]*)((\\[([1-9]\\d*)?\\])+)$";
     final Pattern arrayTypePattern = Pattern.compile(arrayTypeRegex);
 
+    final String bytesTypeRegex = "^bytes[0-9]?[0-9]?$";
+    final Pattern bytesTypePattern = Pattern.compile(bytesTypeRegex);
+
     // This regex tries to extract the dimensions from the
     // square brackets of an array declaration using the ``Regex Groups``.
     // Eg- It extracts ``5, 6, 7`` from ``[5][6][7]``
@@ -245,16 +248,15 @@ public class StructuredDataEncoder {
                 encTypes.add("bytes32");
                 byte[] hashedValue = Numeric.hexStringToByteArray(sha3String((String) value));
                 encValues.add(hashedValue);
-            } else if (field.getType().equals("bytes")) {
-                encTypes.add("bytes32");
-                byte[] hashedValue = sha3((byte[]) value);
-                encValues.add(hashedValue);
             } else if (types.containsKey(field.getType())) {
                 // User Defined Type
                 byte[] hashedValue =
                         sha3(encodeData(field.getType(), (HashMap<String, Object>) value));
                 encTypes.add("bytes32");
                 encValues.add(hashedValue);
+            } else if (bytesTypePattern.matcher(field.getType()).find()) {
+                encTypes.add(field.getType());
+                encValues.add(Numeric.hexStringToByteArray((String)value));
             } else if (arrayTypePattern.matcher(field.getType()).find()) {
                 String baseTypeName = field.getType().substring(0, field.getType().indexOf('['));
                 List<Integer> expectedDimensions =

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -256,7 +256,7 @@ public class StructuredDataEncoder {
                 encValues.add(hashedValue);
             } else if (bytesTypePattern.matcher(field.getType()).find()) {
                 encTypes.add(field.getType());
-                encValues.add(Numeric.hexStringToByteArray((String)value));
+                encValues.add(Numeric.hexStringToByteArray((String) value));
             } else if (arrayTypePattern.matcher(field.getType()).find()) {
                 String baseTypeName = field.getType().substring(0, field.getType().indexOf('['));
                 List<Integer> expectedDimensions =

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -364,7 +364,11 @@ public class StructuredDataEncoder {
         HashMap<String, Object> data =
                 oMapper.convertValue(jsonMessageObject.getDomain(), HashMap.class);
 
-        data.put("chainId", ((HashMap<String, Object>) data.get("chainId")).get("value"));
+        if (data.get("chainId") != null) {
+            data.put("chainId", ((HashMap<String, Object>) data.get("chainId")).get("value"));
+        } else {
+            data.remove("chainId");
+        }
         data.put(
                 "verifyingContract",
                 ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -363,7 +363,6 @@ public class StructuredDataEncoder {
         ObjectMapper oMapper = new ObjectMapper();
         HashMap<String, Object> data =
                 oMapper.convertValue(jsonMessageObject.getDomain(), HashMap.class);
- 
         if (data.get("chainId") != null) {
             data.put("chainId", ((HashMap<String, Object>) data.get("chainId")).get("value"));
         } else {

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -250,7 +250,7 @@ public class StructuredDataEncoder {
                 encValues.add(hashedValue);
             } else if (field.getType().equals("bytes")) {
                 encTypes.add(("bytes32"));
-                encValues.add(sha3(Numeric.hexStringToByteArray((String)value)));
+                encValues.add(sha3(Numeric.hexStringToByteArray((String) value)));
             } else if (types.containsKey(field.getType())) {
                 // User Defined Type
                 byte[] hashedValue =

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -363,11 +363,13 @@ public class StructuredDataEncoder {
         ObjectMapper oMapper = new ObjectMapper();
         HashMap<String, Object> data =
                 oMapper.convertValue(jsonMessageObject.getDomain(), HashMap.class);
+
         if (data.get("chainId") != null) {
             data.put("chainId", ((HashMap<String, Object>) data.get("chainId")).get("value"));
         } else {
             data.remove("chainId");
         }
+        
         data.put(
                 "verifyingContract",
                 ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -38,23 +38,22 @@ public class StructuredDataTest {
         String validStructuredDataJSONFilePath =
                 "build/resources/test/" + "structured_data_json_files/ValidStructuredData.json";
         jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(validStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
+            getResource(validStructuredDataJSONFilePath);
     }
 
-    @Test(expected = RuntimeException.class)
+  private String getResource(String jsonFile) throws IOException {
+    return new String(
+        Files.readAllBytes(
+            Paths.get(jsonFile).toAbsolutePath()),
+        "UTF-8");
+  }
+
+  @Test(expected = RuntimeException.class)
     public void testInvalidIdentifierMessageCaughtByRegex() throws IOException, RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidIdentifierStructuredData.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        new StructuredDataEncoder(jsonMessageString);
+        new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
     }
 
     @Test(expected = RuntimeException.class)
@@ -62,12 +61,7 @@ public class StructuredDataTest {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidTypeStructuredData.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        new StructuredDataEncoder(jsonMessageString);
+        new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
     }
 
     @Test
@@ -157,17 +151,21 @@ public class StructuredDataTest {
         assertEquals(Numeric.toHexString(hashStructuredMessage), expectedDomainStructHash);
     }
 
+    @Test
+    public void testBytesAndBytes32Encoding() throws IOException {
+      StructuredDataEncoder dataEncoder = new StructuredDataEncoder(
+          getResource("build/resources/test/"
+              + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
+      dataEncoder.hashStructuredData();
+    }
+
     @Test(expected = ClassCastException.class)
     public void testInvalidMessageValueTypeMismatch() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
+        StructuredDataEncoder dataEncoder =
+            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -176,12 +174,8 @@ public class StructuredDataTest {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageInvalidABIType.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
+        StructuredDataEncoder dataEncoder =
+            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -190,12 +184,8 @@ public class StructuredDataTest {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
+        StructuredDataEncoder dataEncoder =
+            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -369,12 +359,8 @@ public class StructuredDataTest {
                 "build/resources/test/"
                         + "structured_data_json_files/"
                         + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
+        StructuredDataEncoder dataEncoder =
+            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -385,12 +371,8 @@ public class StructuredDataTest {
                 "build/resources/test/"
                         + "structured_data_json_files/"
                         + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
-        jsonMessageString =
-                new String(
-                        Files.readAllBytes(
-                                Paths.get(invalidStructuredDataJSONFilePath).toAbsolutePath()),
-                        "UTF-8");
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
+        StructuredDataEncoder dataEncoder =
+            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -157,6 +157,18 @@ public class StructuredDataTest {
         dataEncoder.hashStructuredData();
     }
 
+    @Test
+    public void test0xProtocolControlSample() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/0xProtocolControlSample.json"));
+        assertEquals(
+                "0xccb29124860915763e8cd9257da1260abc7df668fde282272587d84b594f37f6",
+                Numeric.toHexString(dataEncoder.hashStructuredData()));
+    }
+
     @Test(expected = ClassCastException.class)
     public void testInvalidMessageValueTypeMismatch() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -37,18 +37,14 @@ public class StructuredDataTest {
     public void validSetUp() throws IOException, RuntimeException {
         String validStructuredDataJSONFilePath =
                 "build/resources/test/" + "structured_data_json_files/ValidStructuredData.json";
-        jsonMessageString =
-            getResource(validStructuredDataJSONFilePath);
+        jsonMessageString = getResource(validStructuredDataJSONFilePath);
     }
 
-  private String getResource(String jsonFile) throws IOException {
-    return new String(
-        Files.readAllBytes(
-            Paths.get(jsonFile).toAbsolutePath()),
-        "UTF-8");
-  }
+    private String getResource(String jsonFile) throws IOException {
+        return new String(Files.readAllBytes(Paths.get(jsonFile).toAbsolutePath()), "UTF-8");
+    }
 
-  @Test(expected = RuntimeException.class)
+    @Test(expected = RuntimeException.class)
     public void testInvalidIdentifierMessageCaughtByRegex() throws IOException, RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
@@ -153,10 +149,12 @@ public class StructuredDataTest {
 
     @Test
     public void testBytesAndBytes32Encoding() throws IOException {
-      StructuredDataEncoder dataEncoder = new StructuredDataEncoder(
-          getResource("build/resources/test/"
-              + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
-      dataEncoder.hashStructuredData();
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
+        dataEncoder.hashStructuredData();
     }
 
     @Test(expected = ClassCastException.class)
@@ -165,7 +163,7 @@ public class StructuredDataTest {
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
         StructuredDataEncoder dataEncoder =
-            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
+                new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -175,7 +173,7 @@ public class StructuredDataTest {
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageInvalidABIType.json";
         StructuredDataEncoder dataEncoder =
-            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
+                new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -185,7 +183,7 @@ public class StructuredDataTest {
                 "build/resources/test/"
                         + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
         StructuredDataEncoder dataEncoder =
-            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
+                new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -360,7 +358,7 @@ public class StructuredDataTest {
                         + "structured_data_json_files/"
                         + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
         StructuredDataEncoder dataEncoder =
-            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
+                new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 
@@ -372,7 +370,7 @@ public class StructuredDataTest {
                         + "structured_data_json_files/"
                         + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
         StructuredDataEncoder dataEncoder =
-            new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
+                new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         dataEncoder.hashStructuredData();
     }
 }

--- a/crypto/src/test/resources/structured_data_json_files/0xProtocolControlSample.json
+++ b/crypto/src/test/resources/structured_data_json_files/0xProtocolControlSample.json
@@ -1,0 +1,43 @@
+{
+  "types": {
+    "EIP712Domain": [
+      {"name": "name", "type": "string"},
+      {"name": "version", "type": "string"},
+      {"name": "verifyingContract", "type": "address"}
+    ],
+    "Order": [
+      { "name": "makerAddress", "type": "address" },
+      { "name": "takerAddress", "type": "address" },
+      { "name": "feeRecipientAddress", "type": "address" },
+      { "name": "senderAddress", "type": "address" },
+      { "name": "makerAssetAmount", "type": "uint256" },
+      { "name": "takerAssetAmount", "type": "uint256" },
+      { "name": "makerFee", "type": "uint256" },
+      { "name": "takerFee", "type": "uint256" },
+      { "name": "expirationTimeSeconds", "type": "uint256" },
+      { "name": "salt", "type": "uint256" },
+      { "name": "makerAssetData", "type": "bytes" },
+      { "name": "takerAssetData", "type": "bytes" }
+    ]
+  },
+  "primaryType": "Order",
+  "domain": {
+    "name": "0x Protocol",
+    "version": "2",
+    "verifyingContract": "0x12459c951127e0c374ff9105dda097662a027093"
+  },
+  "message": {
+    "makerAddress": "0x9e56625509c2f60af937f23b7b532600390e8c8b",
+    "takerAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "feeRecipientAddress": "0xb046140686d052fff581f63f8136cce132e857da",
+    "senderAddress": "0xa2b31dacf30a9c50ca473337c01d8a201ae33e32",
+    "makerAssetAmount": 10000000000000000,
+    "takerAssetAmount": 20000000000000000,
+    "makerFee": 100000000000000,
+    "takerFee": 200000000000000,
+    "expirationTimeSeconds": 1532560590,
+    "salt": 1532559225,
+    "makerAssetData": "0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498",
+    "takerAssetData": "0x02571792000000000000000000000000371b13d97f4bf77d724e78c16b7dc74099f40e840000000000000000000000000000000000000000000000000000000000000063"
+  }
+}

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithBytesTypes.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithBytesTypes.json
@@ -1,0 +1,43 @@
+{
+  "types": {
+    "EIP712Domain": [
+      {"name": "name", "type": "string"},
+      {"name": "version", "type": "string"},
+      {"name": "chainId", "type": "uint256"},
+      {"name": "verifyingContract", "type": "address"}
+    ],
+    "Person": [
+      {"name": "name", "type": "string"},
+      {"name": "wallet", "type": "address"},
+      {"name": "personInfo", "type": "bytes"},
+      {"name": "personData", "type": "bytes3"}
+    ],
+    "Mail": [
+      {"name": "from", "type": "Person"},
+      {"name": "to", "type": "Person"},
+      {"name": "contents", "type": "string"}
+    ]
+  },
+  "primaryType": "Mail",
+  "domain": {
+    "name": "Ether Mail",
+    "version": "1",
+    "chainId": 1,
+    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+  },
+  "message": {
+    "from": {
+      "name": "Cow",
+      "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+      "personInfo": "0xABCD01234",
+      "personData": "0x12345"
+    },
+    "to": {
+      "name": "Bob",
+      "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+      "personInfo": "0x01234ABCD",
+      "personData": "0x54321"
+    },
+    "contents": "Hello, Bob!"
+  }
+}


### PR DESCRIPTION
### What does this PR do?
it fixes https://github.com/web3j/web3j/issues/1054, https://github.com/web3j/web3j/issues/1063

### Where should the reviewer start?
- StructuredDataTest.java:155
- ValidStructuredDataWithBytesTypes.json - bytes and bytes3 datatypes

### Why is it needed?
StructuredDataTest.testBytestAndBytes32Encoding() fails on "bytes" and "bytes1..32" types

