### PR TITLE
Add ethereum-ingest block/tx ingest utility to list of projects.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -548,6 +548,7 @@ Please submit a pull request if you wish to include your project on the list:
 - `Ethereum Java EE JCA Resource Adapter <https://github.com/e-Contract/ethereum-resource-adapter>`_ provides integration of Ethereum within Java EE 6+.
 - `Apache Camel Ethereum Component <https://github.com/apache/camel/blob/master/components/camel-web3j/src/main/docs/web3j-component.adoc>`_ by `@bibryam <https://github.com/bibryam/>`_.
 - `Etherlinker for UE4 <https://bitbucket.org/kelheor/etherlinker-for-ue4>`_ - interact with Ethereum blockchain from Unreal Engine 4.
+- `Ethereum ingest utility <https://ethereum-ingest.com/>`_ - Import and stream blocks/transactions into Hazelcast, Elasticsearch and MongoDB.
 
 
 


### PR DESCRIPTION
### What does this PR do?
Adds another project under "projects using web3j"

### Where should the reviewer start?
README.rst

### Why is it needed?
ethereum-ingest is an useful ingest utility for the ethereum blockchain, which uses web3j.

