### PR TITLE
BUGFIX: fix TypeDecoder.instantiateType() clipping value when passed a Float or Double arg greater than MAX_LONG

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -354,6 +354,8 @@ public class TypeDecoder {
             return Numeric.toBigInt((String) arg);
         } else if (arg instanceof byte[]) {
             return Numeric.toBigInt((byte[]) arg);
+        } else if (arg instanceof Double || arg instanceof Float) {
+            return BigDecimal.valueOf(((Number) arg).doubleValue()).toBigInteger();
         } else if (arg instanceof Number) {
             return BigInteger.valueOf(((Number) arg).longValue());
         }

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -103,6 +103,8 @@ public class TypeDecoderTest {
                         Uint64.class),
                 (new Uint64(new BigInteger("0ffffffffffffffff", 16))));
         assertEquals(TypeDecoder.instantiateType("uint", 123), (new Uint(BigInteger.valueOf(123))));
+        assertEquals(
+                TypeDecoder.instantiateType("uint", 1.0e20), (new Uint(BigInteger.TEN.pow(20))));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in TypeDecoder.instantiateType(). At the moment floats and doubles are coerced into BigInteger format using BigInteger.valueOf(num.longValue()). This produces the wrong result when the float or double is greater than MAX_LONG. This PR converts float and double via BigDecimal.valueOf(num.doubleValue()).toBigInteger()

### Where should the reviewer start?
see added case in TypeDecoder.asBigInteger()

### Why is it needed?
to fix function encoding when passed double or float arguments
