### PR TITLE
Add support for eth_chainId

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -22,6 +22,7 @@ import org.web3j.protocol.core.methods.response.DbPutString;
 import org.web3j.protocol.core.methods.response.EthAccounts;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
+import org.web3j.protocol.core.methods.response.EthChainId;
 import org.web3j.protocol.core.methods.response.EthCoinbase;
 import org.web3j.protocol.core.methods.response.EthCompileLLL;
 import org.web3j.protocol.core.methods.response.EthCompileSerpent;
@@ -80,6 +81,8 @@ public interface Ethereum {
     Request<?, AdminNodeInfo> adminNodeInfo();
 
     Request<?, EthProtocolVersion> ethProtocolVersion();
+
+    Request<?, EthChainId> ethChainId();
 
     Request<?, EthCoinbase> ethCoinbase();
 

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -35,6 +35,7 @@ import org.web3j.protocol.core.methods.response.DbPutString;
 import org.web3j.protocol.core.methods.response.EthAccounts;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
+import org.web3j.protocol.core.methods.response.EthChainId;
 import org.web3j.protocol.core.methods.response.EthCoinbase;
 import org.web3j.protocol.core.methods.response.EthCompileLLL;
 import org.web3j.protocol.core.methods.response.EthCompileSerpent;
@@ -154,6 +155,12 @@ public class JsonRpc2_0Web3j implements Web3j {
                 Collections.<String>emptyList(),
                 web3jService,
                 EthProtocolVersion.class);
+    }
+
+    @Override
+    public Request<?, EthChainId> ethChainId() {
+        return new Request<>(
+                "eth_chainId", Collections.<String>emptyList(), web3jService, EthChainId.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
@@ -17,7 +17,7 @@ import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
 
-/** eth_gasPrice. */
+/** eth_chainId. */
 public class EthChainId extends Response<String> {
     public BigInteger getChainId() {
         return Numeric.decodeQuantity(getResult());

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+
+/** eth_gasPrice. */
+public class EthChainId extends Response<String> {
+    public BigInteger getChainId() {
+        return Numeric.decodeQuantity(getResult());
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthChainId.java
@@ -12,10 +12,10 @@
  */
 package org.web3j.protocol.core.methods.response;
 
+import java.math.BigInteger;
+
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
-
-import java.math.BigInteger;
 
 /** eth_chainId. */
 public class EthChainId extends Response<String> {


### PR DESCRIPTION
### What does this PR do?
Add support the getchainid JSON-RPC method, https://web3js.readthedocs.io/en/v1.2.3/web3-eth.html#getchainid which returns the chain ID of the current connected node as described in the EIP-695.

### Where should the reviewer start?
Simple change hopefully obvious...

### Why is it needed?
To enable support for EIP-555 simple replay attack protection currently have to configure the chainId externally, this would allow lookup from connected 'node'

