### PR TITLE
Fix 404ing URL

### DIFF
--- a/core/src/main/java/org/web3j/ens/EnsResolver.java
+++ b/core/src/main/java/org/web3j/ens/EnsResolver.java
@@ -107,7 +107,7 @@ public class EnsResolver {
 
     /**
      * Reverse name resolution as documented in the <a
-     * href="https://docs.ens.domains/en/latest/userguide.html#reverse-name-resolution">specification</a>.
+     * href="https://docs.ens.domains/contract-api-reference/reverseregistrar">specification</a>.
      *
      * @param address an ethereum address, example: "0x314159265dd8dbb310642f98f50c066173c1259b"
      * @return a EnsName registered for provided address


### PR DESCRIPTION
the documentation for ENS moved a bit. The old URL was 404ing