### PR TITLE
Add multiple event subscribers in filters

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/BlocksFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/BlocksFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.filters;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthLog.LogResult;
+
+/** Handler hashes for working with block filter requests */
+public class BlocksFilter extends Filter<List<String>> {
+
+    public BlocksFilter(Web3j web3j, Callback<List<String>> callback) {
+        super(web3j, callback);
+    }
+
+    @Override
+    EthFilter sendRequest() throws IOException {
+        return web3j.ethNewBlockFilter().send();
+    }
+
+    @Override
+    void process(List<LogResult> logResults) {
+        List<String> blockHashes = new ArrayList<>(logResults.size());
+
+        for (EthLog.LogResult logResult : logResults) {
+            if (!(logResult instanceof EthLog.Hash)) {
+                throw new FilterException(
+                        "Unexpected result type: " + logResult.get() + ", required Hash");
+            }
+
+            blockHashes.add(((EthLog.Hash) logResult).get());
+        }
+
+        callback.onEvent(blockHashes);
+    }
+
+    /**
+     * Since the block filter does not support historic filters, the filterId is ignored and an
+     * empty optional is returned.
+     *
+     * @param filterId Id of the filter for which the historic log should be retrieved
+     * @return Optional.empty()
+     */
+    @Override
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/filters/LogsFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/LogsFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.filters;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthLog.LogResult;
+import org.web3j.protocol.core.methods.response.Log;
+
+/** Logs filter handler. */
+public class LogsFilter extends Filter<List<Log>> {
+
+    private final org.web3j.protocol.core.methods.request.EthFilter ethFilter;
+
+    public LogsFilter(
+            Web3j web3j,
+            Callback<List<Log>> callback,
+            org.web3j.protocol.core.methods.request.EthFilter ethFilter) {
+        super(web3j, callback);
+        this.ethFilter = ethFilter;
+    }
+
+    @Override
+    EthFilter sendRequest() throws IOException {
+        return web3j.ethNewFilter(ethFilter).send();
+    }
+
+    @Override
+    void process(List<LogResult> logResults) {
+        List<Log> logs = new ArrayList<>(logResults.size());
+
+        for (EthLog.LogResult logResult : logResults) {
+            if (!(logResult instanceof EthLog.LogObject)) {
+                throw new FilterException(
+                        "Unexpected result type: " + logResult.get() + " required LogObject");
+            }
+
+            logs.add(((EthLog.LogObject) logResult).get());
+        }
+
+        callback.onEvent(logs);
+    }
+
+    @Override
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.of(web3j.ethGetFilterLogs(filterId));
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionsFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionsFilter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.filters;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthFilter;
+import org.web3j.protocol.core.methods.response.EthLog;
+
+/** Handler hashes for working with transaction filter requests. */
+public class PendingTransactionsFilter extends Filter<List<String>> {
+
+    public PendingTransactionsFilter(Web3j web3j, Callback<List<String>> callback) {
+        super(web3j, callback);
+    }
+
+    @Override
+    EthFilter sendRequest() throws IOException {
+        return web3j.ethNewPendingTransactionFilter().send();
+    }
+
+    @Override
+    void process(List<EthLog.LogResult> logResults) {
+        List<String> logs = new ArrayList<>(logResults.size());
+
+        for (EthLog.LogResult logResult : logResults) {
+            if (!(logResult instanceof EthLog.Hash)) {
+                throw new FilterException(
+                        "Unexpected result type: " + logResult.get() + ", required Hash");
+            }
+
+            logs.add(((EthLog.Hash) logResult).get());
+        }
+
+        callback.onEvent(logs);
+    }
+
+    /**
+     * Since the pending transaction filter does not support historic filters, the filterId is
+     * ignored and an empty optional is returned
+     *
+     * @param filterId Id of the filter for which the historic log should be retrieved
+     * @return Optional.empty()
+     */
+    @Override
+    protected Optional<Request<?, EthLog>> getFilterLogs(BigInteger filterId) {
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds filter that subscribe multiple logs

### Where should the reviewer start?
BlocksFilter, LogsFilter, PendingTransactionsFilter in org.web3j.protocol.core.filter package.

### Why is it needed?
We want to handle multiple filter changes without additional requests.
For example, we want to know latest block hash after request with polling interval.