### PR TITLE
Fix WebSocketService connect

### DIFF
--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -62,6 +62,7 @@ public class WebSocketService implements Web3jService {
 
     // WebSocket client
     private final WebSocketClient webSocketClient;
+    private boolean shouldReConnect;
     // Executor to schedule request timeouts
     private final ScheduledExecutorService executor;
     // Object mapper to map incoming JSON objects
@@ -114,10 +115,16 @@ public class WebSocketService implements Web3jService {
     }
 
     private void connectToWebSocket() throws InterruptedException, ConnectException {
-        boolean connected = webSocketClient.connectBlocking();
+        boolean connected =
+                shouldReConnect
+                        ? webSocketClient.reconnectBlocking()
+                        : webSocketClient.connectBlocking();
+
         if (!connected) {
             throw new ConnectException("Failed to connect to WebSocket");
         }
+
+        shouldReConnect = true;
     }
 
     private void setWebSocketListener(


### PR DESCRIPTION
### What does this PR do?
- fixed WebSocketService:connect() method
- fixed broken test testSendSubscriptionReply() in WebSocketServiceTest
- fixed typo verifyStartedSubscriptionHadnshake to verifyStartedSubscriptionHandshake


### Where should the reviewer start?
WebSocketService, WebSocketServiceTest in core module

### Why is it needed?
If we connect again after connected at once, IllegalStateException occur because WebSocketClient's
thread is already exist. So have to use reconnect method to reset WebSocketClient

