### PR TITLE
Abstracts getCode to transactionmanager

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -27,6 +27,7 @@ import org.web3j.protocol.besu.response.privacy.PrivGetTransactionReceipt;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthAccounts;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.eea.Eea;
@@ -69,4 +70,6 @@ public interface Besu extends Eea {
     Request<?, BooleanResponse> privDeletePrivacyGroup(final Base64String privacyGroupId);
 
     Request<?, PrivGetTransactionReceipt> privGetTransactionReceipt(final String transactionHash);
+
+    Request<?, EthGetCode> privGetCode(String address, DefaultBlockParameter defaultBlockParameter);
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -73,4 +73,9 @@ public interface Besu extends Eea {
 
     Request<?, EthGetCode> privGetCode(
             String address, DefaultBlockParameter defaultBlockParameter, String privacyGroupId);
+
+    Request<?, org.web3j.protocol.core.methods.response.EthCall> privCall(
+            org.web3j.protocol.core.methods.request.Transaction transaction,
+            DefaultBlockParameter defaultBlockParameter,
+            String privacyGroupId);
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -71,5 +71,6 @@ public interface Besu extends Eea {
 
     Request<?, PrivGetTransactionReceipt> privGetTransactionReceipt(final String transactionHash);
 
-    Request<?, EthGetCode> privGetCode(String address, DefaultBlockParameter defaultBlockParameter);
+    Request<?, EthGetCode> privGetCode(
+            String address, DefaultBlockParameter defaultBlockParameter, String privacyGroupId);
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -12,6 +12,7 @@
  */
 package org.web3j.protocol.besu;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,9 @@ import org.web3j.protocol.besu.response.privacy.PrivGetPrivateTransaction;
 import org.web3j.protocol.besu.response.privacy.PrivGetTransactionReceipt;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.EthAccounts;
+import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
@@ -185,8 +188,21 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
             final String address,
             final DefaultBlockParameter defaultBlockParameter,
             final String privacyGroupId) {
-        List<String> result = Arrays.asList(address, defaultBlockParameter.getValue());
+        ArrayList<String> result =
+                new ArrayList<>(Arrays.asList(address, defaultBlockParameter.getValue()));
         if (privacyGroupId != null) result.add(privacyGroupId);
         return new Request<>("priv_getCode", result, web3jService, EthGetCode.class);
+    }
+
+    @Override
+    public Request<?, EthCall> privCall(
+            final Transaction transaction,
+            final DefaultBlockParameter defaultBlockParameter,
+            String privacyGroupId) {
+        return new Request<>(
+                "priv_call",
+                Arrays.asList(transaction, defaultBlockParameter, privacyGroupId),
+                web3jService,
+                org.web3j.protocol.core.methods.response.EthCall.class);
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -30,6 +30,7 @@ import org.web3j.protocol.besu.response.privacy.PrivGetTransactionReceipt;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthAccounts;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.eea.JsonRpc2_0Eea;
@@ -177,5 +178,15 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 Collections.singletonList(transactionHash),
                 web3jService,
                 PrivGetTransactionReceipt.class);
+    }
+
+    @Override
+    public Request<?, EthGetCode> privGetCode(
+            String address, DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "priv_getCode",
+                Arrays.asList(address, defaultBlockParameter.getValue()),
+                web3jService,
+                EthGetCode.class);
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -182,11 +182,11 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
 
     @Override
     public Request<?, EthGetCode> privGetCode(
-            String address, DefaultBlockParameter defaultBlockParameter) {
-        return new Request<>(
-                "priv_getCode",
-                Arrays.asList(address, defaultBlockParameter.getValue()),
-                web3jService,
-                EthGetCode.class);
+            final String address,
+            final DefaultBlockParameter defaultBlockParameter,
+            final String privacyGroupId) {
+        List<String> result = Arrays.asList(address, defaultBlockParameter.getValue());
+        if (privacyGroupId != null) result.add(privacyGroupId);
+        return new Request<>("priv_getCode", result, web3jService, EthGetCode.class);
     }
 }

--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -23,6 +23,7 @@ import org.web3j.crypto.Credentials;
 import org.web3j.protocol.besu.Besu;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.eea.crypto.PrivateTransactionEncoder;
@@ -195,5 +196,12 @@ public abstract class PrivateTransactionManager extends TransactionManager {
         final String transactionHash = transactionResponse.getTransactionHash();
 
         return transactionReceiptProcessor.waitForTransactionReceipt(transactionHash);
+    }
+
+    @Override
+    public EthGetCode getCode(
+            final String contractAddress, final DefaultBlockParameter defaultBlockParameter)
+            throws IOException {
+        return this.besu.privGetCode(contractAddress, defaultBlockParameter).send();
     }
 }

--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -202,6 +202,9 @@ public abstract class PrivateTransactionManager extends TransactionManager {
     public EthGetCode getCode(
             final String contractAddress, final DefaultBlockParameter defaultBlockParameter)
             throws IOException {
-        return this.besu.privGetCode(contractAddress, defaultBlockParameter).send();
+        return this.besu
+                .privGetCode(
+                        contractAddress, defaultBlockParameter, this.getPrivacyGroupId().toString())
+                .send();
     }
 }

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import org.web3j.protocol.RequestTester;
 import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Base64String;
 
@@ -196,5 +197,17 @@ public class RequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getTransactionReceipt\","
                         + "\"params\":[\"0x123\"],\"id\":1}");
+    }
+
+    @Test
+    public void testPrivGetCode() throws Exception {
+        web3j.privGetCode(
+                        "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=",
+                        DefaultBlockParameterName.LATEST)
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getCode\","
+                        + "\"params\":[\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\"latest\"],\"id\":1}");
     }
 }

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -203,7 +203,8 @@ public class RequestTest extends RequestTester {
     public void testPrivGetCode() throws Exception {
         web3j.privGetCode(
                         "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=",
-                        DefaultBlockParameterName.LATEST)
+                        DefaultBlockParameterName.LATEST,
+                        null)
                 .send();
 
         verifyResult(

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.web3j.protocol.RequestTester;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Base64String;
 
@@ -204,11 +205,29 @@ public class RequestTest extends RequestTester {
         web3j.privGetCode(
                         "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=",
                         DefaultBlockParameterName.LATEST,
-                        null)
+                        MOCK_PRIVACY_GROUP_ID.toString())
                 .send();
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getCode\","
-                        + "\"params\":[\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\"latest\"],\"id\":1}");
+                        + "\"params\":[\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\"latest\",\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\"],\"id\":1}");
+    }
+
+    @Test
+    public void testEthCall() throws Exception {
+        web3j.privCall(
+                        Transaction.createEthCallTransaction(
+                                "0xa70e8dd61c5d32be8058bb8eb970870f07233155",
+                                "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+                                "0x0"),
+                        DefaultBlockParameter.valueOf("latest"),
+                        MOCK_PRIVACY_GROUP_ID.toString())
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_call\","
+                        + "\"params\":[{\"from\":\"0xa70e8dd61c5d32be8058bb8eb970870f07233155\","
+                        + "\"to\":\"0xb60e8dd61c5d32be8058bb8eb970870f07233155\",\"data\":\"0x0\"},"
+                        + "\"latest\",\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\"],\"id\":1}");
     }
 }

--- a/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.tx.response.TransactionReceiptProcessor;
 
@@ -73,5 +74,12 @@ public class ClientTransactionManager extends TransactionManager {
                         defaultBlockParameter)
                 .send()
                 .getValue();
+    }
+
+    @Override
+    public EthGetCode getCode(
+            final String contractAddress, final DefaultBlockParameter defaultBlockParameter)
+            throws IOException {
+        return web3j.ethGetCode(contractAddress, defaultBlockParameter).send();
     }
 }

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -242,7 +242,7 @@ public abstract class Contract extends ManagedTransaction {
         }
 
         EthGetCode ethGetCode =
-                web3j.ethGetCode(contractAddress, DefaultBlockParameterName.LATEST).send();
+                transactionManager.getCode(contractAddress, DefaultBlockParameterName.LATEST);
         if (ethGetCode.hasError()) {
             return false;
         }

--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -23,6 +23,7 @@ import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.tx.exceptions.TxHashMismatchException;
@@ -131,6 +132,13 @@ public class RawTransactionManager extends TransactionManager {
                         defaultBlockParameter)
                 .send()
                 .getValue();
+    }
+
+    @Override
+    public EthGetCode getCode(
+            final String contractAddress, final DefaultBlockParameter defaultBlockParameter)
+            throws IOException {
+        return web3j.ethGetCode(contractAddress, defaultBlockParameter).send();
     }
 
     /*

--- a/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
@@ -18,6 +18,7 @@ import java.math.BigInteger;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 
 /** Transaction manager implementation for read-only operations on smart contracts. */
@@ -52,5 +53,12 @@ public class ReadonlyTransactionManager extends TransactionManager {
                         defaultBlockParameter)
                 .send()
                 .getValue();
+    }
+
+    @Override
+    public EthGetCode getCode(
+            final String contractAddress, final DefaultBlockParameter defaultBlockParameter)
+            throws IOException {
+        return web3j.ethGetCode(contractAddress, defaultBlockParameter).send();
     }
 }

--- a/core/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/TransactionManager.java
@@ -17,6 +17,7 @@ import java.math.BigInteger;
 
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionException;
@@ -93,6 +94,9 @@ public abstract class TransactionManager {
 
     public abstract String sendCall(
             String to, String data, DefaultBlockParameter defaultBlockParameter) throws IOException;
+
+    public abstract EthGetCode getCode(
+            String contractAddress, DefaultBlockParameter defaultBlockParameter) throws IOException;
 
     public String getFromAddress() {
         return fromAddress;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Dec 03 15:43:36 GMT 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Dec 03 15:43:36 GMT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
### What does this PR do?
Adds priv_getCode method to web3j, abstracts getCode method away from the Contract class and into the TransactionManager so we can have multiple implementations depending on the transaction types we're dealing with.

### Where should the reviewer start?
*required*

### Why is it needed?
*required*

