### PR TITLE
Generate EVMTest annotation based on the Java version.

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/unit/gen/UnitClassGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/unit/gen/UnitClassGenerator.java
@@ -24,6 +24,8 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
 
+import org.web3j.commons.JavaVersion;
+
 import static org.web3j.codegen.unit.gen.utills.NameUtils.toCamelCase;
 
 /**
@@ -42,12 +44,17 @@ public class UnitClassGenerator {
     }
 
     public void writeClass() throws IOException {
-        ClassName EVM_ANNOTATION = ClassName.get("org.web3j", "EVMTest");
 
+        ClassName EVM_ANNOTATION = ClassName.get("org.web3j", "EVMTest");
+        AnnotationSpec.Builder annotationSpec = AnnotationSpec.builder(EVM_ANNOTATION);
+        if (JavaVersion.getJavaVersionAsDouble() < 11) {
+            ClassName GethContainer = ClassName.get("org.web3j", "NodeType");
+            annotationSpec.addMember("value", "type = $T.GETH", GethContainer);
+        }
         TypeSpec testClass =
                 TypeSpec.classBuilder(theContract.getSimpleName() + "Test")
                         .addMethods(generateMethodSpecsForEachTest())
-                        .addAnnotation(AnnotationSpec.builder(EVM_ANNOTATION).build())
+                        .addAnnotation((annotationSpec).build())
                         .addField(
                                 theContract,
                                 toCamelCase(theContract),

--- a/utils/src/main/java/org/web3j/commons/JavaVersion.java
+++ b/utils/src/main/java/org/web3j/commons/JavaVersion.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.commons;
+
+public class JavaVersion {
+
+    public static String getJavaVersion() {
+        return System.getProperty("java.specification.version");
+    }
+
+    public static double getJavaVersionAsDouble() {
+        return Double.parseDouble(System.getProperty("java.specification.version"));
+    }
+}


### PR DESCRIPTION
### What does this PR do?
When generating the unit tests if the java version is lower than 11 use EVMTest(type = NodeType.Geth)
otherwise, generate the default EVMTest annotation.

### Why is it needed?
To ensure that the tests run out of the box with Java 8 and 11.

