### PR TITLE
Fix the getType method for int40 and uint40

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/AbiTypes.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/AbiTypes.java
@@ -187,9 +187,9 @@ public final class AbiTypes {
             case "int32":
                 return primitives ? Int.class : Int32.class;
             case "uint40":
-                return primitives ? Long.class : Int40.class;
-            case "int40":
                 return primitives ? Long.class : Uint40.class;
+            case "int40":
+                return primitives ? Long.class : Int40.class;
             case "uint48":
                 return primitives ? Long.class : Uint48.class;
             case "int48":


### PR DESCRIPTION
### What does this PR do?
This is a bug fix.
It make the int40 a int40 and not a uint40 and the uint40 a uint40 and not a int40.

### Where should the reviewer start?
just check the file changed.

### Why is it needed?
getType method return the wrong type for int40 and uint40 because of a typo in some previous development.


This should be fast released as it fix a real bug in web3j that prevent users to update to the latest.

