### PR TITLE
Fix private transaction receipt 1132

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/response/privacy/PrivateTransactionReceipt.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/privacy/PrivateTransactionReceipt.java
@@ -24,86 +24,61 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
 public class PrivateTransactionReceipt extends TransactionReceipt {
 
-    private final String contractAddress;
-    private final String from;
-    private final String to;
     private final String output;
-    private final List<Log> logs;
     private final String commitmentHash;
-    private final String transactionHash;
     private final String privateFrom;
     private final ArrayList<String> privateFor;
     private final String privacyGroupId;
-    private final String status;
-    private final String revertReason;
 
     @JsonCreator
     public PrivateTransactionReceipt(
+            @JsonProperty(value = "transactionHash") final String transactionHash,
+            @JsonProperty(value = "transactionIndex") final String transactionIndex,
+            @JsonProperty(value = "blockHash") final String blockHash,
+            @JsonProperty(value = "blockNumber") final String blockNumber,
+            @JsonProperty(value = "cumulativeGasUsed") final String cumulativeGasUsed,
+            @JsonProperty(value = "gasUsed") final String gasUsed,
             @JsonProperty(value = "contractAddress") final String contractAddress,
+            @JsonProperty(value = "root") final String root,
+            @JsonProperty(value = "status") final String status,
             @JsonProperty(value = "from") final String from,
             @JsonProperty(value = "to") final String to,
-            @JsonProperty(value = "output") final String output,
             @JsonProperty(value = "logs") final List<Log> logs,
+            @JsonProperty(value = "logsBloom") final String logsBloom,
+            @JsonProperty(value = "revertReason") final String revertReason,
+            @JsonProperty(value = "output") final String output,
             @JsonProperty(value = "commitmentHash") final String commitmentHash,
-            @JsonProperty(value = "transactionHash") final String transactionHash,
             @JsonProperty(value = "privateFrom") final String privateFrom,
             @JsonProperty(value = "privateFor") final ArrayList<String> privateFor,
-            @JsonProperty(value = "privacyGroupId") final String privacyGroupId,
-            @JsonProperty(value = "status") final String status,
-            @JsonProperty(value = "revertReason") final String revertReason) {
-        this.contractAddress = contractAddress;
-        this.from = from;
-        this.to = to;
+            @JsonProperty(value = "privacyGroupId") final String privacyGroupId) {
+        super(
+                transactionHash,
+                transactionIndex,
+                blockHash,
+                blockNumber,
+                cumulativeGasUsed,
+                gasUsed,
+                contractAddress,
+                root,
+                status,
+                from,
+                to,
+                logs,
+                logsBloom,
+                revertReason);
         this.output = output;
-        this.logs = logs;
         this.commitmentHash = commitmentHash;
-        this.transactionHash = transactionHash;
         this.privateFrom = privateFrom;
         this.privateFor = privateFor;
         this.privacyGroupId = privacyGroupId;
-        this.status = status;
-        this.revertReason = revertReason;
-    }
-
-    @Override
-    public String getContractAddress() {
-        return contractAddress;
-    }
-
-    @Override
-    public String getFrom() {
-        return from;
-    }
-
-    @Override
-    public String getTo() {
-        return to;
     }
 
     public String getOutput() {
         return output;
     }
 
-    @Override
-    public List<Log> getLogs() {
-        return logs;
-    }
-
-    public String getRevertReason() {
-        return revertReason;
-    }
-
-    @Override
-    public String getStatus() {
-        return status;
-    }
-
     public String getcommitmentHash() {
         return commitmentHash;
-    }
-
-    public String gettransactionHash() {
-        return transactionHash;
     }
 
     public String getPrivateFrom() {
@@ -124,35 +99,16 @@ public class PrivateTransactionReceipt extends TransactionReceipt {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         final PrivateTransactionReceipt that = (PrivateTransactionReceipt) o;
-        return Objects.equals(contractAddress, that.contractAddress)
-                && Objects.equals(from, that.from)
-                && Objects.equals(to, that.to)
-                && Objects.equals(output, that.output)
-                && Objects.equals(logs, that.logs)
+        return Objects.equals(output, that.output)
                 && Objects.equals(commitmentHash, that.commitmentHash)
-                && Objects.equals(transactionHash, that.transactionHash)
                 && Objects.equals(privateFrom, that.privateFrom)
                 && Objects.equals(privateFor, that.privateFor)
-                && Objects.equals(privacyGroupId, that.privacyGroupId)
-                && Objects.equals(status, that.status)
-                && Objects.equals(revertReason, that.revertReason);
+                && Objects.equals(privacyGroupId, that.privacyGroupId);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-                super.hashCode(),
-                contractAddress,
-                from,
-                to,
-                output,
-                logs,
-                commitmentHash,
-                transactionHash,
-                privateFrom,
-                privateFor,
-                privacyGroupId,
-                status,
-                revertReason);
+                super.hashCode(), output, commitmentHash, privateFrom, privateFor, privacyGroupId);
     }
 }

--- a/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
@@ -303,10 +303,17 @@ public class ResponseTest extends ResponseTester {
 
         PrivateTransactionReceipt transactionReceipt =
                 new PrivateTransactionReceipt(
+                        "0x5504d87dc6c6ab8ea4f5c988bcf1c41d40e6b594b80849d4444c432099ee6c34",
+                        "0x1",
+                        "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+                        "0xb",
+                        "0x33bc",
+                        "0x4dc",
                         "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+                        null,
+                        "0x1",
                         "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
                         "0x85h43d8a49eeb85d32cf465507dd71d507100c1",
-                        "myRlpEncodedOutputFromPrivateContract",
                         Collections.singletonList(
                                 new Log(
                                         false,
@@ -320,13 +327,13 @@ public class ResponseTest extends ResponseTester {
                                         "mined",
                                         Arrays.asList(
                                                 "0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"))),
+                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        null,
+                        "myRlpEncodedOutputFromPrivateContract",
                         "0x75aaac4be865057a576872587c9672197f1bab25e64b588c81f483c5869e0fa7",
-                        "0x5504d87dc6c6ab8ea4f5c988bcf1c41d40e6b594b80849d4444c432099ee6c34",
                         "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=",
                         null,
-                        "Qlv2Jhn3C3/2KrPU7Jeu/9F6rElio9LNBSieb0Xk/Ro=",
-                        "0x1",
-                        null);
+                        "Qlv2Jhn3C3/2KrPU7Jeu/9F6rElio9LNBSieb0Xk/Ro=");
 
         PrivGetTransactionReceipt privGetTransactionReceipt =
                 deserialiseResponse(PrivGetTransactionReceipt.class);

--- a/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
@@ -304,11 +304,11 @@ public class ResponseTest extends ResponseTester {
         PrivateTransactionReceipt transactionReceipt =
                 new PrivateTransactionReceipt(
                         "0x5504d87dc6c6ab8ea4f5c988bcf1c41d40e6b594b80849d4444c432099ee6c34",
-                        "0x1",
-                        "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-                        "0xb",
-                        "0x33bc",
-                        "0x4dc",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
                         "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
                         null,
                         "0x1",
@@ -327,7 +327,7 @@ public class ResponseTest extends ResponseTester {
                                         "mined",
                                         Arrays.asList(
                                                 "0x59ebeb90bc63057b6515673c3ecf9438e5058bca0f92585014eced636878c9a5"))),
-                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        null,
                         null,
                         "myRlpEncodedOutputFromPrivateContract",
                         "0x75aaac4be865057a576872587c9672197f1bab25e64b588c81f483c5869e0fa7",
@@ -338,6 +338,6 @@ public class ResponseTest extends ResponseTester {
         PrivGetTransactionReceipt privGetTransactionReceipt =
                 deserialiseResponse(PrivGetTransactionReceipt.class);
 
-        assertEquals(privGetTransactionReceipt.getTransactionReceipt().get(), (transactionReceipt));
+        assertEquals(transactionReceipt, privGetTransactionReceipt.getTransactionReceipt().get());
     }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes #1132 by inheriting the fields from superclass instead of creating a new copy of them in the subclass.

### Where should the reviewer start?
PrivateTransactionReceipt

### Why is it needed?
By creating two copies of the same field for the superclass (TransactionReceipt) & subclass (PrivateTransactionReceipt), this creates various issues - for example, Calling privateTransactionReceipt.isStatusOk() Result will always be true because superclass's status is always null, even though subclass status is not.