### PR TITLE
Fixed a problem with solc compiler >= 0.6 since the constant flag is …

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -936,9 +936,13 @@ public class SolidityFunctionWrapper extends Generator {
         List<MethodSpec> results = new ArrayList<>(2);
         String functionName = functionDefinition.getName();
 
+        String stateMutability = functionDefinition.getStateMutability();
+        boolean pureOrView = "pure".equals(stateMutability) || "view".equals(stateMutability);
+        boolean isFunctionDefinitionConstant = functionDefinition.isConstant() || pureOrView;
+
         if (generateSendTxForCalls) {
             final String funcNamePrefix;
-            if (functionDefinition.isConstant()) {
+            if (isFunctionDefinitionConstant) {
                 funcNamePrefix = "call";
             } else {
                 funcNamePrefix = "send";
@@ -960,7 +964,7 @@ public class SolidityFunctionWrapper extends Generator {
         final List<TypeName> outputParameterTypes =
                 buildTypeNames(functionDefinition.getOutputs(), useJavaPrimitiveTypes);
 
-        if (functionDefinition.isConstant()) {
+        if (isFunctionDefinitionConstant) {
             // Avoid generating runtime exception call
             if (functionDefinition.hasOutputs()) {
                 buildConstantFunction(
@@ -979,7 +983,7 @@ public class SolidityFunctionWrapper extends Generator {
             }
         }
 
-        if (!functionDefinition.isConstant()) {
+        if (!isFunctionDefinitionConstant) {
             buildTransactionFunction(functionDefinition, methodBuilder, inputParams, useUpperCase);
             results.add(methodBuilder.build());
         }


### PR DESCRIPTION
### What does this PR do?
solc >=0.6 does not produce the constant flag in the ABI file anymore (see https://github.com/ethereum/solidity/releases/tag/v0.6.0 "ABI: Remove the deprecated constant and payable fields").
Therefore the code generator produces just transaction methods (see also #1139).
I extended the check for being constant in the generation process.

### Where should the reviewer start?
SolidityFunctionWrapper

### Why is it needed?
Otherwise, the generated code is wrong.

