### PR TITLE
Fix private transaction receipt status

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceipt.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceipt.java
@@ -158,10 +158,10 @@ public class TransactionReceipt {
     }
 
     public boolean isStatusOK() {
-        if (null == status) {
+        if (null == getStatus()) {
             return true;
         }
-        BigInteger statusQuantity = Numeric.decodeQuantity(status);
+        BigInteger statusQuantity = Numeric.decodeQuantity(getStatus());
         return BigInteger.ONE.equals(statusQuantity);
     }
 

--- a/core/src/main/java/org/web3j/utils/RevertReasonExtractor.java
+++ b/core/src/main/java/org/web3j/utils/RevertReasonExtractor.java
@@ -65,7 +65,7 @@ public class RevertReasonExtractor {
     public static String retrieveRevertReason(
             TransactionReceipt transactionReceipt, String data, Web3j web3j) throws IOException {
 
-        if (transactionReceipt.getBlockNumber() == null) {
+        if (transactionReceipt.getBlockNumberRaw() == null) {
             return null;
         }
         return web3j.ethCall(


### PR DESCRIPTION
### What does this PR do?
Makes `isStatusOk()` on private transaction receipts return the actual value, instead of always defaulting to true. Also fixes a bug whereby Web3j will throw if the block number on a transaction receipt is null.

### Where should the reviewer start?
*required*

### Why is it needed?
*required*

