### PR TITLE
Fix instantiateType method

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -198,7 +198,7 @@ public class TypeDecoder {
         for (Object o : values) {
             transformedList.add(instantiateType(subTypeReference, o));
         }
-        return (Type) listcons.newInstance(ref.getClassType(), transformedList);
+        return (Type) listcons.newInstance(subTypeReference.getClassType(), transformedList);
     }
 
     static Type instantiateAtomicType(Class<?> referenceClass, Object value)

--- a/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/TypeDecoderTest.java
@@ -1068,8 +1068,10 @@ public class TypeDecoderTest {
 
         assertTrue(arr instanceof StaticArray2);
         StaticArray2 staticArray2 = (StaticArray2) arr;
-        assertEquals(staticArray2.getValue().get(0), (new Uint256(BigInteger.TEN)));
 
+        assertEquals(staticArray2.getComponentType(), Uint256.class);
+
+        assertEquals(staticArray2.getValue().get(0), (new Uint256(BigInteger.TEN)));
         assertEquals(
                 staticArray2.getValue().get(1), (new Uint256(BigInteger.valueOf(Long.MAX_VALUE))));
     }
@@ -1135,6 +1137,8 @@ public class TypeDecoderTest {
         assertTrue(arr instanceof DynamicArray);
         DynamicArray dynamicArray = (DynamicArray) arr;
 
+        assertEquals(dynamicArray.getComponentType(), Utf8String.class);
+
         assertEquals(dynamicArray.getValue().get(0), (new Utf8String("Hello, world!")));
 
         assertEquals(dynamicArray.getValue().get(1), (new Utf8String("world! Hello,")));
@@ -1153,12 +1157,15 @@ public class TypeDecoderTest {
         assertTrue(twoDim instanceof StaticArray3);
         StaticArray3<DynamicArray<Uint256>> staticArray3 =
                 (StaticArray3<DynamicArray<Uint256>>) twoDim;
+        assertEquals(staticArray3.getComponentType(), DynamicArray.class);
         DynamicArray<Uint256> row1 = staticArray3.getValue().get(1);
         assertEquals(row1.getValue().get(2), new Uint256(3));
+
         Type threeDim = TypeDecoder.instantiateType("uint256[][3][3]", bytes3d);
         assertTrue(threeDim instanceof StaticArray3);
         StaticArray3<StaticArray3<DynamicArray<Uint256>>> staticArray3StaticArray3 =
                 (StaticArray3<StaticArray3<DynamicArray<Uint256>>>) threeDim;
+        assertEquals(staticArray3StaticArray3.getComponentType(), StaticArray3.class);
         row1 = staticArray3StaticArray3.getValue().get(1).getValue().get(1);
         assertEquals(row1.getValue().get(1), (new Uint256(2)));
     }


### PR DESCRIPTION
The instantiateArrayType method used by instantiateType did not return an Array with the correct subtype. See bug #1172 .

### What does this PR do?
Correct to instantiateArrayType method.
Add asserts on unit tests of dealing with arrays to chceck the subtype is correct.

### Where should the reviewer start?
Simple correction, not much to review :)

### Why is it needed?
Corrects a bug :)

