### PR TITLE
Changed CLI help link to point to quickstart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ To get the latest version on Mac OS or Linux, type the following in your termina
 
    curl -L https://get.web3j.io | sh
 
-Then follow the on-screen instructions or head `here <https://docs.web3j.io/command_line_tools/>`_. 
+Then follow the on-screen instructions or head `here <https://docs.web3j.io/quickstart/>`_. 
 
 Alternatively, a `web3j sample project <https://github.com/web3j/sample-project-gradle>`_ is available that
 demonstrates a number of core features of Ethereum with web3j, including:


### PR DESCRIPTION
### What does this PR do?
Changed the link that provides information in the cli section of the readme to point to web3j quickstart documentation. A PR is available on the web3j/docs repo that adds more information about starting with the command line interface.

### Where should the reviewer start?
In the readme file.

### Why is it needed?
Point the user to more descriptive information.

