### PR TITLE
EIP-1559 implementation

### DIFF
--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -101,11 +101,17 @@ public abstract class PrivateTransactionManager extends TransactionManager {
 
     @Override
     protected TransactionReceipt executeTransaction(
-            BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException, TransactionException {
 
         EthSendTransaction ethSendTransaction =
-                sendTransaction(gasPrice, gasLimit, to, data, value);
+                sendTransaction(gasPrice, gasLimit, to, data, value, gasPremium, feeCap);
         return processResponse(ethSendTransaction);
     }
 
@@ -125,7 +131,9 @@ public abstract class PrivateTransactionManager extends TransactionManager {
             final String to,
             final String data,
             final BigInteger value,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException {
 
         final BigInteger nonce =
@@ -178,7 +186,9 @@ public abstract class PrivateTransactionManager extends TransactionManager {
                             gasProvider.getGasLimit(),
                             to,
                             data,
-                            BigInteger.ZERO);
+                            BigInteger.ZERO,
+                            null,
+                            null);
             final TransactionReceipt ptr = processResponse(est);
 
             if (!ptr.isStatusOK()) {

--- a/core/src/main/java/org/web3j/ens/contracts/generated/ENS.java
+++ b/core/src/main/java/org/web3j/ens/contracts/generated/ENS.java
@@ -1,11 +1,13 @@
 package org.web3j.ens.contracts.generated;
 
 import io.reactivex.Flowable;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.web3j.abi.EventEncoder;
 import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
@@ -29,7 +31,7 @@ import org.web3j.tx.gas.ContractGasProvider;
  * <p>Auto generated code.
  * <p><strong>Do not modify!</strong>
  * <p>Please use the <a href="https://docs.web3j.io/command_line.html">web3j command line tools</a>,
- * or the org.web3j.codegen.SolidityFunctionWrapperGenerator in the 
+ * or the org.web3j.codegen.SolidityFunctionWrapperGenerator in the
  * <a href="https://github.com/web3j/web3j/tree/master/codegen">codegen module</a> to update.
  *
  * <p>Generated with web3j version 4.0.0.
@@ -51,20 +53,29 @@ public class ENS extends Contract {
 
     public static final String FUNC_SETOWNER = "setOwner";
 
-    public static final Event NEWOWNER_EVENT = new Event("NewOwner", 
-            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {}, new TypeReference<Bytes32>(true) {}, new TypeReference<Address>() {}));
+    public static final Event NEWOWNER_EVENT = new Event("NewOwner",
+            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {
+            }, new TypeReference<Bytes32>(true) {
+            }, new TypeReference<Address>() {
+            }));
     ;
 
-    public static final Event TRANSFER_EVENT = new Event("Transfer", 
-            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {}, new TypeReference<Address>() {}));
+    public static final Event TRANSFER_EVENT = new Event("Transfer",
+            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {
+            }, new TypeReference<Address>() {
+            }));
     ;
 
-    public static final Event NEWRESOLVER_EVENT = new Event("NewResolver", 
-            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {}, new TypeReference<Address>() {}));
+    public static final Event NEWRESOLVER_EVENT = new Event("NewResolver",
+            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {
+            }, new TypeReference<Address>() {
+            }));
     ;
 
-    public static final Event NEWTTL_EVENT = new Event("NewTTL", 
-            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {}, new TypeReference<Uint64>() {}));
+    public static final Event NEWTTL_EVENT = new Event("NewTTL",
+            Arrays.<TypeReference<?>>asList(new TypeReference<Bytes32>(true) {
+            }, new TypeReference<Uint64>() {
+            }));
     ;
 
     @Deprecated
@@ -86,59 +97,62 @@ public class ENS extends Contract {
     }
 
     public RemoteCall<String> resolver(byte[] node) {
-        final Function function = new Function(FUNC_RESOLVER, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)), 
-                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}));
+        final Function function = new Function(FUNC_RESOLVER,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)),
+                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {
+                }));
         return executeRemoteCallSingleValueReturn(function, String.class);
     }
 
     public RemoteCall<String> owner(byte[] node) {
-        final Function function = new Function(FUNC_OWNER, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)), 
-                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {}));
+        final Function function = new Function(FUNC_OWNER,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)),
+                Arrays.<TypeReference<?>>asList(new TypeReference<Address>() {
+                }));
         return executeRemoteCallSingleValueReturn(function, String.class);
     }
 
     public RemoteCall<TransactionReceipt> setSubnodeOwner(byte[] node, byte[] label, String owner) {
         final Function function = new Function(
-                FUNC_SETSUBNODEOWNER, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
-                new org.web3j.abi.datatypes.generated.Bytes32(label), 
-                new org.web3j.abi.datatypes.Address(owner)), 
+                FUNC_SETSUBNODEOWNER,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node),
+                        new org.web3j.abi.datatypes.generated.Bytes32(label),
+                        new org.web3j.abi.datatypes.Address(owner)),
                 Collections.<TypeReference<?>>emptyList());
         return executeRemoteCallTransaction(function);
     }
 
     public RemoteCall<TransactionReceipt> setTTL(byte[] node, BigInteger ttl) {
         final Function function = new Function(
-                FUNC_SETTTL, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
-                new org.web3j.abi.datatypes.generated.Uint64(ttl)), 
+                FUNC_SETTTL,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node),
+                        new org.web3j.abi.datatypes.generated.Uint64(ttl)),
                 Collections.<TypeReference<?>>emptyList());
         return executeRemoteCallTransaction(function);
     }
 
     public RemoteCall<BigInteger> ttl(byte[] node) {
-        final Function function = new Function(FUNC_TTL, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)), 
-                Arrays.<TypeReference<?>>asList(new TypeReference<Uint64>() {}));
+        final Function function = new Function(FUNC_TTL,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node)),
+                Arrays.<TypeReference<?>>asList(new TypeReference<Uint64>() {
+                }));
         return executeRemoteCallSingleValueReturn(function, BigInteger.class);
     }
 
     public RemoteCall<TransactionReceipt> setResolver(byte[] node, String resolver) {
         final Function function = new Function(
-                FUNC_SETRESOLVER, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
-                new org.web3j.abi.datatypes.Address(resolver)), 
+                FUNC_SETRESOLVER,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node),
+                        new org.web3j.abi.datatypes.Address(resolver)),
                 Collections.<TypeReference<?>>emptyList());
         return executeRemoteCallTransaction(function);
     }
 
     public RemoteCall<TransactionReceipt> setOwner(byte[] node, String owner) {
         final Function function = new Function(
-                FUNC_SETOWNER, 
-                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node), 
-                new org.web3j.abi.datatypes.Address(owner)), 
+                FUNC_SETOWNER,
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Bytes32(node),
+                        new org.web3j.abi.datatypes.Address(owner)),
                 Collections.<TypeReference<?>>emptyList());
         return executeRemoteCallTransaction(function);
     }

--- a/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
@@ -58,7 +58,9 @@ public class ClientTransactionManager extends TransactionManager {
             String to,
             String data,
             BigInteger value,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException {
 
         Transaction transaction =

--- a/core/src/main/java/org/web3j/tx/ManagedTransaction.java
+++ b/core/src/main/java/org/web3j/tx/ManagedTransaction.java
@@ -26,8 +26,8 @@ import org.web3j.protocol.exceptions.TransactionException;
 public abstract class ManagedTransaction {
 
     /**
-     * @deprecated use ContractGasProvider
      * @see org.web3j.tx.gas.DefaultGasProvider
+     * @deprecated use ContractGasProvider
      */
     public static final BigInteger GAS_PRICE = BigInteger.valueOf(22_000_000_000L);
 
@@ -96,10 +96,17 @@ public abstract class ManagedTransaction {
     }
 
     protected TransactionReceipt send(
-            String to, String data, BigInteger value, BigInteger gasPrice, BigInteger gasLimit)
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException, TransactionException {
 
-        return transactionManager.executeTransaction(gasPrice, gasLimit, to, data, value);
+        return transactionManager.executeTransaction(
+                gasPrice, gasLimit, to, data, value, gasPremium, feeCap);
     }
 
     protected TransactionReceipt send(
@@ -108,11 +115,13 @@ public abstract class ManagedTransaction {
             BigInteger value,
             BigInteger gasPrice,
             BigInteger gasLimit,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException, TransactionException {
 
         return transactionManager.executeTransaction(
-                gasPrice, gasLimit, to, data, value, constructor);
+                gasPrice, gasLimit, to, data, value, constructor, gasPremium, feeCap);
     }
 
     protected String call(String to, String data, DefaultBlockParameter defaultBlockParameter)

--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -114,13 +114,17 @@ public class RawTransactionManager extends TransactionManager {
             String to,
             String data,
             BigInteger value,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException {
+        System.out.println("RAW = " + gasPremium.toString() + " " + feeCap.toString());
 
         BigInteger nonce = getNonce();
 
         RawTransaction rawTransaction =
-                RawTransaction.createTransaction(nonce, gasPrice, gasLimit, to, value, data);
+                RawTransaction.createTransaction(
+                        nonce, gasPrice, gasLimit, to, value, data, gasPremium, feeCap);
 
         return signAndSend(rawTransaction);
     }

--- a/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
@@ -40,7 +40,9 @@ public class ReadonlyTransactionManager extends TransactionManager {
             String to,
             String data,
             BigInteger value,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException {
         throw new UnsupportedOperationException(
                 "Only read operations are supported by this transaction manager");

--- a/core/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/TransactionManager.java
@@ -61,10 +61,15 @@ public abstract class TransactionManager {
     }
 
     protected TransactionReceipt executeTransaction(
-            BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
             throws IOException, TransactionException {
 
-        return executeTransaction(gasPrice, gasLimit, to, data, value, false);
+        return executeTransaction(gasPrice, gasLimit, to, data, value, constructor, null, null);
     }
 
     protected TransactionReceipt executeTransaction(
@@ -73,18 +78,40 @@ public abstract class TransactionManager {
             String to,
             String data,
             BigInteger value,
-            boolean constructor)
+            BigInteger gasPremium,
+            BigInteger feeCap)
+            throws IOException, TransactionException {
+
+        return executeTransaction(gasPrice, gasLimit, to, data, value, false, gasPremium, feeCap);
+    }
+
+    protected TransactionReceipt executeTransaction(
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException, TransactionException {
 
         EthSendTransaction ethSendTransaction =
-                sendTransaction(gasPrice, gasLimit, to, data, value, constructor);
+                sendTransaction(
+                        gasPrice, gasLimit, to, data, value, constructor, gasPremium, feeCap);
         return processResponse(ethSendTransaction);
     }
 
     public EthSendTransaction sendTransaction(
-            BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException {
-        return sendTransaction(gasPrice, gasLimit, to, data, value, false);
+        return sendTransaction(gasPrice, gasLimit, to, data, value, false, gasPremium, feeCap);
     }
 
     public abstract EthSendTransaction sendTransaction(
@@ -93,7 +120,9 @@ public abstract class TransactionManager {
             String to,
             String data,
             BigInteger value,
-            boolean constructor)
+            boolean constructor,
+            BigInteger gasPremium,
+            BigInteger feeCap)
             throws IOException;
 
     public abstract String sendCall(

--- a/core/src/test/java/org/web3j/tx/ReadonlyTransactionManagerTest.java
+++ b/core/src/test/java/org/web3j/tx/ReadonlyTransactionManagerTest.java
@@ -75,6 +75,12 @@ public class ReadonlyTransactionManagerTest {
                 UnsupportedOperationException.class,
                 () ->
                         readonlyTransactionManager.sendTransaction(
-                                BigInteger.ZERO, BigInteger.ZERO, "", "", BigInteger.ZERO));
+                                BigInteger.ZERO,
+                                BigInteger.ZERO,
+                                "",
+                                "",
+                                BigInteger.ZERO,
+                                null,
+                                null));
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -29,6 +29,8 @@ public class RawTransaction {
     private String to;
     private BigInteger value;
     private String data;
+    private BigInteger gasPremium;
+    private BigInteger feeCap;
 
     protected RawTransaction(
             BigInteger nonce,
@@ -37,12 +39,26 @@ public class RawTransaction {
             String to,
             BigInteger value,
             String data) {
+        this(nonce, gasPrice, gasLimit, to, value, data, null, null);
+    }
+
+    protected RawTransaction(
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
         this.nonce = nonce;
         this.gasPrice = gasPrice;
         this.gasLimit = gasLimit;
         this.to = to;
         this.value = value;
         this.data = data != null ? Numeric.cleanHexPrefix(data) : null;
+        this.gasPremium = gasPremium;
+        this.feeCap = feeCap;
     }
 
     public static RawTransaction createContractTransaction(
@@ -65,6 +81,16 @@ public class RawTransaction {
         return new RawTransaction(nonce, gasPrice, gasLimit, to, value, "");
     }
 
+    public static RawTransaction createEtherTransaction(
+            BigInteger nonce,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
+        return new RawTransaction(nonce, null, gasLimit, to, value, "", gasPremium, feeCap);
+    }
+
     public static RawTransaction createTransaction(
             BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit, String to, String data) {
         return createTransaction(nonce, gasPrice, gasLimit, to, BigInteger.ZERO, data);
@@ -79,6 +105,19 @@ public class RawTransaction {
             String data) {
 
         return new RawTransaction(nonce, gasPrice, gasLimit, to, value, data);
+    }
+
+    public static RawTransaction createTransaction(
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
+
+        return new RawTransaction(nonce, gasPrice, gasLimit, to, value, data, gasPremium, feeCap);
     }
 
     public BigInteger getNonce() {
@@ -103,5 +142,21 @@ public class RawTransaction {
 
     public String getData() {
         return data;
+    }
+
+    public BigInteger getGasPremium() {
+        return gasPremium;
+    }
+
+    public BigInteger getFeeCap() {
+        return feeCap;
+    }
+
+    public boolean isLegacyTransaction() {
+        return gasPrice != null && gasPremium == null && feeCap == null;
+    }
+
+    public boolean isEIP1559Transaction() {
+        return gasPrice == null && gasPremium != null && feeCap != null;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -124,6 +124,12 @@ public class TransactionEncoder {
         byte[] data = Numeric.hexStringToByteArray(rawTransaction.getData());
         result.add(RlpString.create(data));
 
+        // add gas premium and fee cap if this is an EIP-1559 transaction
+        if (rawTransaction.isEIP1559Transaction()) {
+            result.add(RlpString.create(rawTransaction.getGasPremium()));
+            result.add(RlpString.create(rawTransaction.getFeeCap()));
+        }
+
         if (signatureData != null) {
             result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getV())));
             result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getR())));

--- a/rlp/src/main/java/org/web3j/rlp/RlpString.java
+++ b/rlp/src/main/java/org/web3j/rlp/RlpString.java
@@ -52,7 +52,7 @@ public class RlpString implements RlpType {
 
     public static RlpString create(BigInteger value) {
         // RLP encoding only supports positive integer values
-        if (value.signum() < 1) {
+        if (value == null || value.signum() < 1) {
             return new RlpString(EMPTY);
         } else {
             byte[] bytes = value.toByteArray();


### PR DESCRIPTION
### What does this PR do?
This PR brings the changes required to be compliant with EIP-1559 specification. The specification can be found here: https://eips.ethereum.org/EIPS/eip-1559.

### Where should the reviewer start?

- added `gasPremium` and `feeCap` fields to `RawTransaction`
- updated methods to pass the new fields as parameters
- updated `RlpString.create` method that takes a `BigInteger`, it now accepts a null parameter since `gasPrice` can be null for post EIP-1559 transactions
- created `sendFundsEIP1559` method in `Transfer`

### Why is it needed?
It will help to move forward with this EIP. Web3j could then be used for the dedicated test network that will be created to validate this EIP.

### Examples

#### Using raw transaction

```java
RawTransaction rawTransaction = RawTransaction.createEtherTransaction(
                    // nonce
                    BigInteger.valueOf(0),
                    // gas limit
                    BigInteger.valueOf(30000),
                     // to
                    "0x627306090abaB3A6e1400e9345bC60c78a8BEf57",
                    // value
                    BigInteger.valueOf(123),
                    // gas premium
                    BigInteger.valueOf(5678),
                    // fee cap
                    BigInteger.valueOf(1100000)
            );

            byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
            String hexValue = Numeric.toHexString(signedMessage);
            EthSendTransaction ethSendTransaction = web3.ethSendRawTransaction(hexValue).send();
```
####  Using Transfer

```java
final TransactionReceipt transactionReceipt =
                    Transfer.sendFundsEIP1559(
                                    web3,
                                    credentials,
                                    "0x627306090abaB3A6e1400e9345bC60c78a8BEf57",
                                    BigDecimal.valueOf(123), //value
                                    Convert.Unit.WEI,
                                    BigInteger.valueOf(5678), // gas premium
                                    BigInteger.valueOf(1100000)) // fee cap
                            .send();
```

### Compatible Ethereum clients
#### Hyperledger Besu
https://github.com/hyperledger/besu
The EIP-1559 must be explicitly enabled:
```sh
besu --rpc-http-enabled --Xeip1559-enabled=true
```
#### Geth
https://github.com/ethereum/go-ethereum
The EIP-1559 is not available in master branch. To test it before this PR can be used: [20618](https://github.com/ethereum/go-ethereum/pull/20618)
```sh
geth --rpc
```

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>
