### PR TITLE
EIP 1559: Fee market change for ETH 1.0 chain

### DIFF
--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -167,6 +167,56 @@ public abstract class PrivateTransactionManager extends TransactionManager {
         return besu.eeaSendRawTransaction(rawSignedTransaction).send();
     }
 
+    public EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException {
+        final BigInteger nonce =
+                besu.privGetTransactionCount(credentials.getAddress(), getPrivacyGroupId())
+                        .send()
+                        .getTransactionCount();
+
+        final Object privacyGroupIdOrPrivateFor = privacyGroupIdOrPrivateFor();
+
+        final RawPrivateTransaction transaction;
+        if (privacyGroupIdOrPrivateFor instanceof Base64String) {
+            transaction =
+                    RawPrivateTransaction.createTransactionEIP1559(
+                            nonce,
+                            gasPremium,
+                            feeCap,
+                            gasLimit,
+                            to,
+                            data,
+                            privateFrom,
+                            (Base64String) privacyGroupIdOrPrivateFor,
+                            RESTRICTED);
+        } else {
+            transaction =
+                    RawPrivateTransaction.createTransactionEIP1559(
+                            nonce,
+                            gasPremium,
+                            feeCap,
+                            gasLimit,
+                            to,
+                            data,
+                            privateFrom,
+                            (List<Base64String>) privacyGroupIdOrPrivateFor,
+                            RESTRICTED);
+        }
+
+        final String rawSignedTransaction =
+                Numeric.toHexString(
+                        PrivateTransactionEncoder.signMessage(transaction, chainId, credentials));
+
+        return besu.eeaSendRawTransaction(rawSignedTransaction).send();
+    }
+
     @Override
     public String sendCall(
             final String to, final String data, final DefaultBlockParameter defaultBlockParameter)

--- a/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
@@ -39,6 +39,8 @@ public class Transaction {
     private BigInteger value;
     private String data;
     private BigInteger nonce; // nonce field is not present on eth_call/eth_estimateGas
+    private BigInteger gasPremium;
+    private BigInteger feeCap;
 
     public Transaction(
             String from,
@@ -48,6 +50,19 @@ public class Transaction {
             String to,
             BigInteger value,
             String data) {
+        this(from, nonce, gasPrice, gasLimit, to, value, data, null, null);
+    }
+
+    public Transaction(
+            String from,
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
         this.from = from;
         this.to = to;
         this.gas = gasLimit;
@@ -59,6 +74,8 @@ public class Transaction {
         }
 
         this.nonce = nonce;
+        this.gasPremium = gasPremium;
+        this.feeCap = feeCap;
     }
 
     public static Transaction createContractTransaction(

--- a/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ClientTransactionManager.java
@@ -68,6 +68,32 @@ public class ClientTransactionManager extends TransactionManager {
     }
 
     @Override
+    public EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException {
+
+        Transaction transaction =
+                new Transaction(
+                        getFromAddress(),
+                        null,
+                        null,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        gasPremium,
+                        feeCap);
+
+        return web3j.ethSendTransaction(transaction).send();
+    }
+
+    @Override
     public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
         EthCall ethCall =

--- a/core/src/main/java/org/web3j/tx/ManagedTransaction.java
+++ b/core/src/main/java/org/web3j/tx/ManagedTransaction.java
@@ -26,8 +26,8 @@ import org.web3j.protocol.exceptions.TransactionException;
 public abstract class ManagedTransaction {
 
     /**
-     * @deprecated use ContractGasProvider
      * @see org.web3j.tx.gas.DefaultGasProvider
+     * @deprecated use ContractGasProvider
      */
     public static final BigInteger GAS_PRICE = BigInteger.valueOf(22_000_000_000L);
 
@@ -100,6 +100,19 @@ public abstract class ManagedTransaction {
             throws IOException, TransactionException {
 
         return transactionManager.executeTransaction(gasPrice, gasLimit, to, data, value);
+    }
+
+    protected TransactionReceipt sendEIP1559(
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger gasLimit,
+            BigInteger gasPremium,
+            BigInteger feeCap)
+            throws IOException, TransactionException {
+
+        return transactionManager.executeTransactionEIP1559(
+                gasPremium, feeCap, gasLimit, to, data, value);
     }
 
     protected TransactionReceipt send(

--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -126,6 +126,26 @@ public class RawTransactionManager extends TransactionManager {
     }
 
     @Override
+    public EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException {
+
+        BigInteger nonce = getNonce();
+
+        RawTransaction rawTransaction =
+                RawTransaction.createTransaction(
+                        nonce, null, gasLimit, to, value, data, gasPremium, feeCap);
+
+        return signAndSend(rawTransaction);
+    }
+
+    @Override
     public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
         EthCall ethCall =

--- a/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/ReadonlyTransactionManager.java
@@ -47,6 +47,20 @@ public class ReadonlyTransactionManager extends TransactionManager {
     }
 
     @Override
+    public EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException {
+        throw new UnsupportedOperationException(
+                "Only read operations are supported by this transaction manager");
+    }
+
+    @Override
     public String sendCall(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
         EthCall ethCall =

--- a/core/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/TransactionManager.java
@@ -81,14 +81,62 @@ public abstract class TransactionManager {
         return processResponse(ethSendTransaction);
     }
 
+    protected TransactionReceipt executeTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value)
+            throws IOException, TransactionException {
+
+        return executeTransactionEIP1559(gasPremium, feeCap, gasLimit, to, data, value, false);
+    }
+
+    protected TransactionReceipt executeTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException, TransactionException {
+
+        EthSendTransaction ethSendTransaction =
+                sendTransactionEIP1559(gasPremium, feeCap, gasLimit, to, data, value, constructor);
+        return processResponse(ethSendTransaction);
+    }
+
     public EthSendTransaction sendTransaction(
             BigInteger gasPrice, BigInteger gasLimit, String to, String data, BigInteger value)
             throws IOException {
         return sendTransaction(gasPrice, gasLimit, to, data, value, false);
     }
 
+    public EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value)
+            throws IOException {
+        return sendTransactionEIP1559(gasPremium, feeCap, gasLimit, to, data, value, false);
+    }
+
     public abstract EthSendTransaction sendTransaction(
             BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            String data,
+            BigInteger value,
+            boolean constructor)
+            throws IOException;
+
+    public abstract EthSendTransaction sendTransactionEIP1559(
+            BigInteger gasPremium,
+            BigInteger feeCap,
             BigInteger gasLimit,
             String to,
             String data,

--- a/core/src/main/java/org/web3j/tx/Transfer.java
+++ b/core/src/main/java/org/web3j/tx/Transfer.java
@@ -156,6 +156,6 @@ public class Transfer extends ManagedTransaction {
 
         String resolvedAddress = ensResolver.resolve(toAddress);
         return sendEIP1559(
-                resolvedAddress, "", weiValue.toBigIntegerExact(), gasPremium, feeCap, gasLimit);
+                resolvedAddress, "", weiValue.toBigIntegerExact(), gasLimit, gasPremium, feeCap);
     }
 }

--- a/core/src/main/java/org/web3j/tx/Transfer.java
+++ b/core/src/main/java/org/web3j/tx/Transfer.java
@@ -115,4 +115,47 @@ public class Transfer extends ManagedTransaction {
             BigInteger gasLimit) {
         return new RemoteCall<>(() -> send(toAddress, value, unit, gasPrice, gasLimit));
     }
+
+    public static RemoteCall<TransactionReceipt> sendFundsEIP1559(
+            Web3j web3j,
+            Credentials credentials,
+            String toAddress,
+            BigDecimal value,
+            Convert.Unit unit,
+            BigInteger gasLimit,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
+        TransactionManager transactionManager = new RawTransactionManager(web3j, credentials);
+
+        return new RemoteCall<>(
+                () ->
+                        new Transfer(web3j, transactionManager)
+                                .sendEIP1559(toAddress, value, unit, gasLimit, gasPremium, feeCap));
+    }
+
+    private TransactionReceipt sendEIP1559(
+            String toAddress,
+            BigDecimal value,
+            Convert.Unit unit,
+            BigInteger gasLimit,
+            BigInteger gasPremium,
+            BigInteger feeCap)
+            throws IOException, InterruptedException, TransactionException {
+
+        BigDecimal weiValue = Convert.toWei(value, unit);
+        if (!Numeric.isIntegerValue(weiValue)) {
+            throw new UnsupportedOperationException(
+                    "Non decimal Wei value provided: "
+                            + value
+                            + " "
+                            + unit.toString()
+                            + " = "
+                            + weiValue
+                            + " Wei");
+        }
+
+        String resolvedAddress = ensResolver.resolve(toAddress);
+        return sendEIP1559(
+                resolvedAddress, "", weiValue.toBigIntegerExact(), gasPremium, feeCap, gasLimit);
+    }
 }

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -29,6 +29,8 @@ public class RawTransaction {
     private String to;
     private BigInteger value;
     private String data;
+    private BigInteger gasPremium;
+    private BigInteger feeCap;
 
     protected RawTransaction(
             BigInteger nonce,
@@ -37,12 +39,26 @@ public class RawTransaction {
             String to,
             BigInteger value,
             String data) {
+        this(nonce, gasPrice, gasLimit, to, value, data, null, null);
+    }
+
+    protected RawTransaction(
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
         this.nonce = nonce;
         this.gasPrice = gasPrice;
         this.gasLimit = gasLimit;
         this.to = to;
         this.value = value;
         this.data = data != null ? Numeric.cleanHexPrefix(data) : null;
+        this.gasPremium = gasPremium;
+        this.feeCap = feeCap;
     }
 
     public static RawTransaction createContractTransaction(
@@ -65,6 +81,16 @@ public class RawTransaction {
         return new RawTransaction(nonce, gasPrice, gasLimit, to, value, "");
     }
 
+    public static RawTransaction createEtherTransaction(
+            BigInteger nonce,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
+        return new RawTransaction(nonce, null, gasLimit, to, value, "", gasPremium, feeCap);
+    }
+
     public static RawTransaction createTransaction(
             BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit, String to, String data) {
         return createTransaction(nonce, gasPrice, gasLimit, to, BigInteger.ZERO, data);
@@ -79,6 +105,19 @@ public class RawTransaction {
             String data) {
 
         return new RawTransaction(nonce, gasPrice, gasLimit, to, value, data);
+    }
+
+    public static RawTransaction createTransaction(
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger gasPremium,
+            BigInteger feeCap) {
+
+        return new RawTransaction(nonce, gasPrice, gasLimit, to, value, data, gasPremium, feeCap);
     }
 
     public BigInteger getNonce() {
@@ -103,5 +142,21 @@ public class RawTransaction {
 
     public String getData() {
         return data;
+    }
+
+    public BigInteger getGasPremium() {
+        return gasPremium;
+    }
+
+    public BigInteger getFeeCap() {
+        return feeCap;
+    }
+
+    public boolean isLegacyTransaction() {
+        return gasPrice != null && gasPremium == null && feeCap == null;
+    }
+
+    public boolean isEIP1559Transaction() {
+        return gasPrice == null && gasPremium != null && feeCap != null;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -124,6 +124,12 @@ public class TransactionEncoder {
         byte[] data = Numeric.hexStringToByteArray(rawTransaction.getData());
         result.add(RlpString.create(data));
 
+        // add gas premium and fee cap if this is an EIP-1559 transaction
+        if (rawTransaction.isEIP1559Transaction()) {
+            result.add(RlpString.create(rawTransaction.getGasPremium()));
+            result.add(RlpString.create(rawTransaction.getFeeCap()));
+        }
+
         if (signatureData != null) {
             result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getV())));
             result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getR())));

--- a/crypto/src/test/java/org/web3j/crypto/TransactionEncoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionEncoderTest.java
@@ -83,6 +83,19 @@ public class TransactionEncoderTest {
                                 + "5c9f3dc64214b297fb1966a3b6d83")));
     }
 
+    @Test
+    public void testEip1559Transaction() {
+        // https://github.com/ethereum/EIPs/issues/1559
+        Credentials credentials =
+                Credentials.create(
+                        "0x4646464646464646464646464646464646464646464646464646464646464646");
+        assertArrayEquals(
+                TransactionEncoder.signMessage(
+                        createEip1559RawTransaction(), (byte) 1, credentials),
+                (Numeric.hexStringToByteArray(
+                        "0xf866808082753094627306090abab3a6e1400e9345bc60c78a8bef577b8082162e8310c8e026a05b362f1b948135039788c28613e8009c4d38346ece108ebc2f856902d2133243a07f42ab9c3d50e2f6cce3360cba206c7a4065bac0cfca015611af8be7189730fe")));
+    }
+
     private static RawTransaction createEtherTransaction() {
         return RawTransaction.createEtherTransaction(
                 BigInteger.ZERO,
@@ -108,5 +121,15 @@ public class TransactionEncoderTest {
                 BigInteger.valueOf(21000),
                 "0x3535353535353535353535353535353535353535",
                 BigInteger.valueOf(1000000000000000000L));
+    }
+
+    private static RawTransaction createEip1559RawTransaction() {
+        return RawTransaction.createEtherTransaction(
+                BigInteger.valueOf(0),
+                BigInteger.valueOf(30000),
+                "0x627306090abaB3A6e1400e9345bC60c78a8BEf57",
+                BigInteger.valueOf(123),
+                BigInteger.valueOf(5678),
+                BigInteger.valueOf(1100000));
     }
 }

--- a/eea/src/main/java/org/web3j/protocol/eea/crypto/RawPrivateTransaction.java
+++ b/eea/src/main/java/org/web3j/protocol/eea/crypto/RawPrivateTransaction.java
@@ -50,6 +50,24 @@ public class RawPrivateTransaction extends RawTransaction {
     }
 
     protected RawPrivateTransaction(
+            final BigInteger nonce,
+            final BigInteger gasPremium,
+            final BigInteger feeCap,
+            final BigInteger gasLimit,
+            final String to,
+            final String data,
+            final Base64String privateFrom,
+            final List<Base64String> privateFor,
+            final Base64String privacyGroupId,
+            final Restriction restriction) {
+        super(nonce, null, gasLimit, to, BigInteger.ZERO, data, gasPremium, feeCap);
+        this.privateFrom = privateFrom;
+        this.privateFor = privateFor;
+        this.privacyGroupId = privacyGroupId;
+        this.restriction = restriction;
+    }
+
+    protected RawPrivateTransaction(
             final RawTransaction rawTransaction,
             final Base64String privateFrom,
             final Base64String privacyGroupId,
@@ -131,6 +149,30 @@ public class RawPrivateTransaction extends RawTransaction {
                 nonce, gasPrice, gasLimit, to, data, privateFrom, privateFor, null, restriction);
     }
 
+    public static RawPrivateTransaction createTransactionEIP1559(
+            final BigInteger nonce,
+            final BigInteger gasPremium,
+            final BigInteger feeCap,
+            final BigInteger gasLimit,
+            final String to,
+            final String data,
+            final Base64String privateFrom,
+            final List<Base64String> privateFor,
+            final Restriction restriction) {
+
+        return new RawPrivateTransaction(
+                nonce,
+                gasPremium,
+                feeCap,
+                gasLimit,
+                to,
+                data,
+                privateFrom,
+                privateFor,
+                null,
+                restriction);
+    }
+
     public static RawPrivateTransaction createTransaction(
             final BigInteger nonce,
             final BigInteger gasPrice,
@@ -144,6 +186,30 @@ public class RawPrivateTransaction extends RawTransaction {
         return new RawPrivateTransaction(
                 nonce,
                 gasPrice,
+                gasLimit,
+                to,
+                data,
+                privateFrom,
+                null,
+                privacyGroupId,
+                restriction);
+    }
+
+    public static RawPrivateTransaction createTransactionEIP1559(
+            final BigInteger nonce,
+            final BigInteger gasPremium,
+            final BigInteger feeCap,
+            final BigInteger gasLimit,
+            final String to,
+            final String data,
+            final Base64String privateFrom,
+            final Base64String privacyGroupId,
+            final Restriction restriction) {
+
+        return new RawPrivateTransaction(
+                nonce,
+                gasPremium,
+                feeCap,
                 gasLimit,
                 to,
                 data,

--- a/rlp/src/main/java/org/web3j/rlp/RlpString.java
+++ b/rlp/src/main/java/org/web3j/rlp/RlpString.java
@@ -52,7 +52,7 @@ public class RlpString implements RlpType {
 
     public static RlpString create(BigInteger value) {
         // RLP encoding only supports positive integer values
-        if (value.signum() < 1) {
+        if (value == null || value.signum() < 1) {
             return new RlpString(EMPTY);
         } else {
             byte[] bytes = value.toByteArray();


### PR DESCRIPTION
### What does this PR do?
This PR brings the changes required to be compliant with EIP-1559 specification. The specification can be found here: https://eips.ethereum.org/EIPS/eip-1559.

### Where should the reviewer start?

- added `gasPremium` and `feeCap` fields to `RawTransaction`
- updated methods to pass the new fields as parameters
- updated `RlpString.create` method that takes a `BigInteger`, it now accepts a null parameter since `gasPrice` can be null for post EIP-1559 transactions
- created `sendFundsEIP1559` method in `Transfer`

### Why is it needed?
It will help to move forward with this EIP. Web3j could then be used for the dedicated test network that will be created to validate this EIP.

### Examples

#### Using raw transaction

```java
RawTransaction rawTransaction = RawTransaction.createEtherTransaction(
                    // nonce
                    BigInteger.valueOf(0),
                    // gas limit
                    BigInteger.valueOf(30000),
                     // to
                    "0x627306090abaB3A6e1400e9345bC60c78a8BEf57",
                    // value
                    BigInteger.valueOf(123),
                    // gas premium
                    BigInteger.valueOf(5678),
                    // fee cap
                    BigInteger.valueOf(1100000)
            );

            byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
            String hexValue = Numeric.toHexString(signedMessage);
            EthSendTransaction ethSendTransaction = web3.ethSendRawTransaction(hexValue).send();
```
####  Using Transfer

```java
final TransactionReceipt transactionReceipt =
                    Transfer.sendFundsEIP1559(
                                    web3,
                                    credentials,
                                    "0x627306090abaB3A6e1400e9345bC60c78a8BEf57",
                                    BigDecimal.valueOf(123), //value
                                    Convert.Unit.WEI,
                                    BigInteger.valueOf(5678), // gas premium
                                    BigInteger.valueOf(1100000)) // fee cap
                            .send();
```

### Compatible Ethereum clients
#### Hyperledger Besu
https://github.com/hyperledger/besu
The EIP-1559 must be explicitly enabled:
```sh
besu --rpc-http-enabled --Xeip1559-enabled=true
```
#### Geth
https://github.com/ethereum/go-ethereum
The EIP-1559 is not available in master branch. To test it before this PR can be used: [20618](https://github.com/ethereum/go-ethereum/pull/20618)
```sh
geth --rpc
```

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>
