### PR TITLE
Added Besu privacy getLogs and filters methods

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -29,9 +29,12 @@ import org.web3j.protocol.besu.response.privacy.PrivGetTransactionReceipt;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthAccounts;
+import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.core.methods.response.EthLog;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.EthUninstallFilter;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.eea.Eea;
 import org.web3j.protocol.exceptions.TransactionException;
@@ -113,4 +116,16 @@ public interface Besu extends Eea {
             String privacyGroupId,
             org.web3j.protocol.core.methods.request.Transaction transaction,
             DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, EthLog> privGetLogs(
+            String privacyGroupId, org.web3j.protocol.core.methods.request.EthFilter ethFilter);
+
+    Request<?, EthFilter> privNewFilter(
+            String privacyGroupId, org.web3j.protocol.core.methods.request.EthFilter ethFilter);
+
+    Request<?, EthUninstallFilter> privUninstallFilter(String privacyGroupId, String filterId);
+
+    Request<?, EthLog> privGetFilterChanges(String privacyGroupId, String filterId);
+
+    Request<?, EthLog> privGetFilterLogs(String privacyGroupId, String filterId);
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -41,7 +41,9 @@ import org.web3j.protocol.core.methods.response.EthAccounts;
 import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.core.methods.response.EthLog;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.EthUninstallFilter;
 import org.web3j.protocol.core.methods.response.MinerStartResponse;
 import org.web3j.protocol.eea.JsonRpc2_0Eea;
 import org.web3j.protocol.exceptions.TransactionException;
@@ -344,5 +346,54 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 Arrays.asList(privacyGroupId, transaction, defaultBlockParameter),
                 web3jService,
                 org.web3j.protocol.core.methods.response.EthCall.class);
+    }
+
+    @Override
+    public Request<?, EthLog> privGetLogs(
+            final String privacyGroupId,
+            final org.web3j.protocol.core.methods.request.EthFilter ethFilter) {
+        return new Request<>(
+                "priv_getLogs",
+                Arrays.asList(privacyGroupId, ethFilter),
+                web3jService,
+                EthLog.class);
+    }
+
+    @Override
+    public Request<?, org.web3j.protocol.core.methods.response.EthFilter> privNewFilter(
+            String privacyGroupId, org.web3j.protocol.core.methods.request.EthFilter ethFilter) {
+        return new Request<>(
+                "priv_newFilter",
+                Arrays.asList(privacyGroupId, ethFilter),
+                web3jService,
+                org.web3j.protocol.core.methods.response.EthFilter.class);
+    }
+
+    @Override
+    public Request<?, EthUninstallFilter> privUninstallFilter(
+            String privacyGroupId, String filterId) {
+        return new Request<>(
+                "priv_uninstallFilter",
+                Arrays.asList(privacyGroupId, filterId),
+                web3jService,
+                EthUninstallFilter.class);
+    }
+
+    @Override
+    public Request<?, EthLog> privGetFilterChanges(String privacyGroupId, String filterId) {
+        return new Request<>(
+                "priv_getFilterChanges",
+                Arrays.asList(privacyGroupId, filterId),
+                web3jService,
+                EthLog.class);
+    }
+
+    @Override
+    public Request<?, EthLog> privGetFilterLogs(String privacyGroupId, String filterId) {
+        return new Request<>(
+                "priv_getFilterLogs",
+                Arrays.asList(privacyGroupId, filterId),
+                web3jService,
+                EthLog.class);
     }
 }

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import org.web3j.protocol.RequestTester;
 import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Base64String;
 
 public class RequestTest extends RequestTester {
+
     private static final Base64String MOCK_ENCLAVE_KEY =
             Base64String.wrap("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=");
     private static final Base64String MOCK_ENCLAVE_KEY_2 =
@@ -214,7 +216,7 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
-    public void testEthCall() throws Exception {
+    public void testPrivCall() throws Exception {
         web3j.privCall(
                         MOCK_PRIVACY_GROUP_ID.toString(),
                         Transaction.createEthCallTransaction(
@@ -229,5 +231,65 @@ public class RequestTest extends RequestTester {
                         + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\",{\"from\":\"0xa70e8dd61c5d32be8058bb8eb970870f07233155\","
                         + "\"to\":\"0xb60e8dd61c5d32be8058bb8eb970870f07233155\",\"data\":\"0x0\"},"
                         + "\"latest\"],\"id\":1}");
+    }
+
+    @Test
+    public void testPrivGetLogs() throws Exception {
+        web3j.privGetLogs(
+                        MOCK_PRIVACY_GROUP_ID.toString(),
+                        new EthFilter()
+                                .addSingleTopic(
+                                        "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b"))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getLogs\","
+                        + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\""
+                        + ",{\"topics\":[\"0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b\"]}],"
+                        + "\"id\":1}");
+    }
+
+    @Test
+    public void testPrivNewFilter() throws Exception {
+        EthFilter ethFilter = new EthFilter().addSingleTopic("0x12341234");
+
+        web3j.privNewFilter(MOCK_PRIVACY_GROUP_ID.toString(), ethFilter).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_newFilter\","
+                        + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\",{\"topics\":[\"0x12341234\"]}],\"id\":1}");
+    }
+
+    @Test
+    public void testPrivUninstallFilter() throws Exception {
+        web3j.privUninstallFilter(
+                        MOCK_PRIVACY_GROUP_ID.toString(), "0x13e9b67497fa859338ecba166752591b")
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_uninstallFilter\","
+                        + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\",\"0x13e9b67497fa859338ecba166752591b\"],\"id\":1}");
+    }
+
+    @Test
+    public void testPrivGetFilterChanges() throws Exception {
+        web3j.privGetFilterChanges(
+                        MOCK_PRIVACY_GROUP_ID.toString(), "0x13e9b67497fa859338ecba166752591b")
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getFilterChanges\","
+                        + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\",\"0x13e9b67497fa859338ecba166752591b\"],\"id\":1}");
+    }
+
+    @Test
+    public void testPrivGetFilterLogs() throws Exception {
+        web3j.privGetFilterLogs(
+                        MOCK_PRIVACY_GROUP_ID.toString(), "0x13e9b67497fa859338ecba166752591b")
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"priv_getFilterLogs\","
+                        + "\"params\":[\"DyAOiF/ynpc+JXa2YAGB0bCitSlOMNm+ShmB/7M6C4w=\",\"0x13e9b67497fa859338ecba166752591b\"],\"id\":1}");
     }
 }


### PR DESCRIPTION
### What does this PR do?
Added support for private logs/filters methods in Besu.
• priv_getLogs
• priv_newFilter
• priv_uninstallFilter
• priv_getFilterLogs
• priv_getFilterChanges

All of these methods work in the exact same way as their "eth" equivalent. The biggest difference is that they all have the privacyGroupId as request parameter index 0.

### Where should the reviewer start?
• Start by checking the that the method names are correct (using the prefix `priv` instead of `eth`)
• The order of the parameters is important. Parameter 0 for all requests is the `privacyGroupId`.

### Why is it needed?
To support people using web3j + Besu to consume logs.

