### PR TITLE
Align type of constructor parameter chainId with RawTransactionManager

### DIFF
--- a/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
@@ -27,7 +27,7 @@ public class FastRawTransactionManager extends RawTransactionManager {
 
     private volatile BigInteger nonce = BigInteger.valueOf(-1);
 
-    public FastRawTransactionManager(Web3j web3j, Credentials credentials, byte chainId) {
+    public FastRawTransactionManager(Web3j web3j, Credentials credentials, long chainId) {
         super(web3j, credentials, chainId);
     }
 
@@ -45,7 +45,7 @@ public class FastRawTransactionManager extends RawTransactionManager {
     public FastRawTransactionManager(
             Web3j web3j,
             Credentials credentials,
-            byte chainId,
+            long chainId,
             TransactionReceiptProcessor transactionReceiptProcessor) {
         super(web3j, credentials, chainId, transactionReceiptProcessor);
     }


### PR DESCRIPTION
### What does this PR do?
Align the type of FastRawTransactionManager constructor parameter chainId with RawTransactionManager

### Where should the reviewer start?
See RawTransactionManger constructor

### Why is it needed?
So can pass chainId > 127 to the constructor

