### PR TITLE
Upgrade to jackson 2.8.11.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 ext {
     bouncycastleVersion = '1.65'
-    jacksonVersion = '2.8.5'
+    jacksonVersion = '2.8.11.6'
     javaPoetVersion = '1.7.0'
     kotlinPoetVersion = '1.5.0'
     jnr_unixsocketVersion = '0.21'


### PR DESCRIPTION
### What does this PR do?
Upgrades the Jackson dependencies to 2.8.11.6. This is the latest 2.8.x version available.

### Where should the reviewer start?
With the one line that was changed. :)

### Why is it needed?
The current version 2.8.5 contains a deserialisation of untrusted data vulnerability (https://github.com/FasterXML/jackson-databind/issues/2186).
