### PR TITLE
Add IBFT 2.0 API methods to Besu Protocol

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -22,6 +22,7 @@ import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
 import org.web3j.protocol.besu.response.BesuFullDebugTraceResponse;
+import org.web3j.protocol.besu.response.BesuSignerMetrics;
 import org.web3j.protocol.besu.response.privacy.PrivCreatePrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivFindPrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivGetPrivacyPrecompileAddress;
@@ -85,6 +86,19 @@ public interface Besu extends Eea, BesuRx {
 
     Request<?, BesuFullDebugTraceResponse> debugTraceTransaction(
             String transactionHash, Map<String, Boolean> options);
+
+    Request<?, BooleanResponse> ibftDiscardValidatorVote(String address);
+
+    Request<?, BesuEthAccountsMapResponse> ibftGetPendingVotes();
+
+    Request<?, BesuSignerMetrics> ibftGetSignerMetrics();
+
+    Request<?, EthAccounts> ibftGetValidatorsByBlockNumber(
+            DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, EthAccounts> ibftGetValidatorsByBlockHash(String blockHash);
+
+    Request<?, BooleanResponse> ibftProposeValidatorVote(String address, Boolean validatorAddition);
 
     Request<?, EthGetTransactionCount> privGetTransactionCount(
             final String address, final Base64String privacyGroupId);

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -31,6 +31,7 @@ import org.web3j.protocol.besu.privacy.OnChainPrivacyTransactionBuilder;
 import org.web3j.protocol.besu.request.CreatePrivacyGroupRequest;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
 import org.web3j.protocol.besu.response.BesuFullDebugTraceResponse;
+import org.web3j.protocol.besu.response.BesuSignerMetrics;
 import org.web3j.protocol.besu.response.privacy.PrivCreatePrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivFindPrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivGetPrivacyPrecompileAddress;
@@ -141,6 +142,56 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 Arrays.asList(transactionHash, options),
                 web3jService,
                 BesuFullDebugTraceResponse.class);
+    }
+
+    public Request<?, BooleanResponse> ibftDiscardValidatorVote(String address) {
+        return new Request<>(
+                "ibft_discardValidatorVote",
+                Arrays.asList(address),
+                web3jService,
+                BooleanResponse.class);
+    }
+
+    public Request<?, BesuEthAccountsMapResponse> ibftGetPendingVotes() {
+        return new Request<>(
+                "ibft_getPendingVotes",
+                Collections.<String>emptyList(),
+                web3jService,
+                BesuEthAccountsMapResponse.class);
+    }
+
+    public Request<?, BesuSignerMetrics> ibftGetSignerMetrics() {
+        return new Request<>(
+                "ibft_getSignerMetrics",
+                Collections.<String>emptyList(),
+                web3jService,
+                BesuSignerMetrics.class);
+    }
+
+    public Request<?, EthAccounts> ibftGetValidatorsByBlockNumber(
+            DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "ibft_getValidatorsByBlockNumber",
+                Arrays.asList(defaultBlockParameter.getValue()),
+                web3jService,
+                EthAccounts.class);
+    }
+
+    public Request<?, EthAccounts> ibftGetValidatorsByBlockHash(String blockHash) {
+        return new Request<>(
+                "ibft_getValidatorsByBlockHash",
+                Arrays.asList(blockHash),
+                web3jService,
+                EthAccounts.class);
+    }
+
+    public Request<?, BooleanResponse> ibftProposeValidatorVote(
+            String address, Boolean validatorAddition) {
+        return new Request<>(
+                "ibft_proposeValidatorVote",
+                Arrays.asList(address, validatorAddition),
+                web3jService,
+                BooleanResponse.class);
     }
 
     @Override

--- a/besu/src/main/java/org/web3j/protocol/besu/response/BesuSignerMetric.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/BesuSignerMetric.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.web3j.utils.Numeric;
+
+public class BesuSignerMetric {
+
+    private final String address;
+    private final String proposedBlockCount;
+    private final String lastProposedBlockNumber;
+
+    @JsonCreator
+    public BesuSignerMetric(
+            @JsonProperty(value = "address") final String address,
+            @JsonProperty(value = "proposedBlockCount") final String proposedBlockCount,
+            @JsonProperty(value = "name") final String lastProposedBlockNumber) {
+        this.address = address;
+        this.proposedBlockCount = proposedBlockCount;
+        this.lastProposedBlockNumber = lastProposedBlockNumber;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public BigInteger getProposedBlockCount() {
+        return Numeric.decodeQuantity(proposedBlockCount);
+    }
+
+    public BigInteger getLastProposedBlockNumber() {
+        return Numeric.decodeQuantity(lastProposedBlockNumber);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BesuSignerMetric that = (BesuSignerMetric) o;
+        return getAddress().equals(that.getAddress())
+                && Objects.equals(getProposedBlockCount(), that.getProposedBlockCount())
+                && Objects.equals(getLastProposedBlockNumber(), that.getLastProposedBlockNumber());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAddress(), getProposedBlockCount(), getLastProposedBlockNumber());
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/BesuSignerMetrics.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/BesuSignerMetrics.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response;
+
+import java.util.List;
+
+import org.web3j.protocol.core.Response;
+
+public class BesuSignerMetrics extends Response<List<BesuSignerMetric>> {
+    public List<BesuSignerMetric> getSignerMetrics() {
+        return getResult();
+    }
+}

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -132,6 +132,57 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
+    public void testibftDiscardValidatorVote() throws Exception {
+        final String accountId = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
+        web3j.ibftDiscardValidatorVote(accountId).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_discardValidatorVote\","
+                        + "\"params\":[\"0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73\"],\"id\":1}");
+    }
+
+    @Test
+    public void testIbftGetPendingVotes() throws Exception {
+        web3j.ibftGetPendingVotes().send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_getPendingVotes\","
+                        + "\"params\":[],\"id\":1}");
+    }
+
+    @Test
+    public void testIbftGetValidatorsByBlockNumber() throws Exception {
+        final DefaultBlockParameter blockParameter = DefaultBlockParameter.valueOf("latest");
+        web3j.ibftGetValidatorsByBlockNumber(blockParameter).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_getValidatorsByBlockNumber\","
+                        + "\"params\":[\"latest\"],\"id\":1}");
+    }
+
+    @Test
+    public void testIbftGetValidatorsByBlockHash() throws Exception {
+        final String blockHash =
+                "0x98b2ddb5106b03649d2d337d42154702796438b3c74fd25a5782940e84237a48";
+        web3j.ibftGetValidatorsByBlockHash(blockHash).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_getValidatorsByBlockHash\",\"params\":"
+                        + "[\"0x98b2ddb5106b03649d2d337d42154702796438b3c74fd25a5782940e84237a48\"]"
+                        + ",\"id\":1}");
+    }
+
+    @Test
+    public void testIbftProposeValidatorVote() throws Exception {
+        final String validatorAddress = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
+        web3j.ibftProposeValidatorVote(validatorAddress, true).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_proposeValidatorVote\","
+                        + "\"params\":[\"0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73\",true],\"id\":1}");
+    }
+
+    @Test
     public void testPrivGetTransactionCount() throws Exception {
         web3j.privGetTransactionCount(
                         "0x407d73d8a49eeb85d32cf465507dd71d507100c1", MOCK_PRIVACY_GROUP_ID)

--- a/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
@@ -12,6 +12,7 @@
  */
 package org.web3j.protocol.besu;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.web3j.protocol.ResponseTester;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
+import org.web3j.protocol.besu.response.BesuSignerMetrics;
 import org.web3j.protocol.besu.response.privacy.PrivCreatePrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivFindPrivacyGroup;
 import org.web3j.protocol.besu.response.privacy.PrivGetPrivacyPrecompileAddress;
@@ -72,6 +74,32 @@ public class ResponseTest extends ResponseTester {
                 mapResponse.getAccounts().toString(),
                 ("{0x42eb768f2244c8811c63729a21a3569731535f07=false, "
                         + "0x12eb759f2222d7711c63729a45c3585731521d01=true}"));
+    }
+
+    @Test
+    public void testIbftGetValidatorMetrics() {
+        buildResponse(
+                "{\n"
+                        + "    \"jsonrpc\": \"2.0\",\n"
+                        + "    \"id\": 1,\n"
+                        + "    \"result\": [\n"
+                        + "{\"address\": \"0x42eb768f2244c8811c63729a21a3569731535f07\",\n"
+                        + "\"proposedBlockCount\": \"0x0\",\n"
+                        + "\"lastProposedBlockNumber\": \"0x1\"}\n"
+                        + "]\n"
+                        + "}");
+
+        BesuSignerMetrics signerMetrics = deserialiseResponse(BesuSignerMetrics.class);
+        assertEquals(
+                signerMetrics.getSignerMetrics().get(0).getAddress(),
+                "0x42eb768f2244c8811c63729a21a3569731535f07");
+
+        assertEquals(
+                signerMetrics.getSignerMetrics().get(0).getProposedBlockCount(), BigInteger.ZERO);
+
+        assertEquals(
+                signerMetrics.getSignerMetrics().get(0).getLastProposedBlockNumber(),
+                BigInteger.ONE);
     }
 
     @Test


### PR DESCRIPTION
https://besu.hyperledger.org/en/stable/Reference/API-Methods/#ibft-20-methods

ibft_discardValidatorVote
ibft_getPendingVotes
ibft_getValidatorsByBlockHash
ibft_getValidatorsByBlockNumber
ibft_proposeValidatorVote
ibft_getSignerMetrics

New class BesuSignerMetrics to handle response from ibft_getSignerMetrics, list of BesuSignerMetric

BesuSignerMetrics can be used for both clique and ibft 2.0 methods that return signer metrics

https://besu.hyperledger.org/en/stable/Reference/API-Methods/#ibft_getsignermetrics

https://besu.hyperledger.org/en/stable/Reference/API-Methods/#clique_getsignermetrics

Added some basic tests for correct requests and response handling for BesuSignerMetrics.

Other methods reuse existing response types....

### What does this PR do?
Add IBFT 2.0 API methods to the Besu Protocol 

### Where should the reviewer start?
https://besu.hyperledger.org/en/stable/Reference/API-Methods/#ibft-20-methods

org.web3j.protocol.besu.JsonRpc2_0Besu

### Why is it needed?
To enable a node operator to manage the validator set when using IBFT 2.0 and to get stats on the current validator set.

