### PR TITLE
PrivateTransactionManager

### DIFF
--- a/besu/src/main/java/org/web3j/tx/BesuPrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/BesuPrivateTransactionManager.java
@@ -42,15 +42,8 @@ public class BesuPrivateTransactionManager extends PrivateTransactionManager {
             final long chainId,
             final Base64String privateFrom,
             final Base64String privacyGroupId) {
-        this(
-                besu,
-                gasProvider,
-                credentials,
-                chainId,
-                privateFrom,
-                privacyGroupId,
-                DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH,
-                15 * 1000);
+        super(besu, gasProvider, credentials, chainId, privateFrom);
+        this.privacyGroupId = privacyGroupId;
     }
 
     @Override

--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -80,7 +80,7 @@ public abstract class PrivateTransactionManager extends TransactionManager {
                 credentials,
                 chainId,
                 privateFrom,
-                new PollingPrivateTransactionReceiptProcessor(besu, attempts, sleepDuration));
+                new PollingPrivateTransactionReceiptProcessor(besu, sleepDuration, attempts));
     }
 
     protected PrivateTransactionManager(


### PR DESCRIPTION
Fixed order of parameters to polling receipt transaction processor when passing custom values to the constructor.

BesuPrivateTransactionManager

Removed unnecessary passing of default polling attempts and frequency in the constructor. Sleep Duration was a magic number and not the symbolic constant used elsewhere.

### What does this PR do?
Fixes #1225 

### Where should the reviewer start?
PrivateTransactionManager

### Why is it needed?
Without fix private transaction manager with custom options will cause a request 'storm' on the connected node.

