### PR TITLE
split binary string literal longer than 65534 as it is not supported by java complier

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -307,9 +307,18 @@ public class SolidityFunctionWrapper extends Generator {
     }
 
     private FieldSpec createBinaryDefinition(String binary) {
+        // split binary string literal longer than 65534 as it is not support by java compiler
+        int stringLiteralLimit = 65534;
+        String[] binaryArgs = binary.split("(?<=\\G.{" + stringLiteralLimit + "})");
+        StringBuilder binaryString = new StringBuilder();
+        binaryString.append("new StringBuilder()");
+        for (String s : binaryArgs) {
+            binaryString.append(".append($S)");
+        }
+        binaryString.append(".toString()");
         return FieldSpec.builder(String.class, BINARY)
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC)
-                .initializer("$S", binary)
+                .initializer(binaryString.toString(), binaryArgs)
                 .build();
     }
 


### PR DESCRIPTION

### What does this PR do?
This PR enhances `SolidityFunctionWrapper.createBinaryDefinition` method. It splits the `BINARY` string by length 65534 into an array and initialises BINARY string with `StringBuilder` that is made up of this array.

### Where should the reviewer start?
function `SolidityFunctionWrapper.createBinaryDefinition` 

### Why is it needed?
The `BINARY` variable(from java) generated by web3j's codegen does not handle when the `BINARY`'s length is more than 65534. This result's in java program generated not able to compile due to the limitation in java ( does not support string literal size more than 65534). It solves issue #499 

