### PR TITLE
Fix for usage of Uint and Int ABI types in EIP712

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -296,8 +296,7 @@ public class StructuredDataEncoder {
                 byte[] hashedValue = sha3(concatenatedArrayEncodings);
                 encTypes.add("bytes32");
                 encValues.add(hashedValue);
-            } else if (field.getType().startsWith("uint")
-                    || field.getType().startsWith("int")) {
+            } else if (field.getType().startsWith("uint") || field.getType().startsWith("int")) {
                 encTypes.add(field.getType());
                 // convert to BigInteger for ABI constructor compatibility
                 try {
@@ -307,7 +306,8 @@ public class StructuredDataEncoder {
                         encValues.add(new BigInteger(value.toString()));
                     }
                 } catch (NumberFormatException | NullPointerException e) {
-                        encValues.add(value); // value null or failed to convert, fallback to string type
+                    encValues.add(
+                            value); // value null or failed to convert, fallback to string type
                 }
             } else {
                 encTypes.add(field.getType());

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -209,6 +209,23 @@ public class StructuredDataTest {
     }
 
     @Test
+    public void testValidStructureWithValues() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredDataWithValues.json"));
+
+        assertEquals(
+                "0x19015620b3369de388efb28ffd5eeed325817be77135afdd083edcfe7eea4a329e77c064d1cdb9ecfc1653de095a49c59ada5d6979933fbc5d93566944089ac64a61",
+                Numeric.toHexString(dataEncoder.getStructuredData()));
+
+        assertEquals(
+                "0x9a321bee2df12b3b43bc4caf71d19839f05d82264b780b48f1f529bf916b5d30",
+                Numeric.toHexString(dataEncoder.hashStructuredData()));
+    }
+
+    @Test
     public void testGetArrayDimensionsFromData() throws RuntimeException, IOException {
         StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
         // [[1, 2, 3], [4, 5, 6]]

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithValues.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithValues.json
@@ -1,0 +1,95 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "RelayRequest": [
+            {
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "name": "encodedFunction",
+                "type": "bytes"
+            },
+            {
+                "name": "gasData",
+                "type": "GasData"
+            },
+            {
+                "name": "relayData",
+                "type": "RelayData"
+            }
+        ],
+        "GasData": [
+            {
+                "name": "gasLimit",
+                "type": "uint256"
+            },
+            {
+                "name": "gasPrice",
+                "type": "uint256"
+            },
+            {
+                "name": "pctRelayFee",
+                "type": "uint256"
+            },
+            {
+                "name": "baseRelayFee",
+                "type": "uint256"
+            }
+        ],
+        "RelayData": [
+            {
+                "name": "senderAddress",
+                "type": "address"
+            },
+            {
+                "name": "senderNonce",
+                "type": "uint256"
+            },
+            {
+                "name": "relayWorker",
+                "type": "address"
+            },
+            {
+                "name": "paymaster",
+                "type": "address"
+            }
+        ]
+    },
+    "domain": {
+        "name": "Test Relayed Transaction",
+        "version": "1",
+        "chainId": 42,
+        "verifyingContract": "0x1234567890aBcDeF1234567890aBcDeF12345678"
+    },
+    "primaryType": "RelayRequest",
+    "message": {
+        "target": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+        "encodedFunction": "0xa9059cbb0000000000000000000000002e0d94754b348d208d64d52d78bcd443afa9fa520000000000000000000000000000000000000000000000000000000000000007",
+        "gasData": {
+            "gasLimit": "39507",
+            "gasPrice": "1700000000",
+            "pctRelayFee": "70",
+            "baseRelayFee": "0"
+        },
+        "relayData": {
+            "senderAddress": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+            "senderNonce": "3",
+            "relayWorker": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+            "paymaster": "0x1234567890aBcDeF1234567890aBcDeF12345678"
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Fixes usage of Int and Uint types in EIP712 Structured data

### Where should the reviewer start?
See the added test, ValidStructuredDataWithValues.json. The test includes a structure ```GasData``` which consists of uint256 types. The constructors for the Uint and Int ABI types only accept ```long``` and ```BigInteger```, however the values are encoded as ```String```, which means the constructor encoder at line 329 fails as there's no matching constructor. 

### Why is it needed?
Valid EIP712 structures fail to be encoded, for example this construct:

```
        "GasData": [
            {
                "name": "gasLimit",
                "type": "uint256"
            }
        ],
```
```
"message": {
        ...
        "gasData": {
            "gasLimit": "39507"
        },
```
due to incompatible constructor params. An alternative fix would be to add a ```String``` constructor to the Int and Uint ABI types which attempts to convert a submitted ```String``` into a BigInteger, however the submitted fix is more local and doesn't affect code elsewhere.

