### PR TITLE
Add additional admin rpc calls

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -15,6 +15,7 @@ package org.web3j.protocol.core;
 import java.math.BigInteger;
 
 import org.web3j.protocol.core.methods.request.ShhFilter;
+import org.web3j.protocol.core.methods.response.BooleanResponse;
 import org.web3j.protocol.core.methods.response.DbGetHex;
 import org.web3j.protocol.core.methods.response.DbGetString;
 import org.web3j.protocol.core.methods.response.DbPutHex;
@@ -64,6 +65,7 @@ import org.web3j.protocol.core.methods.response.ShhUninstallFilter;
 import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
+import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
 
@@ -82,6 +84,10 @@ public interface Ethereum {
     Request<?, AdminNodeInfo> adminNodeInfo();
 
     Request<?, AdminPeers> adminPeers();
+    
+    Request<?, BooleanResponse> adminAddPeer(String url);
+    
+    Request<?, BooleanResponse> adminRemovePeer(String url);
 
     Request<?, EthProtocolVersion> ethProtocolVersion();
 
@@ -215,4 +221,6 @@ public interface Ethereum {
     Request<?, ShhMessages> shhGetFilterChanges(BigInteger filterId);
 
     Request<?, ShhMessages> shhGetMessages(BigInteger filterId);
+    
+    Request<?, TxPoolStatus> txPoolStatus();
 }

--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -63,9 +63,9 @@ import org.web3j.protocol.core.methods.response.ShhNewGroup;
 import org.web3j.protocol.core.methods.response.ShhNewIdentity;
 import org.web3j.protocol.core.methods.response.ShhUninstallFilter;
 import org.web3j.protocol.core.methods.response.ShhVersion;
+import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
-import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
@@ -85,11 +85,11 @@ public interface Ethereum {
     Request<?, AdminNodeInfo> adminNodeInfo();
 
     Request<?, AdminPeers> adminPeers();
-    
+
     Request<?, BooleanResponse> adminAddPeer(String url);
-    
+
     Request<?, BooleanResponse> adminRemovePeer(String url);
-    
+
     Request<?, AdminDataDir> adminDataDir();
 
     Request<?, EthProtocolVersion> ethProtocolVersion();
@@ -224,6 +224,6 @@ public interface Ethereum {
     Request<?, ShhMessages> shhGetFilterChanges(BigInteger filterId);
 
     Request<?, ShhMessages> shhGetMessages(BigInteger filterId);
-    
+
     Request<?, TxPoolStatus> txPoolStatus();
 }

--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -66,6 +66,7 @@ import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.TxPoolStatus;
+import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
 
@@ -88,6 +89,8 @@ public interface Ethereum {
     Request<?, BooleanResponse> adminAddPeer(String url);
     
     Request<?, BooleanResponse> adminRemovePeer(String url);
+    
+    Request<?, AdminDataDir> adminDataDir();
 
     Request<?, EthProtocolVersion> ethProtocolVersion();
 

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -28,6 +28,7 @@ import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.request.ShhPost;
 import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.BooleanResponse;
 import org.web3j.protocol.core.methods.response.DbGetHex;
 import org.web3j.protocol.core.methods.response.DbGetString;
 import org.web3j.protocol.core.methods.response.DbPutHex;
@@ -79,6 +80,7 @@ import org.web3j.protocol.core.methods.response.ShhUninstallFilter;
 import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
+import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
 import org.web3j.protocol.rx.JsonRpc2_0Rx;
@@ -153,6 +155,18 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, AdminPeers> adminPeers() {
         return new Request<>(
                 "admin_peers", Collections.emptyList(), web3jService, AdminPeers.class);
+    }
+    
+    @Override
+    public Request<?, BooleanResponse> adminAddPeer(String url) {
+        return new Request<>(
+                "admin_addPeer", Arrays.asList(url), web3jService, BooleanResponse.class);
+    }
+    
+    @Override
+    public Request<?, BooleanResponse> adminRemovePeer(String url) {
+        return new Request<>(
+                "admin_removePeer", Arrays.asList(url), web3jService, BooleanResponse.class);
     }
 
     @Override
@@ -650,6 +664,12 @@ public class JsonRpc2_0Web3j implements Web3j {
                 Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
                 web3jService,
                 ShhMessages.class);
+    }
+    
+    @Override
+    public Request<?, TxPoolStatus> txPoolStatus() {
+        return new Request<>(
+                "txpool_status", Collections.<String>emptyList(), web3jService, TxPoolStatus.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -78,9 +78,9 @@ import org.web3j.protocol.core.methods.response.ShhNewGroup;
 import org.web3j.protocol.core.methods.response.ShhNewIdentity;
 import org.web3j.protocol.core.methods.response.ShhUninstallFilter;
 import org.web3j.protocol.core.methods.response.ShhVersion;
+import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
-import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
@@ -157,19 +157,19 @@ public class JsonRpc2_0Web3j implements Web3j {
         return new Request<>(
                 "admin_peers", Collections.emptyList(), web3jService, AdminPeers.class);
     }
-    
+
     @Override
     public Request<?, BooleanResponse> adminAddPeer(String url) {
         return new Request<>(
                 "admin_addPeer", Arrays.asList(url), web3jService, BooleanResponse.class);
     }
-    
+
     @Override
     public Request<?, BooleanResponse> adminRemovePeer(String url) {
         return new Request<>(
                 "admin_removePeer", Arrays.asList(url), web3jService, BooleanResponse.class);
     }
-    
+
     @Override
     public Request<?, AdminDataDir> adminDataDir() {
         return new Request<>(
@@ -672,7 +672,7 @@ public class JsonRpc2_0Web3j implements Web3j {
                 web3jService,
                 ShhMessages.class);
     }
-    
+
     @Override
     public Request<?, TxPoolStatus> txPoolStatus() {
         return new Request<>(

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -81,6 +81,7 @@ import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.TxPoolStatus;
+import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
 import org.web3j.protocol.rx.JsonRpc2_0Rx;
@@ -167,6 +168,12 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, BooleanResponse> adminRemovePeer(String url) {
         return new Request<>(
                 "admin_removePeer", Arrays.asList(url), web3jService, BooleanResponse.class);
+    }
+    
+    @Override
+    public Request<?, AdminDataDir> adminDataDir() {
+        return new Request<>(
+                "admin_datadir", Collections.emptyList(), web3jService, AdminDataDir.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/BooleanResponse.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/BooleanResponse.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+/** Boolean response type. */
+public class BooleanResponse extends Response<Boolean> {
+    public boolean success() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolStatus.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolStatus.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+import org.web3j.utils.Numeric;
+import java.util.Map;
+
+/** txpool_status. */
+public class TxPoolStatus extends Response<Map<String, String>> {
+    public Integer getPending() {  	
+    	return Numeric.decodeQuantity((String) getResult().get("pending")).intValue();
+    }
+    
+    public Integer getQueued() {  	
+    	return Numeric.decodeQuantity((String) getResult().get("queued")).intValue();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolStatus.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/TxPoolStatus.java
@@ -12,18 +12,18 @@
  */
 package org.web3j.protocol.core.methods.response;
 
-import org.web3j.protocol.core.Response;
-
-import org.web3j.utils.Numeric;
 import java.util.Map;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
 
 /** txpool_status. */
 public class TxPoolStatus extends Response<Map<String, String>> {
-    public Integer getPending() {  	
-    	return Numeric.decodeQuantity((String) getResult().get("pending")).intValue();
+    public Integer getPending() {
+        return Numeric.decodeQuantity((String) getResult().get("pending")).intValue();
     }
-    
-    public Integer getQueued() {  	
-    	return Numeric.decodeQuantity((String) getResult().get("queued")).intValue();
+
+    public Integer getQueued() {
+        return Numeric.decodeQuantity((String) getResult().get("queued")).intValue();
     }
 }

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminDataDir.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminDataDir.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response.admin;
+
+import org.web3j.protocol.core.Response;
+
+/** String response type. */
+public class AdminDataDir extends Response<String> {
+    public String getDataDir() {
+        return getResult();
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
@@ -49,9 +49,13 @@ public class AdminNodeInfo extends Response<AdminNodeInfo.NodeInfo> {
         private void consensusDeserializer(Map<String, Object> protocols) {
             if(protocols.containsKey("istanbul")) {
                 consensus = "istanbul";
-            } else {
+            } else if (protocols.containsKey("clique")) {
+            	consensus = "clique";
+            } else if (protocols.containsKey("eth")) {
                 Map<String, Object> eth = (Map<String, Object>) protocols.get("eth");
                 consensus = (String) eth.get("consensus");
+            } else {
+            	consensus = "unknown";
             }
         }
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
@@ -16,9 +16,9 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.annotation.JsonProperty; 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -43,19 +43,19 @@ public class AdminNodeInfo extends Response<AdminNodeInfo.NodeInfo> {
         private String listenAddr;
         private String name;
         private String consensus;
-        
+
         @JsonProperty("protocols")
         @SuppressWarnings("unchecked")
         private void consensusDeserializer(Map<String, Object> protocols) {
-            if(protocols.containsKey("istanbul")) {
+            if (protocols.containsKey("istanbul")) {
                 consensus = "istanbul";
             } else if (protocols.containsKey("clique")) {
-            	consensus = "clique";
+                consensus = "clique";
             } else if (protocols.containsKey("eth")) {
                 Map<String, Object> eth = (Map<String, Object>) protocols.get("eth");
                 consensus = (String) eth.get("consensus");
             } else {
-            	consensus = "unknown";
+                consensus = "unknown";
             }
         }
 
@@ -95,7 +95,7 @@ public class AdminNodeInfo extends Response<AdminNodeInfo.NodeInfo> {
         public String getName() {
             return name;
         }
-        
+
         public String getConsensus() {
             return consensus;
         }

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminNodeInfo.java
@@ -13,10 +13,12 @@
 package org.web3j.protocol.core.methods.response.admin;
 
 import java.io.IOException;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.annotation.JsonProperty; 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -40,15 +42,34 @@ public class AdminNodeInfo extends Response<AdminNodeInfo.NodeInfo> {
         private String ip;
         private String listenAddr;
         private String name;
+        private String consensus;
+        
+        @JsonProperty("protocols")
+        @SuppressWarnings("unchecked")
+        private void consensusDeserializer(Map<String, Object> protocols) {
+            if(protocols.containsKey("istanbul")) {
+                consensus = "istanbul";
+            } else {
+                Map<String, Object> eth = (Map<String, Object>) protocols.get("eth");
+                consensus = (String) eth.get("consensus");
+            }
+        }
 
         public NodeInfo() {}
 
-        public NodeInfo(String enode, String id, String ip, String listenAddr, String name) {
+        public NodeInfo(
+                String enode,
+                String id,
+                String ip,
+                String listenAddr,
+                String name,
+                String consensus) {
             this.enode = enode;
             this.id = id;
             this.ip = ip;
             this.listenAddr = listenAddr;
             this.name = name;
+            this.consensus = consensus;
         }
 
         public String getEnode() {
@@ -69,6 +90,10 @@ public class AdminNodeInfo extends Response<AdminNodeInfo.NodeInfo> {
 
         public String getName() {
             return name;
+        }
+        
+        public String getConsensus() {
+            return consensus;
         }
     }
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminPeers.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/admin/AdminPeers.java
@@ -39,10 +39,11 @@ public class AdminPeers extends Response<List<AdminPeers.Peer>> {
     public static class Peer {
         public Peer() {}
 
-        public Peer(String id, String name, PeerNetwork network) {
+        public Peer(String id, String name, String enode, PeerNetwork network) {
             this.id = id;
             this.name = name;
             this.network = network;
+            this.enode = enode;
         }
 
         public String getId() {
@@ -53,9 +54,14 @@ public class AdminPeers extends Response<List<AdminPeers.Peer>> {
             return name;
         }
 
+        public String getEnode() {
+            return enode;
+        }
+
         private String id;
         private String name;
         private PeerNetwork network;
+        private String enode;
 
         public PeerNetwork getNetwork() {
             return network;

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -79,26 +79,28 @@ public class RequestTest extends RequestTester {
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_nodeInfo\",\"params\":[],\"id\":1}");
     }
-    
+
     @Test
     public void testAdminAddPeer() throws Exception {
         web3j.adminAddPeer("url").send();
 
-        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_addPeer\",\"params\":[\"url\"],\"id\":1}");
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"admin_addPeer\",\"params\":[\"url\"],\"id\":1}");
     }
-    
+
     @Test
     public void testAdminDataDir() throws Exception {
         web3j.adminDataDir().send();
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_datadir\",\"params\":[],\"id\":1}");
     }
-    
+
     @Test
     public void testAdminRemovePeer() throws Exception {
         web3j.adminRemovePeer("url").send();
 
-        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_removePeer\",\"params\":[\"url\"],\"id\":1}");
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"admin_removePeer\",\"params\":[\"url\"],\"id\":1}");
     }
 
     @Test
@@ -737,7 +739,7 @@ public class RequestTest extends RequestTester {
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shh_getMessages\","
                         + "\"params\":[\"0x07\"],\"id\":1}");
     }
-    
+
     @Test
     public void testTxPoolStatus() throws Exception {
         web3j.txPoolStatus().send();

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -79,6 +79,20 @@ public class RequestTest extends RequestTester {
 
         verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_nodeInfo\",\"params\":[],\"id\":1}");
     }
+    
+    @Test
+    public void testAdminAddPeer() throws Exception {
+        web3j.adminAddPeer("url").send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_addPeer\",\"params\":[\"url\"],\"id\":1}");
+    }
+    
+    @Test
+    public void testAdminRemovePeer() throws Exception {
+        web3j.adminRemovePeer("url").send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_removePeer\",\"params\":[\"url\"],\"id\":1}");
+    }
 
     @Test
     public void testEthProtocolVersion() throws Exception {
@@ -715,5 +729,12 @@ public class RequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shh_getMessages\","
                         + "\"params\":[\"0x07\"],\"id\":1}");
+    }
+    
+    @Test
+    public void testTxPoolStatus() throws Exception {
+        web3j.txPoolStatus().send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"txpool_status\",\"params\":[],\"id\":1}");
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -88,6 +88,13 @@ public class RequestTest extends RequestTester {
     }
     
     @Test
+    public void testAdminDataDir() throws Exception {
+        web3j.adminDataDir().send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"admin_datadir\",\"params\":[],\"id\":1}");
+    }
+    
+    @Test
     public void testAdminRemovePeer() throws Exception {
         web3j.adminRemovePeer("url").send();
 

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -81,6 +81,7 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
+import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1582,6 +1583,19 @@ public class ResponseTest extends ResponseTester {
 
         BooleanResponse booleanResponse = deserialiseResponse(BooleanResponse.class);
         assertTrue(booleanResponse.success());
+    }
+    
+    @Test
+    public void testAdminDataDir() {
+        buildResponse(
+                "{\n"
+                        + "    \"jsonrpc\":\"2.0\",\n"
+                        + "    \"id\":22,\n"
+                        + "    \"result\":\"sampleDir\"\n"
+                        + "}");
+
+        AdminDataDir dataDir = deserialiseResponse(AdminDataDir.class);
+        assertEquals(dataDir.getDataDir(), "sampleDir");
     }
     
     @Test

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import org.web3j.protocol.ResponseTester;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
+import org.web3j.protocol.core.methods.response.BooleanResponse;
 import org.web3j.protocol.core.methods.response.DbGetHex;
 import org.web3j.protocol.core.methods.response.DbGetString;
 import org.web3j.protocol.core.methods.response.DbPutHex;
@@ -77,6 +78,7 @@ import org.web3j.protocol.core.methods.response.ShhUninstallFilter;
 import org.web3j.protocol.core.methods.response.ShhVersion;
 import org.web3j.protocol.core.methods.response.Transaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.core.methods.response.TxPoolStatus;
 import org.web3j.protocol.core.methods.response.Web3ClientVersion;
 import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
@@ -217,6 +219,7 @@ public class ResponseTest extends ResponseTester {
                         + "                \"network\": 4,\n"
                         + "                \"difficulty\": 1,\n"
                         + "                \"genesis\": \"0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177\",\n"
+                        + "				   \"consensus\": \"clique\",\n"
                         + "                \"config\": {\n"
                         + "                    \"chainId\": 4,\n"
                         + "                    \"homesteadBlock\": 1,\n"
@@ -1566,5 +1569,33 @@ public class ResponseTest extends ResponseTester {
 
         ShhMessages shhMessages = deserialiseResponse(ShhMessages.class);
         assertEquals(shhMessages.getMessages(), (messages));
+    }
+    
+    @Test
+    public void testBooleanResponse() {
+        buildResponse(
+                "{\n"
+                        + "    \"jsonrpc\":\"2.0\",\n"
+                        + "    \"id\":22,\n"
+                        + "    \"result\":true\n"
+                        + "}");
+
+        BooleanResponse booleanResponse = deserialiseResponse(BooleanResponse.class);
+        assertTrue(booleanResponse.success());
+    }
+    
+    @Test
+    public void testTxPoolStatus() {
+        buildResponse(
+                "{\n"
+                        + "    \"jsonrpc\":\"2.0\",\n"
+                        + "    \"id\":22,\n"
+                        + "    \"result\":{ \"pending\": \"10\",\n"
+                        + "			\"queued\": \"7\"}\n"
+                        + "}");
+
+        TxPoolStatus status = deserialiseResponse(TxPoolStatus.class);
+        assertEquals(status.getPending(), 10);
+        assertEquals(status.getQueued(), 7);
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -1571,7 +1571,7 @@ public class ResponseTest extends ResponseTester {
         ShhMessages shhMessages = deserialiseResponse(ShhMessages.class);
         assertEquals(shhMessages.getMessages(), (messages));
     }
-    
+
     @Test
     public void testBooleanResponse() {
         buildResponse(
@@ -1584,7 +1584,7 @@ public class ResponseTest extends ResponseTester {
         BooleanResponse booleanResponse = deserialiseResponse(BooleanResponse.class);
         assertTrue(booleanResponse.success());
     }
-    
+
     @Test
     public void testAdminDataDir() {
         buildResponse(
@@ -1597,7 +1597,7 @@ public class ResponseTest extends ResponseTester {
         AdminDataDir dataDir = deserialiseResponse(AdminDataDir.class);
         assertEquals(dataDir.getDataDir(), "sampleDir");
     }
-    
+
     @Test
     public void testTxPoolStatus() {
         buildResponse(


### PR DESCRIPTION
### What does this PR do?
-adds additional admin apis (addPeer, removePeer, dataDir)
-adds additional txpool api
-adds consensus field to AdminNodeInfo
-adds enode field to AdminPeers

### Where should the reviewer start?
test the new added apis and updated Response objects

### Why is it needed?
-expands the functionality of current web3j
-enhancement needed to provide missing web3j functionality

