### PR TITLE
Fix #919. Gen consistent privateKey with other eth libs

### DIFF
--- a/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
@@ -70,8 +70,8 @@ public class Bip44WalletUtils extends WalletUtils {
             final int[] path = {44 | HARDENED_BIT, 0 | HARDENED_BIT, 0 | HARDENED_BIT, 0};
             return Bip32ECKeyPair.deriveKeyPair(master, path);
         } else {
-            // m/44'/60'/0'/0
-            final int[] path = {44 | HARDENED_BIT, 60 | HARDENED_BIT, 0 | HARDENED_BIT, 0};
+            // m/44'/60'/0'/0/0
+            final int[] path = {44 | HARDENED_BIT, 60 | HARDENED_BIT, 0 | HARDENED_BIT, 0, 0};
             return Bip32ECKeyPair.deriveKeyPair(master, path);
         }
     }

--- a/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
+++ b/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
@@ -66,8 +66,7 @@ public class Bip44WalletUtilsTest {
                 "xpub6GoSByP58zBY8xUdR7brvCk31yhx7pPxfdnSB5VuvrB2NGqBS9eqf4pVo1xev4GEmip5Wuky9KUtJVxq4fvYfFchS6SA6C4cCRyQkLqNNjq",
                 Base58.encode(addChecksum(serializePublic(bip44Keypair))));
 
-        // Verify address according to https://iancoleman.io/bip39/
-        Credentials credentials = Bip44WalletUtils.loadBip44Credentials("", mnemonic);
+        Credentials credentials = Bip44WalletUtils.loadBip44Credentials("", mnemonic); // Verify address according to https://iancoleman.io/bip39/
         assertEquals("0xece62451ca8fba33746d6dafd0d0ebdef84778b7", credentials.getAddress().toLowerCase());
     }
 

--- a/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
+++ b/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
@@ -60,11 +60,15 @@ public class Bip44WalletUtilsTest {
         Bip32ECKeyPair bip44Keypair = Bip44WalletUtils.generateBip44KeyPair(masterKeypair);
 
         assertEquals(
-                "xprv9zvpunws9gusoXVkmqAXWQm5z5hjR5kY3ifRGL7M8Kpjn8kRhavkGnFLjnFWPGGS2gAUw8rP33Lmj6SwZUpwy2mn2fXRYWzGa9WRTnE8DPz",
+                "xprvA3p5nTrBJcdEvUQAK64rZ4oJTwsTiMg7JQrqNh6JNWe3VUW2tcLb7GW1wj1fNDAoymUTSFERZ2LxPxJNmqoMZPs9y3TMNMuBN8MS9eigoWq",
                 Base58.encode(addChecksum(serializePrivate(bip44Keypair))));
         assertEquals(
-                "xpub6DvBKJUkz4UB21aDsrhXsYhpY7YDpYUPQwb24iWxgfMiew5aF8EzpaZpb567bYYbMfUnPwFNuRYvVpMGQUcaGPMoXUEUZKFvx7LaU5b7zBD",
+                "xpub6GoSByP58zBY8xUdR7brvCk31yhx7pPxfdnSB5VuvrB2NGqBS9eqf4pVo1xev4GEmip5Wuky9KUtJVxq4fvYfFchS6SA6C4cCRyQkLqNNjq",
                 Base58.encode(addChecksum(serializePublic(bip44Keypair))));
+
+        // Verify address according to https://iancoleman.io/bip39/
+        Credentials credentials = Bip44WalletUtils.loadBip44Credentials("", mnemonic);
+        assertEquals("0xece62451ca8fba33746d6dafd0d0ebdef84778b7", credentials.getAddress().toLowerCase());
     }
 
     @Test

--- a/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
+++ b/core/src/test/java/org/web3j/crypto/Bip44WalletUtilsTest.java
@@ -66,8 +66,12 @@ public class Bip44WalletUtilsTest {
                 "xpub6GoSByP58zBY8xUdR7brvCk31yhx7pPxfdnSB5VuvrB2NGqBS9eqf4pVo1xev4GEmip5Wuky9KUtJVxq4fvYfFchS6SA6C4cCRyQkLqNNjq",
                 Base58.encode(addChecksum(serializePublic(bip44Keypair))));
 
-        Credentials credentials = Bip44WalletUtils.loadBip44Credentials("", mnemonic); // Verify address according to https://iancoleman.io/bip39/
-        assertEquals("0xece62451ca8fba33746d6dafd0d0ebdef84778b7", credentials.getAddress().toLowerCase());
+        Credentials credentials =
+                Bip44WalletUtils.loadBip44Credentials(
+                        "", mnemonic); // Verify address according to https://iancoleman.io/bip39/
+        assertEquals(
+                "0xece62451ca8fba33746d6dafd0d0ebdef84778b7",
+                credentials.getAddress().toLowerCase());
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Fix #919 to generate consistent eth private keys with other eth libs by mnemonics.

### Where should the reviewer start?
Please see the changes in the commit, and the comments of @razzbee in #919 .

### Why is it needed?
Inconsistency makes imcompatibilities.
