### PR TITLE
add salt to EIP712 domain

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredData.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredData.java
@@ -48,17 +48,20 @@ public class StructuredData {
         private final String version;
         private final Uint256 chainId;
         private final Address verifyingContract;
+        private final String salt;
 
         @JsonCreator
         public EIP712Domain(
                 @JsonProperty(value = "name") String name,
                 @JsonProperty(value = "version") String version,
                 @JsonProperty(value = "chainId") Uint256 chainId,
-                @JsonProperty(value = "verifyingContract") Address verifyingContract) {
+                @JsonProperty(value = "verifyingContract") Address verifyingContract,
+                @JsonProperty(value = "salt") String salt) {
             this.name = name;
             this.version = version;
             this.chainId = chainId;
             this.verifyingContract = verifyingContract;
+            this.salt = salt;
         }
 
         public String getName() {
@@ -75,6 +78,10 @@ public class StructuredData {
 
         public Address getVerifyingContract() {
             return verifyingContract;
+        }
+
+        public String getSalt() {
+            return salt;
         }
     }
 
@@ -115,13 +122,13 @@ public class StructuredData {
         @Override
         public String toString() {
             return "EIP712Message{"
-                    + "primaryType='"
-                    + this.primaryType
-                    + '\''
-                    + ", message='"
-                    + this.message
-                    + '\''
-                    + '}';
+                   + "primaryType='"
+                   + this.primaryType
+                   + '\''
+                   + ", message='"
+                   + this.message
+                   + '\''
+                   + '}';
         }
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/StructuredData.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredData.java
@@ -122,13 +122,13 @@ public class StructuredData {
         @Override
         public String toString() {
             return "EIP712Message{"
-                   + "primaryType='"
-                   + this.primaryType
-                   + '\''
-                   + ", message='"
-                   + this.message
-                   + '\''
-                   + '}';
+                    + "primaryType='"
+                    + this.primaryType
+                    + '\''
+                    + ", message='"
+                    + this.message
+                    + '\''
+                    + '}';
         }
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -362,6 +362,10 @@ public class StructuredDataEncoder {
         data.put(
                 "verifyingContract",
                 ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));
+
+        if (data.get("salt") == null) {
+            data.remove("salt");
+        }
         return sha3(encodeData("EIP712Domain", data));
     }
 

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -51,7 +51,7 @@ public class StructuredDataTest {
     public void testInvalidIdentifierMessageCaughtByRegex() throws RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/InvalidIdentifierStructuredData.json";
+                        + "structured_data_json_files/InvalidIdentifierStructuredData.json";
         assertThrows(
                 RuntimeException.class,
                 () -> new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath)));
@@ -61,7 +61,7 @@ public class StructuredDataTest {
     public void testInvalidTypeMessageCaughtByRegex() throws RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/InvalidTypeStructuredData.json";
+                        + "structured_data_json_files/InvalidTypeStructuredData.json";
         assertThrows(
                 RuntimeException.class,
                 () -> new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath)));
@@ -85,7 +85,7 @@ public class StructuredDataTest {
         StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
         String expectedTypeEncoding =
                 "Mail(Person from,Person to,string contents)"
-                + "Person(string name,address wallet)";
+                        + "Person(string name,address wallet)";
 
         assertEquals(
                 dataEncoder.encodeType(dataEncoder.jsonMessageObject.getPrimaryType()),
@@ -114,10 +114,10 @@ public class StructuredDataTest {
                         (HashMap<String, Object>) dataEncoder.jsonMessageObject.getMessage());
         String expectedDataEncodingHex =
                 "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bd"
-                + "c2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6"
-                + "604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8"
-                + "ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae57027"
-                + "01d05cd2305f7c52a2fc8";
+                        + "c2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6"
+                        + "604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8"
+                        + "ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae57027"
+                        + "01d05cd2305f7c52a2fc8";
 
         assertEquals(Numeric.toHexString(encodedData), expectedDataEncodingHex);
     }
@@ -162,7 +162,7 @@ public class StructuredDataTest {
                 new StructuredDataEncoder(
                         getResource(
                                 "build/resources/test/"
-                                + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
+                                        + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
         dataEncoder.hashStructuredData();
     }
 
@@ -172,7 +172,7 @@ public class StructuredDataTest {
                 new StructuredDataEncoder(
                         getResource(
                                 "build/resources/test/"
-                                + "structured_data_json_files/0xProtocolControlSample.json"));
+                                        + "structured_data_json_files/0xProtocolControlSample.json"));
         assertEquals(
                 "0xccb29124860915763e8cd9257da1260abc7df668fde282272587d84b594f37f6",
                 Numeric.toHexString(dataEncoder.hashStructuredData()));
@@ -182,7 +182,7 @@ public class StructuredDataTest {
     public void testInvalidMessageValueTypeMismatch() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
+                        + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(ClassCastException.class, dataEncoder::hashStructuredData);
@@ -192,7 +192,7 @@ public class StructuredDataTest {
     public void testInvalidMessageInvalidABIType() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/InvalidMessageInvalidABIType.json";
+                        + "structured_data_json_files/InvalidMessageInvalidABIType.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(UnsupportedOperationException.class, dataEncoder::hashStructuredData);
@@ -202,7 +202,7 @@ public class StructuredDataTest {
     public void testInvalidMessageValidABITypeInvalidValue() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
+                        + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
@@ -376,8 +376,8 @@ public class StructuredDataTest {
     public void testUnequalArrayLengthsBetweenSchemaAndData() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/"
-                + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
+                        + "structured_data_json_files/"
+                        + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
@@ -388,8 +388,8 @@ public class StructuredDataTest {
             throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/"
-                + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
+                        + "structured_data_json_files/"
+                        + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
@@ -399,9 +399,10 @@ public class StructuredDataTest {
     public void testHashDomainWithSalt() throws RuntimeException, IOException {
         String validStructuredDataWithSaltJSONFilePath =
                 "build/resources/test/"
-                + "structured_data_json_files/"
-                + "ValidStructuredDataWithSalt.json";
-        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(getResource(validStructuredDataWithSaltJSONFilePath));
+                        + "structured_data_json_files/"
+                        + "ValidStructuredDataWithSalt.json";
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(getResource(validStructuredDataWithSaltJSONFilePath));
         byte[] structHashDomain = dataEncoder.hashDomain();
         String expectedDomainStructHash =
                 "0xbae4f6f7b9bfdfda060692099b0e1ccecd25d62b7c92cc9f3b907f33178b81e3";

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -51,7 +51,7 @@ public class StructuredDataTest {
     public void testInvalidIdentifierMessageCaughtByRegex() throws RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/InvalidIdentifierStructuredData.json";
+                + "structured_data_json_files/InvalidIdentifierStructuredData.json";
         assertThrows(
                 RuntimeException.class,
                 () -> new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath)));
@@ -61,7 +61,7 @@ public class StructuredDataTest {
     public void testInvalidTypeMessageCaughtByRegex() throws RuntimeException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/InvalidTypeStructuredData.json";
+                + "structured_data_json_files/InvalidTypeStructuredData.json";
         assertThrows(
                 RuntimeException.class,
                 () -> new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath)));
@@ -85,7 +85,7 @@ public class StructuredDataTest {
         StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
         String expectedTypeEncoding =
                 "Mail(Person from,Person to,string contents)"
-                        + "Person(string name,address wallet)";
+                + "Person(string name,address wallet)";
 
         assertEquals(
                 dataEncoder.encodeType(dataEncoder.jsonMessageObject.getPrimaryType()),
@@ -114,10 +114,10 @@ public class StructuredDataTest {
                         (HashMap<String, Object>) dataEncoder.jsonMessageObject.getMessage());
         String expectedDataEncodingHex =
                 "0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bd"
-                        + "c2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6"
-                        + "604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8"
-                        + "ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae57027"
-                        + "01d05cd2305f7c52a2fc8";
+                + "c2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6"
+                + "604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8"
+                + "ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae57027"
+                + "01d05cd2305f7c52a2fc8";
 
         assertEquals(Numeric.toHexString(encodedData), expectedDataEncodingHex);
     }
@@ -162,7 +162,7 @@ public class StructuredDataTest {
                 new StructuredDataEncoder(
                         getResource(
                                 "build/resources/test/"
-                                        + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
+                                + "structured_data_json_files/ValidStructuredDataWithBytesTypes.json"));
         dataEncoder.hashStructuredData();
     }
 
@@ -172,7 +172,7 @@ public class StructuredDataTest {
                 new StructuredDataEncoder(
                         getResource(
                                 "build/resources/test/"
-                                        + "structured_data_json_files/0xProtocolControlSample.json"));
+                                + "structured_data_json_files/0xProtocolControlSample.json"));
         assertEquals(
                 "0xccb29124860915763e8cd9257da1260abc7df668fde282272587d84b594f37f6",
                 Numeric.toHexString(dataEncoder.hashStructuredData()));
@@ -182,7 +182,7 @@ public class StructuredDataTest {
     public void testInvalidMessageValueTypeMismatch() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
+                + "structured_data_json_files/InvalidMessageValueTypeMismatch.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(ClassCastException.class, dataEncoder::hashStructuredData);
@@ -192,7 +192,7 @@ public class StructuredDataTest {
     public void testInvalidMessageInvalidABIType() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/InvalidMessageInvalidABIType.json";
+                + "structured_data_json_files/InvalidMessageInvalidABIType.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(UnsupportedOperationException.class, dataEncoder::hashStructuredData);
@@ -202,7 +202,7 @@ public class StructuredDataTest {
     public void testInvalidMessageValidABITypeInvalidValue() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
+                + "structured_data_json_files/InvalidMessageValidABITypeInvalidValue.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
@@ -376,8 +376,8 @@ public class StructuredDataTest {
     public void testUnequalArrayLengthsBetweenSchemaAndData() throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/"
-                        + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
+                + "structured_data_json_files/"
+                + "InvalidMessageUnequalArrayLengthsBetweenSchemaAndData.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
@@ -388,10 +388,24 @@ public class StructuredDataTest {
             throws RuntimeException, IOException {
         String invalidStructuredDataJSONFilePath =
                 "build/resources/test/"
-                        + "structured_data_json_files/"
-                        + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
+                + "structured_data_json_files/"
+                + "InvalidMessageDataNotPerfectArrayButDeclaredArrayInSchema.json";
         StructuredDataEncoder dataEncoder =
                 new StructuredDataEncoder(getResource(invalidStructuredDataJSONFilePath));
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
+    }
+
+    @Test
+    public void testHashDomainWithSalt() throws RuntimeException, IOException {
+        String validStructuredDataWithSaltJSONFilePath =
+                "build/resources/test/"
+                + "structured_data_json_files/"
+                + "ValidStructuredDataWithSalt.json";
+        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(getResource(validStructuredDataWithSaltJSONFilePath));
+        byte[] structHashDomain = dataEncoder.hashDomain();
+        String expectedDomainStructHash =
+                "0xbae4f6f7b9bfdfda060692099b0e1ccecd25d62b7c92cc9f3b907f33178b81e3";
+
+        assertEquals(Numeric.toHexString(structHashDomain), expectedDomainStructHash);
     }
 }

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithSalt.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithSalt.json
@@ -1,0 +1,39 @@
+{
+  "types": {
+    "EIP712Domain": [
+      {"name": "name", "type": "string"},
+      {"name": "version", "type": "string"},
+      {"name": "chainId", "type": "uint256"},
+      {"name": "verifyingContract", "type": "address"},
+      {"name": "salt", "type": "bytes32"}
+    ],
+    "Person": [
+      {"name": "name", "type": "string"},
+      {"name": "wallet", "type": "address"}
+    ],
+    "Mail": [
+      {"name": "from", "type": "Person"},
+      {"name": "to", "type": "Person"},
+      {"name": "contents", "type": "string"}
+    ]
+  },
+  "primaryType": "Mail",
+  "domain": {
+    "name": "Ether Mail",
+    "version": "1",
+    "chainId": 1,
+    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+    "salt": "0xf2d857f4a3edcb9b78b4d503bfe733db1e3f6cdc2b7971ee739626c97e86a558"
+  },
+  "message": {
+    "from": {
+      "name": "Cow",
+      "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+    },
+    "to": {
+      "name": "Bob",
+      "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+    },
+    "contents": "Hello, Bob!"
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds salt to the EIP712Domain. According to the [EIP](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md), a salt can be added to the domain: 
> an disambiguating salt for the protocol. This can be used as a domain separator of last resort

I double checked the results with what I got back from an [EIP712 demo ](https://weijiekoh.github.io/eip712-signing-demo/index.html)together with metamask. I also verified it in remix.

### Where should the reviewer start?
4 changes:
- Added the salt in StructuredData - EIP712Domain
- Made sure the salt is not present when it is null (StructuredDataEncoder)
- Added a valid JSON test file with salt
- Created a new test to validate the result

### Why is it needed?
If you use a valid EIP712 json with a salt, you get a deserialisation exception (unknown field). 
Since this is part of the EIP it should be implemented.

