### PR TITLE
Generate secp256k1 keypair on Android without modifying system security providers

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -20,7 +20,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 

--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -18,6 +18,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.spec.ECGenParameterSpec;
@@ -41,11 +42,7 @@ public class Keys {
     static final int PUBLIC_KEY_LENGTH_IN_HEX = PUBLIC_KEY_SIZE << 1;
     public static final int PRIVATE_KEY_LENGTH_IN_HEX = PRIVATE_KEY_SIZE << 1;
 
-    static {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-    }
+    static final Provider PROVIDER = new BouncyCastleProvider();
 
     private Keys() {}
 
@@ -66,7 +63,7 @@ public class Keys {
             throws NoSuchProviderException, NoSuchAlgorithmException,
                     InvalidAlgorithmParameterException {
 
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", PROVIDER);
         ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256k1");
         if (random != null) {
             keyPairGenerator.initialize(ecGenParameterSpec, random);


### PR DESCRIPTION
### What does this PR do?
This PR makes available to generate secp256k1 keypair on Android devices without the need of removing native android BC provider and inserting external BC provider, that can break many functionality of Android native components.

### Where should the reviewer start?
There is only one place in web3j that modifies system properties by injecting BC provider if it not registered yet.
crypto/src/main/java/org/web3j/crypto/Keys.java

### Why is it needed?
Android has always registered native BC provider and it's implementation doesn't support ECDSA key generation: createSecp256k1KeyPair methods will always throw NoSuchAlgorithmException exception.
This PR removes unnecessary registration of BC provider in java security (aka changing System settings).
Instead BouncyCastle provider instance is used to get KeyPairGenerator instance from included external BouncyCastle lib.
Before this change Android developers have to remove existing native BC provider and insert real one that support ECDSA key generation. Now it's not required at all.

I've tested it on Android 11.
Before change it throws an exception.
After change it successfully generates the keypair.


