### PR TITLE
Add blockHash filter to EthFilter due to EIP-234

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
@@ -12,7 +12,7 @@
  */
 package org.web3j.protocol.core.methods.request;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.web3j.protocol.core.DefaultBlockParameter;
@@ -24,6 +24,7 @@ import org.web3j.protocol.core.DefaultBlockParameter;
 public class EthFilter extends Filter<EthFilter> {
     private DefaultBlockParameter fromBlock; // optional, params - defaults to latest for both
     private DefaultBlockParameter toBlock;
+    private String blockHash; // optional, cannot be used together with fromBlock/toBlock
     private List<String> address; // spec. implies this can be single address as string or list
 
     public EthFilter() {
@@ -40,7 +41,17 @@ public class EthFilter extends Filter<EthFilter> {
 
     public EthFilter(
             DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, String address) {
-        this(fromBlock, toBlock, Arrays.asList(address));
+        this(fromBlock, toBlock, Collections.singletonList(address));
+    }
+
+    public EthFilter(String blockHash) {
+        super();
+        this.blockHash = blockHash;
+    }
+
+    public EthFilter(String blockHash, String address) {
+        this(null, null, Collections.singletonList(address));
+        this.blockHash = blockHash;
     }
 
     public DefaultBlockParameter getFromBlock() {
@@ -49,6 +60,10 @@ public class EthFilter extends Filter<EthFilter> {
 
     public DefaultBlockParameter getToBlock() {
         return toBlock;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
     }
 
     public List<String> getAddress() {

--- a/core/src/test/java/org/web3j/protocol/RequestTester.java
+++ b/core/src/test/java/org/web3j/protocol/RequestTester.java
@@ -54,7 +54,7 @@ public abstract class RequestTester {
 
         Buffer buffer = new Buffer();
         requestBody.writeTo(buffer);
-        assertEquals(replaceRequestId(buffer.readUtf8()), (replaceRequestId(expected)));
+        assertEquals((replaceRequestId(expected)), replaceRequestId(buffer.readUtf8()));
     }
 
     private String replaceRequestId(String json) {

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -564,6 +564,21 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
+    public void testEthGetLogsWithBlockHash() throws Exception {
+        web3j.ethGetLogs(
+                        new EthFilter(
+                                "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
+                                ""))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getLogs\","
+                        + "\"params\":[{\"topics\":[],"
+                        + "\"blockHash\":\"0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331\","
+                        + "\"address\":[\"\"]}],\"id\":<generatedValue>}");
+    }
+
+    @Test
     public void testEthGetWork() throws Exception {
         web3j.ethGetWork().send();
 


### PR DESCRIPTION
### What does this PR do?
1. Add blockHash filter to EthFilter due to [EIP-234](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-234.md).
2. Fix test bug that actual and expected value were switched.

### Where should the reviewer start?
1. EthFilter => RequestTest
2. RequestTester

### Why is it needed?
1. Support to query logs with blockHash which is described at `eth_getLogs` part of [ethereum json wiki](https://eth.wiki/json-rpc/API)
2. Test logs were confused.

