### PR TITLE
Fix Javadoc warning for org.web3j.protocol.core.Batcher

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Batcher.java
+++ b/core/src/main/java/org/web3j/protocol/core/Batcher.java
@@ -14,6 +14,10 @@ package org.web3j.protocol.core;
 
 public interface Batcher {
 
-    /** Create a new {@link BatchRequest}. */
+    /**
+     * Create a new {@link BatchRequest}.
+     *
+     * @return New BatchRequest.
+     */
     BatchRequest newBatch();
 }


### PR DESCRIPTION
### What does this PR do?
Fixed only Javadoc warning in core project.

### Where should the reviewer start?
This is a small maintenance patch.

### Why is it needed?
Fixes a Javadoc warning.

