### PR TITLE
Fix leak in HttpService

### DIFF
--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -187,7 +187,7 @@ public class HttpService extends Service {
 
             BufferedSource source = responseBody.source();
             source.request(Long.MAX_VALUE); // Buffer the entire body
-            Buffer buffer = source.buffer();
+            Buffer buffer = source.getBuffer();
 
             long size = buffer.size();
             if (size > Integer.MAX_VALUE) {

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -157,20 +157,22 @@ public class HttpService extends Service {
         okhttp3.Request httpRequest =
                 new okhttp3.Request.Builder().url(url).headers(headers).post(requestBody).build();
 
-        okhttp3.Response response = httpClient.newCall(httpRequest).execute();
-        processHeaders(response.headers());
-        ResponseBody responseBody = response.body();
-        if (response.isSuccessful()) {
-            if (responseBody != null) {
-                return buildInputStream(responseBody);
+        try (okhttp3.Response response = httpClient.newCall(httpRequest).execute()) {
+            processHeaders(response.headers());
+            ResponseBody responseBody = response.body();
+            if (response.isSuccessful()) {
+                if (responseBody != null) {
+                    return buildInputStream(responseBody);
+                } else {
+                    return null;
+                }
             } else {
-                return null;
-            }
-        } else {
-            int code = response.code();
-            String text = responseBody == null ? "N/A" : responseBody.string();
+                int code = response.code();
+                String text = responseBody == null ? "N/A" : responseBody.string();
 
-            throw new ClientConnectionException("Invalid response received: " + code + "; " + text);
+                throw new ClientConnectionException(
+                        "Invalid response received: " + code + "; " + text);
+            }
         }
     }
 

--- a/core/src/test/java/org/web3j/protocol/ResponseTester.java
+++ b/core/src/test/java/org/web3j/protocol/ResponseTester.java
@@ -76,7 +76,7 @@ public abstract class ResponseTester {
 
             okhttp3.Response response =
                     new okhttp3.Response.Builder()
-                            .body(ResponseBody.create(JSON_MEDIA_TYPE, jsonResponse))
+                            .body(ResponseBody.create(jsonResponse, JSON_MEDIA_TYPE))
                             .request(chain.request())
                             .protocol(Protocol.HTTP_2)
                             .code(200)


### PR DESCRIPTION
### What does this PR do?
- Fixes a `okhttp3.Response` leak in `HttpService`
- Fixes deprecated `okhttp3` API calls

### Where should the reviewer start?
See commit 3b5d027

### Why is it needed?
Response objects should be closed.

