### PR TITLE
Make Sign.getEthereumMessageHash() method public

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -53,7 +53,7 @@ public class Sign {
         return MESSAGE_PREFIX.concat(String.valueOf(messageLength)).getBytes();
     }
 
-    static byte[] getEthereumMessageHash(byte[] message) {
+    public static byte[] getEthereumMessageHash(byte[] message) {
         byte[] prefix = getEthereumMessagePrefix(message.length);
 
         byte[] result = new byte[prefix.length + message.length];


### PR DESCRIPTION
It's useful for unit testing.

### What does this PR do?
Makes `Sign.getEthereumMessageHash()` method public.

### Where should the reviewer start?
See patch.

### Why is it needed?
It's useful for unit testing.

