### PR TITLE
Close Scanner in RawResponseDeserializer

### DIFF
--- a/core/src/main/java/org/web3j/protocol/deserializer/RawResponseDeserializer.java
+++ b/core/src/main/java/org/web3j/protocol/deserializer/RawResponseDeserializer.java
@@ -65,6 +65,9 @@ public class RawResponseDeserializer extends StdDeserializer<Response>
     }
 
     private String streamToString(InputStream input) throws IOException {
-        return new Scanner(input, StandardCharsets.UTF_8.name()).useDelimiter("\\Z").next();
+        try (Scanner scanner =
+                new Scanner(input, StandardCharsets.UTF_8.name()).useDelimiter("\\Z")) {
+            return scanner.next();
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?
Closes `java.io.Scanner` in `RawResponseDeserializer`.

### Where should the reviewer start?
See commit 134ce4c

### Why is it needed?
`Scanner` implements `Closeable`.

