### PR TITLE
Compatible with uint256 expressed as a string

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +50,9 @@ public class StructuredDataEncoder {
 
     final String bytesTypeRegex = "^bytes[0-9][0-9]?$";
     final Pattern bytesTypePattern = Pattern.compile(bytesTypeRegex);
+
+    final String uintTypeRegex = "^uint[1-9][0-9]*$";
+    final Pattern uintTypePattern = Pattern.compile(uintTypeRegex);
 
     // This regex tries to extract the dimensions from the
     // square brackets of an array declaration using the ``Regex Groups``.
@@ -295,6 +299,18 @@ public class StructuredDataEncoder {
                 byte[] hashedValue = sha3(concatenatedArrayEncodings);
                 encTypes.add("bytes32");
                 encValues.add(hashedValue);
+            } else if (uintTypePattern.matcher(field.getType()).find() && value instanceof String) {
+                encTypes.add(field.getType());
+                String stringValue = (String) value;
+                try {
+                    if (stringValue.startsWith("0x")) {
+                        encValues.add(new BigInteger(stringValue.substring(2), 16));
+                    } else {
+                        encValues.add(new BigInteger(stringValue));
+                    }
+                } catch (NumberFormatException e) {
+                    encValues.add(value);
+                }
             } else {
                 encTypes.add(field.getType());
                 encValues.add(value);

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -408,5 +409,25 @@ public class StructuredDataTest {
                 "0xbae4f6f7b9bfdfda060692099b0e1ccecd25d62b7c92cc9f3b907f33178b81e3";
 
         assertEquals(Numeric.toHexString(structHashDomain), expectedDomainStructHash);
+    }
+
+    @Test
+    public void testValidStructuredDataWithUint256Types() throws IOException {
+        String path =
+                "build/resources/test/"
+                        + "structured_data_json_files/"
+                        + "ValidStructuredDataWithUint256Types.json";
+        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(getResource(path));
+        System.out.println(Hex.toHexString(dataEncoder.hashStructuredData()));
+
+        String expectedTypeEncoding =
+                "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)";
+
+        assertEquals(
+                dataEncoder.encodeType(dataEncoder.jsonMessageObject.getPrimaryType()),
+                expectedTypeEncoding);
+        assertEquals(
+                "545da263947d741ccf1c2865d15f94e195d3cc9f1f665643b989087ad23086bc",
+                Hex.toHexString(dataEncoder.hashStructuredData()));
     }
 }

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithUint256Types.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithUint256Types.json
@@ -1,0 +1,58 @@
+{
+  "types": {
+    "EIP712Domain": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address"
+      }
+    ],
+    "Permit": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ]
+  },
+  "domain": {
+    "name": "Uniswap V2",
+    "version": "1",
+    "chainId": 3,
+    "verifyingContract": "0x36a59aC1b05D10Cc00bD8e7e5D98B967aeB4feDb"
+  },
+  "primaryType": "Permit",
+  "message": {
+    "owner": "0xE10AA6471B33845FaE88DD7bBeB63c250DA3a639",
+    "spender": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
+    "value": "681042469863612417",
+    "nonce": "0x00",
+    "deadline": 1610522220
+  }
+}


### PR DESCRIPTION
### What does this PR do?
StructuredDataEncoder can not handle the structured data generate by Uniswap:
```
{
  "types": {
    "EIP712Domain": [
      {
        "name": "name",
        "type": "string"
      },
      {
        "name": "version",
        "type": "string"
      },
      {
        "name": "chainId",
        "type": "uint256"
      },
      {
        "name": "verifyingContract",
        "type": "address"
      }
    ],
    "Permit": [
      {
        "name": "owner",
        "type": "address"
      },
      {
        "name": "spender",
        "type": "address"
      },
      {
        "name": "value",
        "type": "uint256"
      },
      {
        "name": "nonce",
        "type": "uint256"
      },
      {
        "name": "deadline",
        "type": "uint256"
      }
    ]
  },
  "domain": {
    "name": "Uniswap V2",
    "version": "1",
    "chainId": 3,
    "verifyingContract": "0x36a59aC1b05D10Cc00bD8e7e5D98B967aeB4feDb"
  },
  "primaryType": "Permit",
  "message": {
    "owner": "0xE10AA6471B33845FaE88DD7bBeB63c250DA3a639",
    "spender": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
    "value": "681042469863612417",
    "nonce": "0x00",
    "deadline": 1610522220
  }
}
```

exception:
```
java.lang.RuntimeException: Received an invalid argument for which no constructor exists for the ABI Class Uint256
	at org.web3j.crypto.StructuredDataEncoder.encodeData(StructuredDataEncoder.java:337)
	at org.web3j.crypto.StructuredDataEncoder.hashMessage(StructuredDataEncoder.java:350)
	at org.web3j.crypto.StructuredDataEncoder.hashStructuredData(StructuredDataEncoder.java:416)
```

Root Cause：
 The `uint256` class does not have a constructor that accepts string parameters

Solution:
 try Convert String to BigInteger


### Where should the reviewer start?
see the commit 5fd4ec1

### Why is it needed?
Compatible with uint256 expressed as a string

