### PR TITLE
Fix EIP712 StructuredDataEncoding

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredData.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredData.java
@@ -12,6 +12,7 @@
  */
 package org.web3j.crypto;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 
@@ -54,12 +55,12 @@ public class StructuredData {
         public EIP712Domain(
                 @JsonProperty(value = "name") String name,
                 @JsonProperty(value = "version") String version,
-                @JsonProperty(value = "chainId") Uint256 chainId,
+                @JsonProperty(value = "chainId") String chainId,
                 @JsonProperty(value = "verifyingContract") Address verifyingContract,
                 @JsonProperty(value = "salt") String salt) {
             this.name = name;
             this.version = version;
-            this.chainId = chainId;
+            this.chainId = chainId != null ? new Uint256(new BigInteger(chainId)) : null;
             this.verifyingContract = verifyingContract;
             this.salt = salt;
         }

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -143,8 +143,7 @@ public class StructuredDataEncoder {
         // If any dimension is empty, then it's value is set to -1.
         Matcher arrayTypeMatcher = arrayTypePattern.matcher(declaration);
         arrayTypeMatcher.find();
-        String dimensionsString = arrayTypeMatcher.group(1);
-        Matcher dimensionTypeMatcher = arrayDimensionPattern.matcher(dimensionsString);
+        Matcher dimensionTypeMatcher = arrayDimensionPattern.matcher(declaration);
         List<Integer> dimensions = new ArrayList<>();
         while (dimensionTypeMatcher.find()) {
             String currentDimension = dimensionTypeMatcher.group(1);
@@ -153,10 +152,6 @@ public class StructuredDataEncoder {
             } else {
                 dimensions.add(Integer.parseInt(currentDimension));
             }
-        }
-
-        if (dimensions.size() == 0) {
-            dimensions.add(Integer.parseInt("-1"));
         }
 
         return dimensions;

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -154,6 +155,10 @@ public class StructuredDataEncoder {
             }
         }
 
+        if (dimensions.size() == 0) {
+            dimensions.add(Integer.parseInt("-1"));
+        }
+
         return dimensions;
     }
 
@@ -222,6 +227,56 @@ public class StructuredDataEncoder {
         return flattenedArray;
     }
 
+    private byte[] convertToEncodedItem(String baseType, Object data) {
+        byte[] hashBytes;
+        try {
+            if (baseType.toLowerCase().startsWith("uint")
+                    || baseType.toLowerCase().startsWith("int")) {
+                hashBytes = convertToBigInt(data).toByteArray();
+            } else if (baseType.equals("string")) {
+                hashBytes = ((String) data).getBytes();
+            } else if (baseType.equals("bytes")) {
+                hashBytes = Numeric.hexStringToByteArray((String) data);
+            } else {
+                byte[] b = convertArgToBytes((String) data);
+                BigInteger bi = new BigInteger(1, b);
+                hashBytes = Numeric.toBytesPadded(bi, 32);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            hashBytes = new byte[0];
+        }
+
+        return hashBytes;
+    }
+
+    private List<Object> getArrayItems(StructuredData.Entry field, Object value) {
+        List<Integer> expectedDimensions = getArrayDimensionsFromDeclaration(field.getType());
+        // This function will itself give out errors in case
+        // that the data is not a proper array
+        List<Integer> dataDimensions = getArrayDimensionsFromData(value);
+
+        final String format =
+                String.format(
+                        "Array Data %s has dimensions %s, " + "but expected dimensions are %s",
+                        value.toString(), dataDimensions.toString(), expectedDimensions.toString());
+        if (expectedDimensions.size() != dataDimensions.size()) {
+            // Ex: Expected a 3d array, but got only a 2d array
+            throw new RuntimeException(format);
+        }
+        for (int i = 0; i < expectedDimensions.size(); i++) {
+            if (expectedDimensions.get(i) == -1) {
+                // Skip empty or dynamically declared dimensions
+                continue;
+            }
+            if (!expectedDimensions.get(i).equals(dataDimensions.get(i))) {
+                throw new RuntimeException(format);
+            }
+        }
+
+        return flattenMultidimensionalArray(value);
+    }
+
     @SuppressWarnings("unchecked")
     public byte[] encodeData(String primaryType, HashMap<String, Object> data)
             throws RuntimeException {
@@ -237,6 +292,8 @@ public class StructuredDataEncoder {
         // Add field contents
         for (StructuredData.Entry field : types.get(primaryType)) {
             Object value = data.get(field.getName());
+
+            if (value == null) continue;
 
             if (field.getType().equals("string")) {
                 encTypes.add("bytes32");
@@ -256,45 +313,44 @@ public class StructuredDataEncoder {
                 encValues.add(Numeric.hexStringToByteArray((String) value));
             } else if (arrayTypePattern.matcher(field.getType()).find()) {
                 String baseTypeName = field.getType().substring(0, field.getType().indexOf('['));
-                List<Integer> expectedDimensions =
-                        getArrayDimensionsFromDeclaration(field.getType());
-                // This function will itself give out errors in case
-                // that the data is not a proper array
-                List<Integer> dataDimensions = getArrayDimensionsFromData(value);
-
-                final String format =
-                        String.format(
-                                "Array Data %s has dimensions %s, "
-                                        + "but expected dimensions are %s",
-                                value.toString(),
-                                dataDimensions.toString(),
-                                expectedDimensions.toString());
-                if (expectedDimensions.size() != dataDimensions.size()) {
-                    // Ex: Expected a 3d array, but got only a 2d array
-                    throw new RuntimeException(format);
-                }
-                for (int i = 0; i < expectedDimensions.size(); i++) {
-                    if (expectedDimensions.get(i) == -1) {
-                        // Skip empty or dynamically declared dimensions
-                        continue;
-                    }
-                    if (!expectedDimensions.get(i).equals(dataDimensions.get(i))) {
-                        throw new RuntimeException(format);
-                    }
-                }
-
-                List<Object> arrayItems = flattenMultidimensionalArray(value);
+                List<Object> arrayItems = getArrayItems(field, value);
                 ByteArrayOutputStream concatenatedArrayEncodingBuffer = new ByteArrayOutputStream();
+
                 for (Object arrayItem : arrayItems) {
-                    byte[] arrayItemEncoding =
-                            encodeData(baseTypeName, (HashMap<String, Object>) arrayItem);
+                    byte[] arrayItemEncoding;
+                    if (types.containsKey(baseTypeName)) {
+                        arrayItemEncoding =
+                                sha3(
+                                        encodeData(
+                                                baseTypeName,
+                                                (HashMap<String, Object>)
+                                                        arrayItem)); // need to hash each user type
+                        // before adding
+                    } else {
+                        arrayItemEncoding =
+                                convertToEncodedItem(
+                                        baseTypeName,
+                                        arrayItem); // add raw item, packed to 32 bytes
+                    }
+
                     concatenatedArrayEncodingBuffer.write(
                             arrayItemEncoding, 0, arrayItemEncoding.length);
                 }
+
                 byte[] concatenatedArrayEncodings = concatenatedArrayEncodingBuffer.toByteArray();
                 byte[] hashedValue = sha3(concatenatedArrayEncodings);
                 encTypes.add("bytes32");
                 encValues.add(hashedValue);
+            } else if (field.getType().startsWith("uint") || field.getType().startsWith("int")) {
+                encTypes.add(field.getType());
+                // convert to BigInteger for ABI constructor compatibility
+                try {
+                    encValues.add(convertToBigInt(value));
+                } catch (NumberFormatException | NullPointerException e) {
+                    encValues.add(
+                            value); // value null or failed to convert, fallback to add string as
+                    // before
+                }
             } else {
                 encTypes.add(field.getType());
                 encValues.add(value);
@@ -337,9 +393,17 @@ public class StructuredDataEncoder {
                                 typeClazz.getSimpleName()));
             }
         }
-        byte[] result = baos.toByteArray();
 
-        return result;
+        return baos.toByteArray();
+    }
+
+    private BigInteger convertToBigInt(Object value)
+            throws NumberFormatException, NullPointerException {
+        if (value.toString().startsWith("0x")) {
+            return Numeric.toBigInt(value.toString());
+        } else {
+            return new BigInteger(value.toString());
+        }
     }
 
     public byte[] hashMessage(String primaryType, HashMap<String, Object> data)
@@ -359,9 +423,13 @@ public class StructuredDataEncoder {
             data.remove("chainId");
         }
 
-        data.put(
-                "verifyingContract",
-                ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));
+        if (data.get("verifyingContract") != null) {
+            data.put(
+                    "verifyingContract",
+                    ((HashMap<String, Object>) data.get("verifyingContract")).get("value"));
+        } else {
+            data.remove("verifyingContract");
+        }
 
         if (data.get("salt") == null) {
             data.remove("salt");
@@ -402,7 +470,7 @@ public class StructuredDataEncoder {
     }
 
     @SuppressWarnings("unchecked")
-    public byte[] hashStructuredData() throws RuntimeException {
+    public byte[] getStructuredData() throws RuntimeException {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -419,7 +487,31 @@ public class StructuredDataEncoder {
                         (HashMap<String, Object>) jsonMessageObject.getMessage());
         baos.write(dataHash, 0, dataHash.length);
 
-        byte[] result = baos.toByteArray();
-        return sha3(result);
+        return baos.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    public byte[] hashStructuredData() throws RuntimeException {
+        return sha3(getStructuredData());
+    }
+
+    private static byte[] convertArgToBytes(String inputValue) throws Exception {
+        String hexValue = inputValue;
+        if (!Numeric.containsHexPrefix(inputValue)) {
+            BigInteger value;
+            try {
+                value = new BigInteger(inputValue);
+            } catch (NumberFormatException e) {
+                value = new BigInteger(inputValue, 16);
+            }
+
+            hexValue = Numeric.toHexStringNoPrefix(value.toByteArray());
+            // fix sign condition
+            if (hexValue.length() > 64 && hexValue.startsWith("00")) {
+                hexValue = hexValue.substring(2);
+            }
+        }
+
+        return Numeric.hexStringToByteArray(hexValue);
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -208,6 +208,48 @@ public class StructuredDataTest {
         assertThrows(RuntimeException.class, dataEncoder::hashStructuredData);
     }
 
+    // EIP712 v3
+    @Test
+    public void testValidStructureWithValues() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredDataWithValues.json"));
+
+        assertEquals(
+                "0x9a321bee2df12b3b43bc4caf71d19839f05d82264b780b48f1f529bf916b5d30",
+                Numeric.toHexString(dataEncoder.hashStructuredData()));
+    }
+
+    // EIP712 v4
+    @Test
+    public void testValidStructureWithArrays() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredArrayData.json")); // taken from https://danfinlay.github.io/js-eth-personal-sign-examples/
+
+        assertEquals(
+                "0xa85c2e2b118698e88db68a8105b794a8cc7cec074e89ef991cb4f5f533819cc2",
+                Numeric.toHexString(dataEncoder.hashStructuredData()));
+    }
+
+    // EIP712 v3 Gnosis format; Multisig Structured message with addresses blanked
+    @Test
+    public void testValidGnosisStructure() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredGnosisData.json")); // typical Gnosis safe EIP712 data
+
+        assertEquals(
+                "0xb3ffe0073b0c3aecb00b19a636e4b3820cfc9692189f874312c906f70edf10bd",
+                Numeric.toHexString(dataEncoder.hashStructuredData()));
+    }
+
     @Test
     public void testGetArrayDimensionsFromData() throws RuntimeException, IOException {
         StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredArrayData.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredArrayData.json
@@ -1,0 +1,83 @@
+{
+    "domain": {
+        "chainId": 1,
+        "name": "Ether Mail",
+        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+        "version": "1"
+    },
+    "message": {
+        "contents": "Hello, Bob!",
+        "from": {
+            "name": "Cow",
+            "wallets": [
+                "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+                "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+            ]
+        },
+        "to": [
+            {
+                "name": "Bob",
+                "wallets": [
+                    "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                    "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
+                    "0xB0B0b0b0b0b0B000000000000000000000000000"
+                ]
+            }
+        ]
+    },
+    "primaryType": "Mail",
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "chainId",
+                "type": "uint256"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "Group": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "members",
+                "type": "Person[]"
+            }
+        ],
+        "Mail": [
+            {
+                "name": "from",
+                "type": "Person"
+            },
+            {
+                "name": "to",
+                "type": "Person[]"
+            },
+            {
+                "name": "contents",
+                "type": "string"
+            }
+        ],
+        "Person": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "wallets",
+                "type": "address[]"
+            }
+        ]
+    }
+}

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithArrays.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithArrays.json
@@ -1,37 +1,83 @@
 {
-  "types": {
-    "EIP712Domain": [
-      {"name": "name", "type": "string"},
-      {"name": "version", "type": "string"},
-      {"name": "chainId", "type": "uint256"},
-      {"name": "verifyingContract", "type": "address"}
-    ],
-    "Person": [
-      {"name": "name", "type": "string"},
-      {"name": "wallet", "type": "address"}
-    ],
-    "Mail": [
-      {"name": "from", "type": "Person"},
-      {"name": "to", "type": "Person[2]"},
-      {"name": "contents", "type": "string"}
+  "domain": {
+    "chainId": 1,
+    "name": "Ether Mail",
+    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+    "version": "1"
+  },
+  "message": {
+    "contents": "Hello, Bob!",
+    "from": {
+      "name": "Cow",
+      "wallets": [
+        "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+        "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+      ]
+    },
+    "to": [
+      {
+        "name": "Bob",
+        "wallets": [
+          "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+          "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
+          "0xB0B0b0b0b0b0B000000000000000000000000000"
+        ]
+      }
     ]
   },
   "primaryType": "Mail",
-  "domain": {
-    "name": "Ether Mail",
-    "version": "1",
-    "chainId": 1,
-    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
-  },
-  "message": {
-    "from": {
-      "name": "Cow",
-      "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
-    },
-    "to": [{
-      "name": "Bob",
-      "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
-    }],
-    "contents": "Hello, Bob!"
+  "types": {
+    "EIP712Domain": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address"
+      }
+    ],
+    "Group": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "members",
+        "type": "Person[]"
+      }
+    ],
+    "Mail": [
+      {
+        "name": "from",
+        "type": "Person"
+      },
+      {
+        "name": "to",
+        "type": "Person[]"
+      },
+      {
+        "name": "contents",
+        "type": "string"
+      }
+    ],
+    "Person": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "wallets",
+        "type": "address[]"
+      }
+    ]
   }
 }

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithValues.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithValues.json
@@ -1,0 +1,95 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "version",
+                "type": "string"
+            },
+            {
+                "name": "verifyingContract",
+                "type": "address"
+            }
+        ],
+        "RelayRequest": [
+            {
+                "name": "target",
+                "type": "address"
+            },
+            {
+                "name": "encodedFunction",
+                "type": "bytes"
+            },
+            {
+                "name": "gasData",
+                "type": "GasData"
+            },
+            {
+                "name": "relayData",
+                "type": "RelayData"
+            }
+        ],
+        "GasData": [
+            {
+                "name": "gasLimit",
+                "type": "uint256"
+            },
+            {
+                "name": "gasPrice",
+                "type": "uint256"
+            },
+            {
+                "name": "pctRelayFee",
+                "type": "uint256"
+            },
+            {
+                "name": "baseRelayFee",
+                "type": "uint256"
+            }
+        ],
+        "RelayData": [
+            {
+                "name": "senderAddress",
+                "type": "address"
+            },
+            {
+                "name": "senderNonce",
+                "type": "uint256"
+            },
+            {
+                "name": "relayWorker",
+                "type": "address"
+            },
+            {
+                "name": "paymaster",
+                "type": "address"
+            }
+        ]
+    },
+    "domain": {
+        "name": "Test Relayed Transaction",
+        "version": "1",
+        "chainId": 42,
+        "verifyingContract": "0x1234567890aBcDeF1234567890aBcDeF12345678"
+    },
+    "primaryType": "RelayRequest",
+    "message": {
+        "target": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+        "encodedFunction": "0xa9059cbb0000000000000000000000002e0d94754b348d208d64d52d78bcd443afa9fa520000000000000000000000000000000000000000000000000000000000000007",
+        "gasData": {
+            "gasLimit": "39507",
+            "gasPrice": "1700000000",
+            "pctRelayFee": "70",
+            "baseRelayFee": "0"
+        },
+        "relayData": {
+            "senderAddress": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+            "senderNonce": "3",
+            "relayWorker": "0x1234567890aBcDeF1234567890aBcDeF12345678",
+            "paymaster": "0x1234567890aBcDeF1234567890aBcDeF12345678"
+        }
+    }
+}

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredGnosisData.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredGnosisData.json
@@ -1,0 +1,68 @@
+{
+    "types": {
+        "EIP712Domain": [
+            {
+                "type": "address",
+                "name": "verifyingContract"
+            }
+        ],
+        "SafeTx": [
+            {
+                "type": "address",
+                "name": "to"
+            },
+            {
+                "type": "uint256",
+                "name": "value"
+            },
+            {
+                "type": "bytes",
+                "name": "data"
+            },
+            {
+                "type": "uint8",
+                "name": "operation"
+            },
+            {
+                "type": "uint256",
+                "name": "safeTxGas"
+            },
+            {
+                "type": "uint256",
+                "name": "baseGas"
+            },
+            {
+                "type": "uint256",
+                "name": "gasPrice"
+            },
+            {
+                "type": "address",
+                "name": "gasToken"
+            },
+            {
+                "type": "address",
+                "name": "refundReceiver"
+            },
+            {
+                "type": "uint256",
+                "name": "nonce"
+            }
+        ]
+    },
+    "domain": {
+        "verifyingContract": "0x0000000000000000000000000000000000000123"
+    },
+    "primaryType": "SafeTx",
+    "message": {
+        "to": "0x0000000000000000000000000000000000000123",
+        "value": "0",
+        "data": "0x1cff79cd00000000000000000000000000000000000000000000000000000000000001234",
+        "operation": 0,
+        "safeTxGas": 222496,
+        "baseGas": 0,
+        "gasPrice": "0",
+        "gasToken": "0x0000000000000000000000000000000000000000",
+        "refundReceiver": "0x0000000000000000000000000000000000000000",
+        "nonce": 28
+    }
+}


### PR DESCRIPTION
### What does this PR do?
- Fix for StructuredDataEncoding (EIP712), including EIP712v3 and EIP712v4 Standards.
- Add unit tests for EIP712v3, EIPv712v4 and a real world message all of which previously failed.

### Where should the reviewer start?
Check the new tests, which are encoded here:
- ValidStructuredDataWithValues: showing an EIP713v3 packet that previously was failing to parse due to Uint256 value.
- ValidStructuredArrayData: EIP712v4 signing example from https://danfinlay.github.io/js-eth-personal-sign-examples/ (currently unsuported)
- ValidStructuredGnosisData: EIP713v3 real world sample which currently fails, fixed in this PR.

### Why is it needed?
Increasingly, wallets are being required to sign Structured EIP712 data, eg for Multisig transactions. The current state of Web3j doesn't support EIP712v3 or v4.
The attached code has been live in the AlphaWallet wallet for 8 months, and in several other wallets that have run into the same issue and forked/duped this fix.