### PR TITLE
Alignment with Besu OnChainPrivacyGroups signature modified from 20.10.…

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -64,6 +64,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
 
     private final JsonRpc2_0BesuRx besuRx;
     private final long blockTime;
+    private final OnChainPrivacyTransactionBuilder onChainPrivacyTransactionBuilder;
 
     public JsonRpc2_0Besu(final Web3jService web3jService) {
         this(web3jService, DEFAULT_BLOCK_TIME, Async.defaultExecutorService());
@@ -73,9 +74,23 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
             Web3jService web3jService,
             long pollingInterval,
             ScheduledExecutorService scheduledExecutorService) {
+        this(
+                web3jService,
+                pollingInterval,
+                scheduledExecutorService,
+                new OnChainPrivacyTransactionBuilder());
+    }
+
+    public JsonRpc2_0Besu(
+            Web3jService web3jService,
+            long pollingInterval,
+            ScheduledExecutorService scheduledExecutorService,
+            OnChainPrivacyTransactionBuilder onChainPrivacyTransactionBuilder) {
         super(web3jService, pollingInterval, scheduledExecutorService);
+
         this.besuRx = new JsonRpc2_0BesuRx(this, scheduledExecutorService);
         this.blockTime = pollingInterval;
+        this.onChainPrivacyTransactionBuilder = onChainPrivacyTransactionBuilder;
     }
 
     @Override
@@ -261,7 +276,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                         lock ? "lock" : "unlock");
 
         String lockPrivacyGroupTransactionPayload =
-                OnChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
+                onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
                         credentials,
                         enclaveKey,
@@ -287,7 +302,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 OnChainPrivacyTransactionBuilder.getEncodedSingleParamFunction("lock");
 
         String lockPrivacyGroupTransactionPayload =
-                OnChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
+                onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
                         credentials,
                         enclaveKey,
@@ -327,11 +342,10 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                         .send()
                         .getTransactionCount();
         String addToContractCall =
-                OnChainPrivacyTransactionBuilder.getEncodedAddToGroupFunction(
-                        enclaveKey, participantsAsBytes);
+                OnChainPrivacyTransactionBuilder.getEncodedAddToGroupFunction(participantsAsBytes);
 
         String addToPrivacyGroupTransactionPayload =
-                OnChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
+                onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
                         credentials,
                         enclaveKey,
@@ -356,15 +370,15 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 OnChainPrivacyTransactionBuilder.getEncodedRemoveFromGroupFunction(
                         enclaveKey, participant.raw());
 
-        String removeFromProupTransactionPayload =
-                OnChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
+        String removeFromGroupTransactionPayload =
+                onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
                         credentials,
                         enclaveKey,
                         transactionCount,
                         removeFromContractCall);
 
-        return eeaSendRawTransaction(removeFromProupTransactionPayload);
+        return eeaSendRawTransaction(removeFromGroupTransactionPayload);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
This PR tries to align the Besu OnChainPrivacyGroups with the last version of Besu.
Since the versión of besu 20.10.0, some changes were introduced in the Besu OnchainPermissioning Smartcontracts and the actual version of Web3j is unable to create an OnChainPrivacyGroups.

### Where should the reviewer start?
Reviewing the last versión of SC OnChainPrivacyGroups implementation and verify that the signature mismatch since v20.10.0

### Why is it needed?
- Fix the OnChainPrivacyGroups creation process
- Fix the hardcoded chainId for the rawTransaction
- Fix the ZeroGasFactory used to generate transaction
- Parametrize the hardcoded transaction such us Restriction and Address of the EeaRawTransaction

