### PR TITLE
Expose `OkHttpClient.Builder` to `HttpService` users

### DIFF
--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -134,11 +134,15 @@ public class HttpService extends Service {
         this(DEFAULT_URL);
     }
 
-    private static OkHttpClient createOkHttpClient() {
+    public static OkHttpClient.Builder getOkHttpClientBuilder() {
         final OkHttpClient.Builder builder =
                 new OkHttpClient.Builder().connectionSpecs(CONNECTION_SPEC_LIST);
         configureLogging(builder);
-        return builder.build();
+        return builder;
+    }
+
+    private static OkHttpClient createOkHttpClient() {
+        return getOkHttpClientBuilder().build();
     }
 
     private static void configureLogging(OkHttpClient.Builder builder) {


### PR DESCRIPTION
Expose the pre-configured client builder to library users so that they can customize configurations such as
* logging,
* time-outs.

By making the `Builder` public, library users can customize the `OkHttpClient` configuration before constructing an instance of `HttpService` while re-using the present default configuration.

For motivation of this PR, see e.g. 
* https://github.com/web3j/web3j/issues/953
* https://github.com/web3j/web3j-spring-boot-starter/pull/4

