### PR TITLE
Equalsverifier version bump.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     picocliVersion = '3.0.0'
     web3jUnitVersion = version
     // test dependencies
-    equalsverifierVersion = '3.1.10'
+    equalsverifierVersion = '3.5.5'
     junitVersion = '5.5.2'
     junitBenchmarkVersion = '0.7.2'
     logbackVersion = '1.2.3'


### PR DESCRIPTION
Bump equals verifier version to latest stable.

Building with
```
equalsverifierVersion = '3.1.10'
```
results with
```
openjdk version "15.0.2" 2021-01-19
```
in test failures of the form

```
java.lang.AssertionError: EqualsVerifier found a problem in class Block.
-> Unsupported class file major version 59

For more information, go to: http://www.jqno.nl/equalsverifier/errormessages
	at nl.jqno.equalsverifier.EqualsVerifierApi.verify(EqualsVerifierApi.java:308)
	at org.web3j.protocol.core.EqualsVerifierResponseTest.testBlock(EqualsVerifierResponseTest.java:36)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

Bumping equals verifier version to the latest stable version (`3.5.5`) fixes the issue and results in a stable build.

See also https://github.com/jqno/equalsverifier/issues/339
