### PR TITLE
Minor Fix to adapt with different chains.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -433,8 +433,17 @@ public class WebSocketService implements Web3jService {
         }
 
         if (!idField.isIntegralNumber()) {
-            throw new IOException(
-                    String.format("'id' expected to be long, but it is: '%s'", idField.asText()));
+            if(idField.isTextual()) {
+                String string = idField.asText();
+                try {
+                    return Long.parseLong(string);
+                } catch (Exception e) {
+                    throw new IOException(String.format("Textual Found 'id' that cannot be casted to long. Input : '%s'", idField.asText()));
+                }
+            } else {
+                throw new IOException(
+                        String.format("'id' expected to be long, but it is: '%s'", idField.asText()));
+            }
         }
 
         return idField.longValue();


### PR DESCRIPTION
Long ago, I was working using this library to work with matic chain (Polygon). Apparently, It seems that in the JSON, they send a long value in string format. So it kept throwing error in the code. I use this patched version in my code, but i thought i should make this change on original code and propose a pull request so that others don't have to go through the same issue.

### What does this PR do?
In this patch, if the id in JSON is not a long value, but still a long value in text format, then we check for that and if possible, we try to return that value.

### Where should the reviewer start?
Very very small change has been made.  Just look at the changes made at line 435 and few lines below it.

### Why is it needed?
I believe it is required so that we can avoid errors when working with different types of chains. At least it is needed for matic when using maticVigil endpoints for receiving data.

