### PR TITLE
Signer Abstraction

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.web3j.crypto.Credentials;
+import org.web3j.crypto.signer.Signer;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
@@ -113,6 +114,7 @@ public interface Besu extends Eea, BesuRx {
     Request<?, PrivCreatePrivacyGroup> privCreatePrivacyGroup(
             final List<Base64String> addresses, final String name, final String description);
 
+    @Deprecated
     Request<?, EthSendTransaction> privOnChainSetGroupLockState(
             final Base64String privacyGroupId,
             final Credentials credentials,
@@ -120,6 +122,14 @@ public interface Besu extends Eea, BesuRx {
             final Boolean lock)
             throws IOException;
 
+    Request<?, EthSendTransaction> privOnChainSetGroupLockState(
+            final Base64String privacyGroupId,
+            final Signer signer,
+            final Base64String enclaveKey,
+            final Boolean lock)
+            throws IOException;
+
+    @Deprecated
     Request<?, EthSendTransaction> privOnChainAddToPrivacyGroup(
             Base64String privacyGroupId,
             Credentials credentials,
@@ -127,6 +137,14 @@ public interface Besu extends Eea, BesuRx {
             List<Base64String> participants)
             throws IOException, TransactionException;
 
+    Request<?, EthSendTransaction> privOnChainAddToPrivacyGroup(
+            final Base64String privacyGroupId,
+            final Signer signer,
+            final Base64String enclaveKey,
+            final List<Base64String> participants)
+            throws IOException, TransactionException;
+
+    @Deprecated
     Request<?, EthSendTransaction> privOnChainCreatePrivacyGroup(
             Base64String privacyGroupId,
             Credentials credentials,
@@ -134,9 +152,24 @@ public interface Besu extends Eea, BesuRx {
             List<Base64String> participants)
             throws IOException;
 
+    Request<?, EthSendTransaction> privOnChainCreatePrivacyGroup(
+            final Base64String privacyGroupId,
+            final Signer signer,
+            final Base64String enclaveKey,
+            final List<Base64String> participants)
+            throws IOException;
+
+    @Deprecated
     Request<?, EthSendTransaction> privOnChainRemoveFromPrivacyGroup(
             final Base64String privacyGroupId,
             final Credentials credentials,
+            final Base64String enclaveKey,
+            final Base64String participant)
+            throws IOException;
+
+    Request<?, EthSendTransaction> privOnChainRemoveFromPrivacyGroup(
+            final Base64String privacyGroupId,
+            final Signer signer,
             final Base64String enclaveKey,
             final Base64String participant)
             throws IOException;

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import io.reactivex.Flowable;
 
 import org.web3j.crypto.Credentials;
+import org.web3j.crypto.signer.DefaultSigner;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.besu.privacy.OnChainPrivacyTransactionBuilder;
@@ -278,7 +279,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
         String lockPrivacyGroupTransactionPayload =
                 onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
-                        credentials,
+                        DefaultSigner.fromCredentials(credentials),
                         enclaveKey,
                         transactionCount,
                         lockContractCall);
@@ -304,7 +305,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
         String lockPrivacyGroupTransactionPayload =
                 onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
-                        credentials,
+                        DefaultSigner.fromCredentials(credentials),
                         enclaveKey,
                         transactionCount,
                         lockContractCall);
@@ -347,7 +348,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
         String addToPrivacyGroupTransactionPayload =
                 onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
-                        credentials,
+                        DefaultSigner.fromCredentials(credentials),
                         enclaveKey,
                         transactionCount,
                         addToContractCall);
@@ -373,7 +374,7 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
         String removeFromGroupTransactionPayload =
                 onChainPrivacyTransactionBuilder.buildOnChainPrivateTransaction(
                         privacyGroupId,
-                        credentials,
+                        DefaultSigner.fromCredentials(credentials),
                         enclaveKey,
                         transactionCount,
                         removeFromContractCall);

--- a/besu/src/main/java/org/web3j/protocol/besu/privacy/OnChainPrivacyTransactionBuilder.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/privacy/OnChainPrivacyTransactionBuilder.java
@@ -23,6 +23,7 @@ import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.crypto.Credentials;
+import org.web3j.crypto.signer.Signer;
 import org.web3j.protocol.eea.crypto.PrivateTransactionEncoder;
 import org.web3j.protocol.eea.crypto.RawPrivateTransaction;
 import org.web3j.tx.gas.BesuPrivacyGasProvider;
@@ -81,6 +82,7 @@ public class OnChainPrivacyTransactionBuilder {
         return FunctionEncoder.encode(function);
     }
 
+    @Deprecated
     public String buildOnChainPrivateTransaction(
             Base64String privacyGroupId,
             Credentials credentials,
@@ -100,5 +102,26 @@ public class OnChainPrivacyTransactionBuilder {
 
         return Numeric.toHexString(
                 PrivateTransactionEncoder.signMessage(rawTransaction, chainId, credentials));
+    }
+
+    public String buildOnChainPrivateTransaction(
+            Base64String privacyGroupId,
+            Signer signer,
+            Base64String enclaveKey,
+            final BigInteger nonce,
+            String call) {
+        RawPrivateTransaction rawTransaction =
+                RawPrivateTransaction.createTransaction(
+                        nonce,
+                        gasProvider.getGasPrice(),
+                        gasProvider.getGasLimit(),
+                        OnChainPrivacyPrecompiledContract,
+                        call,
+                        enclaveKey,
+                        privacyGroupId,
+                        restriction);
+
+        return Numeric.toHexString(
+                PrivateTransactionEncoder.signMessage(rawTransaction, chainId, signer));
     }
 }

--- a/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/PrivateTransactionManager.java
@@ -48,6 +48,7 @@ public class PrivateTransactionManager extends TransactionManager {
 
     private final Restriction restriction;
 
+    @Deprecated
     public PrivateTransactionManager(
             final Besu besu,
             final Credentials credentials,
@@ -59,6 +60,24 @@ public class PrivateTransactionManager extends TransactionManager {
         super(transactionReceiptProcessor, credentials.getAddress());
         this.besu = besu;
         this.signer = DefaultSigner.fromCredentials(credentials);
+        this.chainId = chainId;
+        this.privateFrom = privateFrom;
+        this.privateFor = null;
+        this.privacyGroupId = privacyGroupId;
+        this.restriction = restriction;
+    }
+
+    public PrivateTransactionManager(
+            final Besu besu,
+            final Signer signer,
+            final TransactionReceiptProcessor transactionReceiptProcessor,
+            final long chainId,
+            final Base64String privateFrom,
+            final Base64String privacyGroupId,
+            final Restriction restriction) {
+        super(transactionReceiptProcessor, signer.getAddress());
+        this.besu = besu;
+        this.signer = signer;
         this.chainId = chainId;
         this.privateFrom = privateFrom;
         this.privateFor = null;

--- a/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/FastRawTransactionManager.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 
 import org.web3j.crypto.Credentials;
+import org.web3j.crypto.signer.Signer;
 import org.web3j.protocol.Web3j;
 import org.web3j.tx.response.TransactionReceiptProcessor;
 
@@ -27,14 +28,25 @@ public class FastRawTransactionManager extends RawTransactionManager {
 
     private volatile BigInteger nonce = BigInteger.valueOf(-1);
 
+    @Deprecated
     public FastRawTransactionManager(Web3j web3j, Credentials credentials, long chainId) {
         super(web3j, credentials, chainId);
     }
 
+    public FastRawTransactionManager(Web3j web3j, Signer signer, long chainId) {
+        super(web3j, signer, chainId);
+    }
+
+    @Deprecated
     public FastRawTransactionManager(Web3j web3j, Credentials credentials) {
         super(web3j, credentials);
     }
 
+    public FastRawTransactionManager(Web3j web3j, Signer signer) {
+        super(web3j, signer);
+    }
+
+    @Deprecated
     public FastRawTransactionManager(
             Web3j web3j,
             Credentials credentials,
@@ -42,12 +54,21 @@ public class FastRawTransactionManager extends RawTransactionManager {
         super(web3j, credentials, ChainId.NONE, transactionReceiptProcessor);
     }
 
+    @Deprecated
     public FastRawTransactionManager(
             Web3j web3j,
             Credentials credentials,
             long chainId,
             TransactionReceiptProcessor transactionReceiptProcessor) {
         super(web3j, credentials, chainId, transactionReceiptProcessor);
+    }
+
+    public FastRawTransactionManager(
+            Web3j web3j,
+            Signer signer,
+            long chainId,
+            TransactionReceiptProcessor transactionReceiptProcessor) {
+        super(web3j, signer, chainId, transactionReceiptProcessor);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/tx/RawTransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/RawTransactionManager.java
@@ -52,6 +52,7 @@ public class RawTransactionManager extends TransactionManager {
 
     protected TxHashVerifier txHashVerifier = new TxHashVerifier();
 
+    @Deprecated
     public RawTransactionManager(Web3j web3j, Credentials credentials, long chainId) {
         super(web3j, credentials.getAddress());
 
@@ -61,6 +62,16 @@ public class RawTransactionManager extends TransactionManager {
         this.signer = DefaultSigner.fromCredentials(credentials);
     }
 
+    public RawTransactionManager(Web3j web3j, Signer signer, long chainId) {
+        super(web3j, signer.getAddress());
+
+        this.web3j = web3j;
+
+        this.chainId = chainId;
+        this.signer = signer;
+    }
+
+    @Deprecated
     public RawTransactionManager(
             Web3j web3j,
             Credentials credentials,
@@ -75,6 +86,19 @@ public class RawTransactionManager extends TransactionManager {
     }
 
     public RawTransactionManager(
+            Web3j web3j,
+            Signer signer,
+            long chainId,
+            TransactionReceiptProcessor transactionReceiptProcessor) {
+        super(transactionReceiptProcessor, signer.getAddress());
+
+        this.web3j = web3j;
+
+        this.chainId = chainId;
+        this.signer = signer;
+    }
+
+    public RawTransactionManager(
             Web3j web3j, Credentials credentials, long chainId, int attempts, long sleepDuration) {
         super(web3j, attempts, sleepDuration, credentials.getAddress());
 
@@ -84,10 +108,16 @@ public class RawTransactionManager extends TransactionManager {
         this.signer = DefaultSigner.fromCredentials(credentials);
     }
 
+    @Deprecated
     public RawTransactionManager(Web3j web3j, Credentials credentials) {
         this(web3j, credentials, ChainId.NONE);
     }
 
+    public RawTransactionManager(Web3j web3j, Signer signer) {
+        this(web3j, signer, ChainId.NONE);
+    }
+
+    @Deprecated
     public RawTransactionManager(
             Web3j web3j, Credentials credentials, int attempts, int sleepDuration) {
         this(web3j, credentials, ChainId.NONE, attempts, sleepDuration);

--- a/core/src/main/java/org/web3j/tx/Transfer.java
+++ b/core/src/main/java/org/web3j/tx/Transfer.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.web3j.crypto.Credentials;
+import org.web3j.crypto.signer.DefaultSigner;
+import org.web3j.crypto.signer.Signer;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.RemoteCall;
 import org.web3j.protocol.core.methods.response.EthChainId;
@@ -80,6 +82,7 @@ public class Transfer extends ManagedTransaction {
         return send(resolvedAddress, "", weiValue.toBigIntegerExact(), gasPrice, gasLimit);
     }
 
+    @Deprecated
     public static RemoteCall<TransactionReceipt> sendFunds(
             Web3j web3j,
             Credentials credentials,
@@ -87,8 +90,14 @@ public class Transfer extends ManagedTransaction {
             BigDecimal value,
             Convert.Unit unit)
             throws InterruptedException, IOException, TransactionException {
+        return sendFunds(web3j, DefaultSigner.fromCredentials(credentials), toAddress, value, unit);
+    }
 
-        TransactionManager transactionManager = new RawTransactionManager(web3j, credentials);
+    public static RemoteCall<TransactionReceipt> sendFunds(
+            Web3j web3j, Signer signer, String toAddress, BigDecimal value, Convert.Unit unit)
+            throws InterruptedException, IOException, TransactionException {
+
+        TransactionManager transactionManager = new RawTransactionManager(web3j, signer);
 
         return new RemoteCall<>(
                 () -> new Transfer(web3j, transactionManager).send(toAddress, value, unit));

--- a/crypto/src/main/java/org/web3j/crypto/Credentials.java
+++ b/crypto/src/main/java/org/web3j/crypto/Credentials.java
@@ -46,6 +46,10 @@ public class Credentials {
         return create(ECKeyPair.create(Numeric.toBigInt(privateKey)));
     }
 
+    public static Credentials createEmptyCredentials(String address) {
+        return new Credentials(null, address);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -91,7 +91,7 @@ public class TransactionEncoder {
         return encode(rawTransaction, (long) chainId);
     }
 
-    private static byte[] encode(RawTransaction rawTransaction, Sign.SignatureData signatureData) {
+    public static byte[] encode(RawTransaction rawTransaction, Sign.SignatureData signatureData) {
         List<RlpType> values = asRlpValues(rawTransaction, signatureData);
         RlpList rlpList = new RlpList(values);
         byte[] encoded = RlpEncoder.encode(rlpList);

--- a/crypto/src/main/java/org/web3j/crypto/signer/DefaultSigner.java
+++ b/crypto/src/main/java/org/web3j/crypto/signer/DefaultSigner.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto.signer;
+
+import java.math.BigInteger;
+
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.Keys;
+import org.web3j.crypto.Sign;
+import org.web3j.utils.Numeric;
+
+public class DefaultSigner implements Signer {
+
+    private final Credentials credentials;
+
+    protected DefaultSigner(final Credentials credentials) {
+        this.credentials = credentials;
+    }
+
+    @Override
+    public Sign.SignatureData sign(final byte[] encodedTransaction) {
+        return Sign.signMessage(encodedTransaction, credentials.getEcKeyPair());
+    }
+
+    @Override
+    public String getAddress() {
+        return Numeric.prependHexPrefix(Keys.getAddress(getPublicKey()));
+    }
+
+    @Override
+    public BigInteger getPublicKey() {
+        return credentials.getEcKeyPair().getPublicKey();
+    }
+
+    public static DefaultSigner fromCredentials(final Credentials credentials) {
+        return new DefaultSigner(credentials);
+    }
+}

--- a/crypto/src/main/java/org/web3j/crypto/signer/Signer.java
+++ b/crypto/src/main/java/org/web3j/crypto/signer/Signer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto.signer;
+
+import java.math.BigInteger;
+
+import org.web3j.crypto.Sign;
+
+public interface Signer {
+    Sign.SignatureData sign(final byte[] encodedTransaction);
+
+    String getAddress();
+
+    BigInteger getPublicKey();
+}

--- a/integration-tests/src/test/java/org/web3j/protocol/besu/BesuPrivacyQuickstartIntegrationTest.java
+++ b/integration-tests/src/test/java/org/web3j/protocol/besu/BesuPrivacyQuickstartIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.Sign;
 import org.web3j.crypto.TransactionEncoder;
+import org.web3j.crypto.signer.DefaultSigner;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionWithPrivacyGroup;
 import org.web3j.protocol.eea.crypto.PrivateTransactionEncoder;
@@ -186,7 +187,7 @@ public class BesuPrivacyQuickstartIntegrationTest {
         PrivateTransactionManager tmAlice =
                 new PrivateTransactionManager(
                         nodeAlice,
-                        ALICE,
+                        DefaultSigner.fromCredentials(ALICE),
                         transactionReceiptProcessor,
                         ChainIdLong.NONE,
                         ENCLAVE_KEY_ALICE,
@@ -196,7 +197,7 @@ public class BesuPrivacyQuickstartIntegrationTest {
         PrivateTransactionManager tmBob =
                 new PrivateTransactionManager(
                         nodeBob,
-                        BOB,
+                        DefaultSigner.fromCredentials(BOB),
                         transactionReceiptProcessor,
                         ChainIdLong.NONE,
                         ENCLAVE_KEY_BOB,


### PR DESCRIPTION
### What does this PR do?
With this PR a new Signer component is created in order to abstract the signing process of public and private transactions.
Abstracting the signing as an independent process brings benefits for the security because the Transactions Managers do not have to store and handle the Private Key in the credentials objects and opens the possibility to integrate external signer components without changing the behaviour of the library. 

### Where should the reviewer start?
The reviewer should start validating the new interface Signer that should model the actual signing process. With this interface and the Default implementation (DefaultSigner) with stores but not expose the private key of the Credentails object all the logic is modelled.
The rest of the changes of the PR is creating new contructors for the Tx Managers to accept a signer instead of a Credentails.
The approach for the actual changes inside these Tx Managers was substitute the credentials object for the Default Signer.

### Why is it needed?
Moving to a wide and flexible signing solutions should be appreciate to enable the web3j more suitable and secure for both public and private solutions.

