### PR TITLE
Fix eip-155 transactions not being signed correctly for large chain ids

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -64,7 +64,7 @@ public class TransactionEncoder {
             Sign.SignatureData signatureData, long chainId) {
         BigInteger v = Numeric.toBigInt(signatureData.getV());
         v = v.subtract(BigInteger.valueOf(LOWER_REAL_V));
-        v = v.add(BigInteger.valueOf(chainId * 2));
+        v = v.add(BigInteger.valueOf(chainId).multiply(BigInteger.valueOf(2)));
         v = v.add(BigInteger.valueOf(CHAIN_ID_INC));
 
         return new Sign.SignatureData(v.toByteArray(), signatureData.getR(), signatureData.getS());

--- a/crypto/src/test/java/org/web3j/crypto/TransactionEncoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionEncoderTest.java
@@ -84,6 +84,20 @@ public class TransactionEncoderTest {
     }
 
     @Test
+    public void testEip155TransactionWithLargeChainId() {
+        // https://github.com/ethereum/EIPs/issues/155
+        Credentials credentials =
+                Credentials.create(
+                        "0x4646464646464646464646464646464646464646464646464646464646464646");
+
+        assertArrayEquals(
+                TransactionEncoder.signMessage(
+                        createEip155RawTransaction(), Long.MAX_VALUE, credentials),
+                (Numeric.hexStringToByteArray(
+                        "0xf875098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008089010000000000000021a0ed14bd16ddd7788623f4439db3ddbc8bf548c241c3af87819c187a638ef40e17a03b4972ee3adb77b6b06784d12fe098c2cb84c03afd79d17b1caf8f63483101f0")));
+    }
+
+    @Test
     public void testEip1559Transaction() {
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md
         Credentials credentials =


### PR DESCRIPTION
### What does this PR do?
Fixes an issue signing EIP155 transactions that have large chain ids. Without this change signing EIP155 transactions with a large chain id such as 9218438534861846528 creates an incorrect v value and when the transaction is decoded it has an incorrect chain id.

### Where should the reviewer start?
Look at the TransactionEncoder createEip155SignatureData method specifically line 67 to change the assignment of v from BigInteger.valueOf(chainId * 2) to BigInteger.valueOf(chainId).multiply(BigInteger.valueOf(2)

### Why is it needed?
Without this change large chain ids are not encoded correctly in the signature data for EIP155 transactions.

