### PR TITLE
Add support to generate both `call` and `send` functions in wrappers

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -1286,7 +1286,8 @@ public class SolidityFunctionWrapper extends Generator {
         return buildFunctions(functionDefinition, useUpperCase, false);
     }
 
-    List<MethodSpec> buildFunctions(AbiDefinition functionDefinition, boolean useUpperCase, boolean generateViceversa)
+    List<MethodSpec> buildFunctions(
+            AbiDefinition functionDefinition, boolean useUpperCase, boolean generateViceversa)
             throws ClassNotFoundException {
 
         List<MethodSpec> results = new ArrayList<>(2);
@@ -1333,7 +1334,12 @@ public class SolidityFunctionWrapper extends Generator {
                 results.add(methodBuilder.build());
             }
         } else {
-            buildTransactionFunction(functionDefinition, methodBuilder, inputParams, useUpperCase, generateViceversa);
+            buildTransactionFunction(
+                    functionDefinition,
+                    methodBuilder,
+                    inputParams,
+                    useUpperCase,
+                    generateViceversa);
             results.add(methodBuilder.build());
         }
 

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -121,7 +121,7 @@ public class SolidityFunctionWrapper extends Generator {
 
     private final boolean useNativeJavaTypes;
     private final boolean useJavaPrimitiveTypes;
-    private final boolean generateSendTxForCalls;
+    private final boolean generateBothCallAndSend;
 
     private final int addressLength;
 
@@ -143,19 +143,19 @@ public class SolidityFunctionWrapper extends Generator {
     }
 
     public SolidityFunctionWrapper(
-            boolean useNativeJavaTypes, int addressLength, boolean generateSendTxForCalls) {
-        this(useNativeJavaTypes, generateSendTxForCalls, false, addressLength);
+            boolean useNativeJavaTypes, int addressLength, boolean generateBothCallAndSend) {
+        this(useNativeJavaTypes, false, generateBothCallAndSend, addressLength);
     }
 
     public SolidityFunctionWrapper(
             boolean useNativeJavaTypes,
             boolean useJavaPrimitiveTypes,
-            boolean generateSendTxForCalls,
+            boolean generateBothCallAndSend,
             int addressLength) {
         this(
                 useNativeJavaTypes,
                 useJavaPrimitiveTypes,
-                generateSendTxForCalls,
+                generateBothCallAndSend,
                 addressLength,
                 new LogGenerationReporter(LOGGER));
     }
@@ -163,14 +163,14 @@ public class SolidityFunctionWrapper extends Generator {
     public SolidityFunctionWrapper(
             boolean useNativeJavaTypes,
             boolean useJavaPrimitiveTypes,
-            boolean generateSendTxForCalls,
+            boolean generateBothCallAndSend,
             int addressLength,
             GenerationReporter reporter) {
         this.useNativeJavaTypes = useNativeJavaTypes;
         this.useJavaPrimitiveTypes = useJavaPrimitiveTypes;
         this.addressLength = addressLength;
         this.reporter = reporter;
-        this.generateSendTxForCalls = generateSendTxForCalls;
+        this.generateBothCallAndSend = generateBothCallAndSend;
     }
 
     public void generateJavaFiles(
@@ -1283,6 +1283,11 @@ public class SolidityFunctionWrapper extends Generator {
 
     List<MethodSpec> buildFunctions(AbiDefinition functionDefinition, boolean useUpperCase)
             throws ClassNotFoundException {
+        return buildFunctions(functionDefinition, useUpperCase, false);
+    }
+
+    List<MethodSpec> buildFunctions(AbiDefinition functionDefinition, boolean useUpperCase, boolean generateViceversa)
+            throws ClassNotFoundException {
 
         List<MethodSpec> results = new ArrayList<>(2);
         String functionName = functionDefinition.getName();
@@ -1291,9 +1296,9 @@ public class SolidityFunctionWrapper extends Generator {
         boolean pureOrView = "pure".equals(stateMutability) || "view".equals(stateMutability);
         boolean isFunctionDefinitionConstant = functionDefinition.isConstant() || pureOrView;
 
-        if (generateSendTxForCalls) {
+        if (generateBothCallAndSend) {
             final String funcNamePrefix;
-            if (isFunctionDefinitionConstant) {
+            if (isFunctionDefinitionConstant ^ generateViceversa) {
                 funcNamePrefix = "call";
             } else {
                 funcNamePrefix = "send";
@@ -1315,7 +1320,7 @@ public class SolidityFunctionWrapper extends Generator {
         final List<TypeName> outputParameterTypes =
                 buildTypeNames(functionDefinition.getOutputs(), useJavaPrimitiveTypes);
 
-        if (isFunctionDefinitionConstant) {
+        if (isFunctionDefinitionConstant ^ generateViceversa) {
             // Avoid generating runtime exception call
             if (functionDefinition.hasOutputs()) {
                 buildConstantFunction(
@@ -1327,16 +1332,13 @@ public class SolidityFunctionWrapper extends Generator {
 
                 results.add(methodBuilder.build());
             }
-            if (generateSendTxForCalls) {
-                AbiDefinition sendFuncDefinition = new AbiDefinition(functionDefinition);
-                sendFuncDefinition.setConstant(false);
-                results.addAll(buildFunctions(sendFuncDefinition));
-            }
+        } else {
+            buildTransactionFunction(functionDefinition, methodBuilder, inputParams, useUpperCase, generateViceversa);
+            results.add(methodBuilder.build());
         }
 
-        if (!isFunctionDefinitionConstant) {
-            buildTransactionFunction(functionDefinition, methodBuilder, inputParams, useUpperCase);
-            results.add(methodBuilder.build());
+        if (generateBothCallAndSend && !generateViceversa) {
+            results.addAll(buildFunctions(functionDefinition, useUpperCase, true));
         }
 
         return results;
@@ -1483,10 +1485,11 @@ public class SolidityFunctionWrapper extends Generator {
             AbiDefinition functionDefinition,
             MethodSpec.Builder methodBuilder,
             String inputParams,
-            boolean useUpperCase)
+            boolean useUpperCase,
+            boolean isViceversa)
             throws ClassNotFoundException {
 
-        if (functionDefinition.hasOutputs()) {
+        if (functionDefinition.hasOutputs() && !isViceversa) {
             reporter.report(
                     String.format(
                             "Definition of the function %s returns a value but is not defined as a view function. "

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -40,7 +40,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
     public static final String COMMAND_PREFIX = COMMAND_SOLIDITY + " " + COMMAND_GENERATE;
 
     /*
-     * Usage: solidity generate [-hV] [-jt] [-st] -a=<abiFile> [-b=<binFile>]
+     * Usage: solidity generate [-hV] [-jt] [-st] [-B] -a=<abiFile> [-b=<binFile>]
      * -o=<destinationFileDir> -p=<packageName>
      * -h, --help                 Show this help message and exit.
      * -V, --version              Print version information and exit.
@@ -54,6 +54,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
      * -jt, --javaTypes       use native java types.
      * Default: true
      * -st, --solidityTypes   use solidity types.
+     * -B, --generateBoth     generate both call and send functions.
      */
 
     private final File binFile;
@@ -63,7 +64,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
 
     private final int addressLength;
 
-    private final boolean generateSendTxForCalls;
+    private final boolean generateBothCallAndSend;
 
     public SolidityFunctionWrapperGenerator(
             File binFile,
@@ -96,7 +97,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
             String basePackageName,
             boolean useJavaNativeTypes,
             boolean useJavaPrimitiveTypes,
-            boolean generateSendTxForCalls,
+            boolean generateBothCallAndSend,
             Class<? extends Contract> contractClass,
             int addressLength) {
 
@@ -111,7 +112,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
         this.abiFile = abiFile;
         this.contractName = contractName;
         this.addressLength = addressLength;
-        this.generateSendTxForCalls = generateSendTxForCalls;
+        this.generateBothCallAndSend = generateBothCallAndSend;
     }
 
     protected List<AbiDefinition> loadContractDefinition(File absFile) throws IOException {
@@ -136,7 +137,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
             new SolidityFunctionWrapper(
                             useJavaNativeTypes,
                             useJavaPrimitiveTypes,
-                            generateSendTxForCalls,
+                            generateBothCallAndSend,
                             addressLength)
                     .generateJavaFiles(
                             contractClass,
@@ -228,6 +229,12 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
                 required = false)
         private boolean primitiveTypes = false;
 
+        @Option(
+                names = {"-B", "--generateBoth"},
+                description = "generate both call and send functions.",
+                required = false)
+        private boolean generateBothCallAndSend;
+
         @Override
         public void run() {
             try {
@@ -247,6 +254,8 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
                                 packageName,
                                 useJavaTypes,
                                 primitiveTypes,
+                                generateBothCallAndSend,
+                                Contract.class,
                                 addressLength)
                         .generate();
             } catch (Exception e) {

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -758,7 +758,6 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         assertEquals(builder.build().toString(), (expected));
     }
 
-
     @Test
     public void testBuildFunctionTransactionAndCall() throws Exception {
         AbiDefinition functionDefinition =
@@ -770,7 +769,8 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         "type",
                         false);
 
-        List<MethodSpec> methodSpecs = solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
+        List<MethodSpec> methodSpecs =
+                solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
 
         String expectedSend =
                 "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> send_functionName(java.math.BigInteger param) {\n"
@@ -805,7 +805,8 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         "type",
                         false);
 
-        List<MethodSpec> methodSpecs = solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
+        List<MethodSpec> methodSpecs =
+                solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
 
         String expectedCall =
                 "public org.web3j.protocol.core.RemoteFunctionCall<java.math.BigInteger> call_functionName(java.math.BigInteger param) {\n"
@@ -828,5 +829,4 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         assertEquals(expectedCall, methodSpecs.get(0).toString());
         assertEquals(expectedSend, methodSpecs.get(1).toString());
     }
-
 }

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -56,6 +56,7 @@ import static org.web3j.codegen.SolidityFunctionWrapper.getNativeType;
 public class SolidityFunctionWrapperTest extends TempFileProvider {
 
     private SolidityFunctionWrapper solidityFunctionWrapper;
+    private SolidityFunctionWrapper solidityFunctionWrapperBoth;
 
     private GenerationReporter generationReporter;
 
@@ -67,6 +68,9 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
         solidityFunctionWrapper =
                 new SolidityFunctionWrapper(
                         true, false, false, Address.DEFAULT_LENGTH, generationReporter);
+        solidityFunctionWrapperBoth =
+                new SolidityFunctionWrapper(
+                        true, false, true, Address.DEFAULT_LENGTH, generationReporter);
     }
 
     @Test
@@ -753,4 +757,76 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
 
         assertEquals(builder.build().toString(), (expected));
     }
+
+
+    @Test
+    public void testBuildFunctionTransactionAndCall() throws Exception {
+        AbiDefinition functionDefinition =
+                new AbiDefinition(
+                        false,
+                        Arrays.asList(new NamedType("param", "uint8")),
+                        "functionName",
+                        Arrays.asList(new NamedType("result", "int8")),
+                        "type",
+                        false);
+
+        List<MethodSpec> methodSpecs = solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
+
+        String expectedSend =
+                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> send_functionName(java.math.BigInteger param) {\n"
+                        + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
+                        + "      FUNC_FUNCTIONNAME, \n"
+                        + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
+                        + "      java.util.Collections.<org.web3j.abi.TypeReference<?>>emptyList());\n"
+                        + "  return executeRemoteCallTransaction(function);\n"
+                        + "}\n";
+
+        String expectedCall =
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.math.BigInteger> call_functionName(java.math.BigInteger param) {\n"
+                        + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
+                        + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
+                        + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}));\n"
+                        + "  return executeRemoteCallSingleValueReturn(function, java.math.BigInteger.class);\n"
+                        + "}\n";
+
+        assertEquals(2, methodSpecs.size());
+        assertEquals(expectedSend, methodSpecs.get(0).toString());
+        assertEquals(expectedCall, methodSpecs.get(1).toString());
+    }
+
+    @Test
+    public void testBuildFunctionConstantSingleValueReturnAndTransaction() throws Exception {
+        AbiDefinition functionDefinition =
+                new AbiDefinition(
+                        true,
+                        Arrays.asList(new NamedType("param", "uint8")),
+                        "functionName",
+                        Arrays.asList(new NamedType("result", "int8")),
+                        "type",
+                        false);
+
+        List<MethodSpec> methodSpecs = solidityFunctionWrapperBoth.buildFunctions(functionDefinition);
+
+        String expectedCall =
+                "public org.web3j.protocol.core.RemoteFunctionCall<java.math.BigInteger> call_functionName(java.math.BigInteger param) {\n"
+                        + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_FUNCTIONNAME, \n"
+                        + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
+                        + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.generated.Int8>() {}));\n"
+                        + "  return executeRemoteCallSingleValueReturn(function, java.math.BigInteger.class);\n"
+                        + "}\n";
+
+        String expectedSend =
+                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> send_functionName(java.math.BigInteger param) {\n"
+                        + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
+                        + "      FUNC_FUNCTIONNAME, \n"
+                        + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
+                        + "      java.util.Collections.<org.web3j.abi.TypeReference<?>>emptyList());\n"
+                        + "  return executeRemoteCallTransaction(function);\n"
+                        + "}\n";
+
+        assertEquals(2, methodSpecs.size());
+        assertEquals(expectedCall, methodSpecs.get(0).toString());
+        assertEquals(expectedSend, methodSpecs.get(1).toString());
+    }
+
 }


### PR DESCRIPTION
### What does this PR do?
- replace the broken generateSendTxForCalls flag with generateBothCallAndSend
- keep backward compatibility
- add -B / --generateBoth flag to CLI
- add tests
- fix an ordering bug in construstor arguments

### Where should the reviewer start?
What does it mean?! :-)

### Why is it needed?
Because it fixes bugs and add the ability to call methods without sending transactions.

