### PR TITLE
Fix ClassCastException when using native types (default) and arrays.

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/Array.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/Array.java
@@ -14,6 +14,7 @@ package org.web3j.abi.datatypes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -65,6 +66,14 @@ public abstract class Array<T extends Type> implements Type<List<T>> {
     @Override
     public List<T> getValue() {
         return value;
+    }
+
+    public List<Object> getNativeValueCopy() {
+        List<Object> copy = new ArrayList<>(value.size());
+        for (T t : value) {
+            copy.add(t.getValue());
+        }
+        return Collections.unmodifiableList(copy);
     }
 
     public Class<T> getComponentType() {

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -1778,7 +1778,8 @@ public class SolidityFunctionWrapper extends Generator {
             }
             if (needsArrayCast) {
                 builder.addStatement(
-                        "$L.$L = ($T) (($T) eventValues.getIndexedValues().get($L))" + nativeConversion,
+                        "$L.$L = ($T) (($T) eventValues.getIndexedValues().get($L))"
+                                + nativeConversion,
                         objectName,
                         namedTypeName.getName(),
                         indexedEventWrapperType,
@@ -1826,7 +1827,8 @@ public class SolidityFunctionWrapper extends Generator {
             }
             if (needsArrayCast) {
                 builder.addStatement(
-                        "$L.$L = ($T) (($T) eventValues.getNonIndexedValues().get($L))" + nativeConversion,
+                        "$L.$L = ($T) (($T) eventValues.getNonIndexedValues().get($L))"
+                                + nativeConversion,
                         objectName,
                         namedTypeName.getName(),
                         nonIndexedEventWrapperType,

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -50,6 +50,7 @@ import org.web3j.abi.EventEncoder;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Array;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicStruct;
 import org.web3j.abi.datatypes.Event;
@@ -1751,12 +1752,18 @@ public class SolidityFunctionWrapper extends Generator {
         for (int i = 0; i < indexedParameters.size(); i++) {
             final NamedTypeName namedTypeName = indexedParameters.get(i);
             final String nativeConversion;
+            boolean needsArrayCast = false;
             if (useNativeJavaTypes
                     && structClassNameMap.values().stream()
                             .map(ClassName::simpleName)
                             .noneMatch(
                                     name -> name.equals(namedTypeName.getTypeName().toString()))) {
-                nativeConversion = ".getValue()";
+                if (namedTypeName.typeName instanceof ParameterizedTypeName) {
+                    nativeConversion = ".getNativeValueCopy()";
+                    needsArrayCast = true;
+                } else {
+                    nativeConversion = ".getValue()";
+                }
             } else {
                 nativeConversion = "";
             }
@@ -1769,23 +1776,39 @@ public class SolidityFunctionWrapper extends Generator {
             } else {
                 indexedEventWrapperType = getIndexedEventWrapperType(namedTypeName.getTypeName());
             }
-            builder.addStatement(
-                    "$L.$L = ($T) eventValues.getIndexedValues().get($L)" + nativeConversion,
-                    objectName,
-                    namedTypeName.getName(),
-                    indexedEventWrapperType,
-                    i);
+            if (needsArrayCast) {
+                builder.addStatement(
+                        "$L.$L = ($T) (($T) eventValues.getIndexedValues().get($L))" + nativeConversion,
+                        objectName,
+                        namedTypeName.getName(),
+                        indexedEventWrapperType,
+                        Array.class,
+                        i);
+            } else {
+                builder.addStatement(
+                        "$L.$L = ($T) eventValues.getIndexedValues().get($L)" + nativeConversion,
+                        objectName,
+                        namedTypeName.getName(),
+                        indexedEventWrapperType,
+                        i);
+            }
         }
 
         for (int i = 0; i < nonIndexedParameters.size(); i++) {
             final NamedTypeName namedTypeName = nonIndexedParameters.get(i);
             final String nativeConversion;
+            boolean needsArrayCast = false;
             if (useNativeJavaTypes
                     && structClassNameMap.values().stream()
                             .map(ClassName::simpleName)
                             .noneMatch(
                                     name -> name.equals(namedTypeName.getTypeName().toString()))) {
-                nativeConversion = ".getValue()";
+                if (namedTypeName.typeName instanceof ParameterizedTypeName) {
+                    nativeConversion = ".getNativeValueCopy()";
+                    needsArrayCast = true;
+                } else {
+                    nativeConversion = ".getValue()";
+                }
             } else {
                 nativeConversion = "";
             }
@@ -1801,12 +1824,22 @@ public class SolidityFunctionWrapper extends Generator {
                 nonIndexedEventWrapperType =
                         getWrapperType(nonIndexedParameters.get(i).getTypeName());
             }
-            builder.addStatement(
-                    "$L.$L = ($T) eventValues.getNonIndexedValues().get($L)" + nativeConversion,
-                    objectName,
-                    namedTypeName.getName(),
-                    nonIndexedEventWrapperType,
-                    i);
+            if (needsArrayCast) {
+                builder.addStatement(
+                        "$L.$L = ($T) (($T) eventValues.getNonIndexedValues().get($L))" + nativeConversion,
+                        objectName,
+                        namedTypeName.getName(),
+                        nonIndexedEventWrapperType,
+                        Array.class,
+                        i);
+            } else {
+                builder.addStatement(
+                        "$L.$L = ($T) eventValues.getNonIndexedValues().get($L)" + nativeConversion,
+                        objectName,
+                        namedTypeName.getName(),
+                        nonIndexedEventWrapperType,
+                        i);
+            }
         }
         return builder.build();
     }

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -731,6 +731,62 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
+    public void testBuildEventWithNativeList() throws Exception {
+
+        NamedType array = new NamedType("array", "uint256[]");
+
+        AbiDefinition functionDefinition =
+                new AbiDefinition(
+                        false, Arrays.asList(array), "Transfer", new ArrayList<>(), "event", false);
+        TypeSpec.Builder builder = TypeSpec.classBuilder("testClass");
+
+        builder.addMethods(
+                solidityFunctionWrapper.buildEventFunctions(functionDefinition, builder));
+
+        String expected =
+                "class testClass {\n"
+                        + "  public static final org.web3j.abi.datatypes.Event TRANSFER_EVENT = new org.web3j.abi.datatypes.Event(\"Transfer\", \n"
+                        + "      java.util.Arrays.<org.web3j.abi.TypeReference<?>>asList(new org.web3j.abi.TypeReference<org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint256>>() {}));\n  ;\n\n"
+                        + "  public java.util.List<TransferEventResponse> getTransferEvents(org.web3j.protocol.core.methods.response.TransactionReceipt transactionReceipt) {\n"
+                        + "    java.util.List<org.web3j.tx.Contract.EventValuesWithLog> valueList = extractEventParametersWithLog(TRANSFER_EVENT, transactionReceipt);\n"
+                        + "    java.util.ArrayList<TransferEventResponse> responses = new java.util.ArrayList<TransferEventResponse>(valueList.size());\n"
+                        + "    for (org.web3j.tx.Contract.EventValuesWithLog eventValues : valueList) {\n"
+                        + "      TransferEventResponse typedResponse = new TransferEventResponse();\n"
+                        + "      typedResponse.log = eventValues.getLog();\n"
+                        + "      typedResponse.array = (java.util.List<java.math.BigInteger>) ((org.web3j.abi.datatypes.Array) eventValues.getNonIndexedValues().get(0)).getNativeValueCopy();\n"
+                        + "      responses.add(typedResponse);\n"
+                        + "    }\n"
+                        + "    return responses;\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<TransferEventResponse> transferEventFlowable(org.web3j.protocol.core.methods.request.EthFilter filter) {\n"
+                        + "    return web3j.ethLogFlowable(filter).map(new io.reactivex.functions.Function<org.web3j.protocol.core.methods.response.Log, TransferEventResponse>() {\n"
+                        + "      @java.lang.Override\n"
+                        + "      public TransferEventResponse apply(org.web3j.protocol.core.methods.response.Log log) {\n"
+                        + "        org.web3j.tx.Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(TRANSFER_EVENT, log);\n"
+                        + "        TransferEventResponse typedResponse = new TransferEventResponse();\n"
+                        + "        typedResponse.log = log;\n"
+                        + "        typedResponse.array = (java.util.List<java.math.BigInteger>) ((org.web3j.abi.datatypes.Array) eventValues.getNonIndexedValues().get(0)).getNativeValueCopy();\n"
+                        + "        return typedResponse;\n"
+                        + "      }\n"
+                        + "    });\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public io.reactivex.Flowable<TransferEventResponse> transferEventFlowable(org.web3j.protocol.core.DefaultBlockParameter startBlock, org.web3j.protocol.core.DefaultBlockParameter endBlock) {\n"
+                        + "    org.web3j.protocol.core.methods.request.EthFilter filter = new org.web3j.protocol.core.methods.request.EthFilter(startBlock, endBlock, getContractAddress());\n"
+                        + "    filter.addSingleTopic(org.web3j.abi.EventEncoder.encode(TRANSFER_EVENT));\n"
+                        + "    return transferEventFlowable(filter);\n"
+                        + "  }\n"
+                        + "\n"
+                        + "  public static class TransferEventResponse extends org.web3j.protocol.core.methods.response.BaseEventResponse {\n"
+                        + "    public java.util.List<java.math.BigInteger> array;\n"
+                        + "  }\n"
+                        + "}\n";
+
+        assertEquals(builder.build().toString(), (expected));
+    }
+
+    @Test
     public void testBuildFuncNameConstants() throws Exception {
         AbiDefinition functionDefinition =
                 new AbiDefinition(


### PR DESCRIPTION
### What does this PR do?
`getValue` on `Array` types doesn't automatically return a List of
native types, but a List of solidity types, that generates a
ClassCastException at runtime. This patch fixes it, by adding a new
function in `Array` class and using it in the generated code.

### Why is it needed?
To avoid ClassCastException
