### PR TITLE
Fix NPE when `eth_getFilterLogs` returns an error at filter init.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -116,6 +116,10 @@ public abstract class Filter<T> {
                 ethLog.setResult(Collections.emptyList());
             }
 
+            if (ethLog.hasError()) {
+                throwException(ethLog.getError());
+            }
+
             process(ethLog.getLogs());
 
         } catch (IOException e) {


### PR DESCRIPTION
### What does this PR do?
Replace a NullPointerException with the underlying RPC exception.

### Why is it needed?
To avoid wasting hours to understand why the filters are not working.

