### PR TITLE
Fix reinstallFilter interrupting its own thread, causing InterruptedI…

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -155,7 +155,7 @@ public abstract class Filter<T> {
 
     private void reinstallFilter() {
         log.warn("The filter has not been found. Filter id: " + filterId);
-        schedule.cancel(true);
+        schedule.cancel(false);
         this.run(scheduledExecutorService, blockTime);
     }
 


### PR DESCRIPTION
…OException when installing new filters

### What does this PR do?
Fixes the issue where an InterruptedIOException is thrown when reinstalling filters after a network issue or the geth node restarting. This is caused by a ScheduledFuture execution being cancelled with interruption enabled from within its execution. The fix disables the interruption.

### Where should the reviewer start?
Only one line is changed: line 158 of Filter.java

### Why is it needed?
Reinstallation of filters after a network issue or geth node restart is currently impossible other than restarting the app using the web3j module.

