### PR TITLE
Add support for decoding EIP1559 transaction hex string.

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -12,10 +12,6 @@
  */
 package org.web3j.crypto;
 
-import java.math.BigInteger;
-import java.security.SignatureException;
-import java.util.Arrays;
-
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
@@ -24,8 +20,11 @@ import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
-
 import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.util.Arrays;
 
 import static org.bouncycastle.util.BigIntegers.TWO;
 import static org.web3j.crypto.SignatureDataOperations.CHAIN_ID_INC;
@@ -286,6 +285,17 @@ public class Sign {
             throw new RuntimeException(String.format("Unsupported format exception", v));
         }
     }
+
+    /**
+     * Returns the header 'v'.
+     *
+     * @param recId The recovery id.
+     * @return byte[] header 'v'.
+     */
+    public static byte[] getVFromRecId(int recId) {
+        return new byte[]{(byte) (LOWER_REAL_V + recId)};
+    }
+
     /**
      * Returns public key from the given private key.
      *

--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -12,6 +12,10 @@
  */
 package org.web3j.crypto;
 
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.util.Arrays;
+
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
@@ -20,11 +24,8 @@ import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
-import org.web3j.utils.Numeric;
 
-import java.math.BigInteger;
-import java.security.SignatureException;
-import java.util.Arrays;
+import org.web3j.utils.Numeric;
 
 import static org.bouncycastle.util.BigIntegers.TWO;
 import static org.web3j.crypto.SignatureDataOperations.CHAIN_ID_INC;
@@ -293,7 +294,7 @@ public class Sign {
      * @return byte[] header 'v'.
      */
     public static byte[] getVFromRecId(int recId) {
-        return new byte[]{(byte) (LOWER_REAL_V + recId)};
+        return new byte[] {(byte) (LOWER_REAL_V + recId)};
     }
 
     /**

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -12,17 +12,71 @@
  */
 package org.web3j.crypto;
 
-import java.math.BigInteger;
-
+import org.web3j.crypto.transaction.type.TransactionType;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;
 import org.web3j.utils.Numeric;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 public class TransactionDecoder {
+    private static final int UNSIGNED_EIP1559TX_RLP_LIST_SIZE = 9;
 
     public static RawTransaction decode(final String hexTransaction) {
         final byte[] transaction = Numeric.hexStringToByteArray(hexTransaction);
+        if (getTransactionType(transaction) == TransactionType.EIP1559) {
+            return decodeEIP1559Transaction(transaction);
+        }
+        return decodeLegacyTransaction(transaction);
+    }
+
+    private static TransactionType getTransactionType(final byte[] transaction) {
+        // The first byte indicates a transaction type.
+        byte firstByte = transaction[0];
+        if (firstByte == TransactionType.EIP1559.getRlpType())
+            return TransactionType.EIP1559;
+        return TransactionType.LEGACY;
+    }
+
+    private static RawTransaction decodeEIP1559Transaction(final byte[] transaction) {
+        final byte[] encodedTx = Arrays.copyOfRange(transaction, 1, transaction.length);
+        final RlpList rlpList = RlpDecoder.decode(encodedTx);
+        final RlpList values = (RlpList) rlpList.getValues().get(0);
+
+        final long chainId = ((RlpString) values.getValues().get(0)).asPositiveBigInteger().longValue();
+        final BigInteger nonce = ((RlpString) values.getValues().get(1)).asPositiveBigInteger();
+        final BigInteger maxPriorityFeePerGas = ((RlpString) values.getValues().get(2)).asPositiveBigInteger();
+        final BigInteger maxFeePerGas = ((RlpString) values.getValues().get(3)).asPositiveBigInteger();
+        final BigInteger gasLimit = ((RlpString) values.getValues().get(4)).asPositiveBigInteger();
+        final String to = ((RlpString) values.getValues().get(5)).asString();
+
+        final BigInteger value = ((RlpString) values.getValues().get(6)).asPositiveBigInteger();
+        final String data = ((RlpString) values.getValues().get(7)).asString();
+
+        final RawTransaction rawTransaction = RawTransaction.createTransaction(chainId, nonce, gasLimit, to, value, data,
+                maxPriorityFeePerGas, maxFeePerGas);
+
+        if (values.getValues().size() == UNSIGNED_EIP1559TX_RLP_LIST_SIZE) {
+            return rawTransaction;
+        } else {
+            final byte[] v = Sign.getVFromRecId(
+                    Numeric.toBigInt(((RlpString) values.getValues().get(9)).getBytes()).intValue());
+            final byte[] r =
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(10)).getBytes()),
+                            32);
+            final byte[] s =
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(11)).getBytes()),
+                            32);
+            final Sign.SignatureData signatureData = new Sign.SignatureData(v, r, s);
+            return new SignedRawTransaction(rawTransaction.getTransaction(), signatureData);
+        }
+    }
+
+    private static RawTransaction decodeLegacyTransaction(final byte[] transaction) {
         final RlpList rlpList = RlpDecoder.decode(transaction);
         final RlpList values = (RlpList) rlpList.getValues().get(0);
         final BigInteger nonce = ((RlpString) values.getValues().get(0)).asPositiveBigInteger();

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -12,14 +12,14 @@
  */
 package org.web3j.crypto;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import org.web3j.crypto.transaction.type.TransactionType;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;
 import org.web3j.utils.Numeric;
-
-import java.math.BigInteger;
-import java.util.Arrays;
 
 public class TransactionDecoder {
     private static final int UNSIGNED_EIP1559TX_RLP_LIST_SIZE = 9;
@@ -35,8 +35,7 @@ public class TransactionDecoder {
     private static TransactionType getTransactionType(final byte[] transaction) {
         // The first byte indicates a transaction type.
         byte firstByte = transaction[0];
-        if (firstByte == TransactionType.EIP1559.getRlpType())
-            return TransactionType.EIP1559;
+        if (firstByte == TransactionType.EIP1559.getRlpType()) return TransactionType.EIP1559;
         return TransactionType.LEGACY;
     }
 
@@ -45,24 +44,37 @@ public class TransactionDecoder {
         final RlpList rlpList = RlpDecoder.decode(encodedTx);
         final RlpList values = (RlpList) rlpList.getValues().get(0);
 
-        final long chainId = ((RlpString) values.getValues().get(0)).asPositiveBigInteger().longValue();
+        final long chainId =
+                ((RlpString) values.getValues().get(0)).asPositiveBigInteger().longValue();
         final BigInteger nonce = ((RlpString) values.getValues().get(1)).asPositiveBigInteger();
-        final BigInteger maxPriorityFeePerGas = ((RlpString) values.getValues().get(2)).asPositiveBigInteger();
-        final BigInteger maxFeePerGas = ((RlpString) values.getValues().get(3)).asPositiveBigInteger();
+        final BigInteger maxPriorityFeePerGas =
+                ((RlpString) values.getValues().get(2)).asPositiveBigInteger();
+        final BigInteger maxFeePerGas =
+                ((RlpString) values.getValues().get(3)).asPositiveBigInteger();
         final BigInteger gasLimit = ((RlpString) values.getValues().get(4)).asPositiveBigInteger();
         final String to = ((RlpString) values.getValues().get(5)).asString();
 
         final BigInteger value = ((RlpString) values.getValues().get(6)).asPositiveBigInteger();
         final String data = ((RlpString) values.getValues().get(7)).asString();
 
-        final RawTransaction rawTransaction = RawTransaction.createTransaction(chainId, nonce, gasLimit, to, value, data,
-                maxPriorityFeePerGas, maxFeePerGas);
+        final RawTransaction rawTransaction =
+                RawTransaction.createTransaction(
+                        chainId,
+                        nonce,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas);
 
         if (values.getValues().size() == UNSIGNED_EIP1559TX_RLP_LIST_SIZE) {
             return rawTransaction;
         } else {
-            final byte[] v = Sign.getVFromRecId(
-                    Numeric.toBigInt(((RlpString) values.getValues().get(9)).getBytes()).intValue());
+            final byte[] v =
+                    Sign.getVFromRecId(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(9)).getBytes())
+                                    .intValue());
             final byte[] r =
                     Numeric.toBytesPadded(
                             Numeric.toBigInt(((RlpString) values.getValues().get(10)).getBytes()),

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -12,16 +12,14 @@
  */
 package org.web3j.crypto;
 
-import java.math.BigInteger;
-
 import org.junit.jupiter.api.Test;
-
+import org.web3j.crypto.transaction.type.Transaction1559;
 import org.web3j.utils.Numeric;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.math.BigInteger;
+import java.security.SignatureException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransactionDecoderTest {
 
@@ -118,5 +116,76 @@ public class TransactionDecoderTest {
         RawTransaction result = TransactionDecoder.decode(hexTransaction);
         SignedRawTransaction signedResult = (SignedRawTransaction) result;
         assertEquals("0x1b609b03e2e9b0275a61fa5c69a8f32550285536", signedResult.getFrom());
+    }
+
+    @Test
+    public void testDecoding1559() {
+        final RawTransaction rawTransaction = createEip1559RawTransaction();
+        final Transaction1559 transaction1559 = (Transaction1559) rawTransaction.getTransaction();
+
+        final byte[] encodedMessage = TransactionEncoder.encode(rawTransaction);
+        final String hexMessage = Numeric.toHexString(encodedMessage);
+
+        final RawTransaction result = TransactionDecoder.decode(hexMessage);
+        assertTrue(result.getTransaction() instanceof Transaction1559);
+        final Transaction1559 resultTransaction1559 = (Transaction1559) result.getTransaction();
+
+        assertNotNull(result);
+        assertEquals(transaction1559.getChainId(), resultTransaction1559.getChainId());
+        assertEquals(transaction1559.getNonce(), resultTransaction1559.getNonce());
+        assertEquals(transaction1559.getMaxFeePerGas(), resultTransaction1559.getMaxFeePerGas());
+        assertEquals(transaction1559.getMaxPriorityFeePerGas(), resultTransaction1559.getMaxPriorityFeePerGas());
+        assertEquals(transaction1559.getGasLimit(), resultTransaction1559.getGasLimit());
+        assertEquals(transaction1559.getTo(), resultTransaction1559.getTo());
+        assertEquals(transaction1559.getValue(), resultTransaction1559.getValue());
+        assertEquals(transaction1559.getData(), resultTransaction1559.getData());
+    }
+
+    @Test
+    public void testDecodingSigned1559() throws SignatureException {
+        final RawTransaction rawTransaction = createEip1559RawTransaction();
+        final Transaction1559 transaction1559 = (Transaction1559) rawTransaction.getTransaction();
+
+        final byte[] signedMessage =
+                TransactionEncoder.signMessage(rawTransaction, SampleKeys.CREDENTIALS);
+        final String signedHexMessage = Numeric.toHexString(signedMessage);
+
+
+        final RawTransaction result = TransactionDecoder.decode(signedHexMessage);
+        assertTrue(result.getTransaction() instanceof Transaction1559);
+        final Transaction1559 resultTransaction1559 = (Transaction1559) result.getTransaction();
+
+        assertNotNull(result);
+        assertEquals(transaction1559.getChainId(), resultTransaction1559.getChainId());
+        assertEquals(transaction1559.getNonce(), resultTransaction1559.getNonce());
+        assertEquals(transaction1559.getMaxFeePerGas(), resultTransaction1559.getMaxFeePerGas());
+        assertEquals(transaction1559.getMaxPriorityFeePerGas(), resultTransaction1559.getMaxPriorityFeePerGas());
+        assertEquals(transaction1559.getGasLimit(), resultTransaction1559.getGasLimit());
+        assertEquals(transaction1559.getTo(), resultTransaction1559.getTo());
+        assertEquals(transaction1559.getValue(), resultTransaction1559.getValue());
+        assertEquals(transaction1559.getData(), resultTransaction1559.getData());
+
+        assertTrue(result instanceof SignedRawTransaction);
+        final SignedRawTransaction signedResult = (SignedRawTransaction) result;
+        assertNotNull(signedResult.getSignatureData());
+
+        final Sign.SignatureData signatureData = signedResult.getSignatureData();
+        final byte[] encodedTransaction = TransactionEncoder.encode(rawTransaction);
+        final BigInteger key = Sign.signedMessageToKey(encodedTransaction, signatureData);
+        assertEquals(key, SampleKeys.PUBLIC_KEY);
+        assertEquals(SampleKeys.ADDRESS, signedResult.getFrom());
+        signedResult.verify(SampleKeys.ADDRESS);
+        assertNull(signedResult.getChainId());
+    }
+
+    private static RawTransaction createEip1559RawTransaction() {
+        return RawTransaction.createEtherTransaction(
+                3L,
+                BigInteger.valueOf(0),
+                BigInteger.valueOf(30000),
+                "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+                BigInteger.valueOf(123),
+                BigInteger.valueOf(5678),
+                BigInteger.valueOf(1100000));
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -12,12 +12,13 @@
  */
 package org.web3j.crypto;
 
-import org.junit.jupiter.api.Test;
-import org.web3j.crypto.transaction.type.Transaction1559;
-import org.web3j.utils.Numeric;
-
 import java.math.BigInteger;
 import java.security.SignatureException;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.crypto.transaction.type.Transaction1559;
+import org.web3j.utils.Numeric;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -134,7 +135,9 @@ public class TransactionDecoderTest {
         assertEquals(transaction1559.getChainId(), resultTransaction1559.getChainId());
         assertEquals(transaction1559.getNonce(), resultTransaction1559.getNonce());
         assertEquals(transaction1559.getMaxFeePerGas(), resultTransaction1559.getMaxFeePerGas());
-        assertEquals(transaction1559.getMaxPriorityFeePerGas(), resultTransaction1559.getMaxPriorityFeePerGas());
+        assertEquals(
+                transaction1559.getMaxPriorityFeePerGas(),
+                resultTransaction1559.getMaxPriorityFeePerGas());
         assertEquals(transaction1559.getGasLimit(), resultTransaction1559.getGasLimit());
         assertEquals(transaction1559.getTo(), resultTransaction1559.getTo());
         assertEquals(transaction1559.getValue(), resultTransaction1559.getValue());
@@ -150,7 +153,6 @@ public class TransactionDecoderTest {
                 TransactionEncoder.signMessage(rawTransaction, SampleKeys.CREDENTIALS);
         final String signedHexMessage = Numeric.toHexString(signedMessage);
 
-
         final RawTransaction result = TransactionDecoder.decode(signedHexMessage);
         assertTrue(result.getTransaction() instanceof Transaction1559);
         final Transaction1559 resultTransaction1559 = (Transaction1559) result.getTransaction();
@@ -159,7 +161,9 @@ public class TransactionDecoderTest {
         assertEquals(transaction1559.getChainId(), resultTransaction1559.getChainId());
         assertEquals(transaction1559.getNonce(), resultTransaction1559.getNonce());
         assertEquals(transaction1559.getMaxFeePerGas(), resultTransaction1559.getMaxFeePerGas());
-        assertEquals(transaction1559.getMaxPriorityFeePerGas(), resultTransaction1559.getMaxPriorityFeePerGas());
+        assertEquals(
+                transaction1559.getMaxPriorityFeePerGas(),
+                resultTransaction1559.getMaxPriorityFeePerGas());
         assertEquals(transaction1559.getGasLimit(), resultTransaction1559.getGasLimit());
         assertEquals(transaction1559.getTo(), resultTransaction1559.getTo());
         assertEquals(transaction1559.getValue(), resultTransaction1559.getValue());

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -20,7 +20,10 @@ import org.junit.jupiter.api.Test;
 import org.web3j.crypto.transaction.type.Transaction1559;
 import org.web3j.utils.Numeric;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TransactionDecoderTest {
 


### PR DESCRIPTION
### What does this PR do?
*TransactionDecoder currently supports only decoding of legacy transaction hex string to a RawTransaction instance. This PR add implementation required to support the decoding of EIP1559 transaction hex string.*

### Where should the reviewer start?
*Reviewers can start looking at the TransactionDecoder class followed by the unit tests.*

### Why is it needed?
*It is needed to decode eip1559 transaction hex string to its corresponding RawTransaction.*

