### PR TITLE
Fix No virtual method longValueExact() on android

### DIFF
--- a/core/src/main/java/org/web3j/ens/EnsResolver.java
+++ b/core/src/main/java/org/web3j/ens/EnsResolver.java
@@ -156,7 +156,7 @@ public class EnsResolver {
         } else {
             EthBlock ethBlock =
                     web3j.ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false).send();
-            long timestamp = ethBlock.getBlock().getTimestamp().longValueExact() * 1000;
+            long timestamp = ethBlock.getBlock().getTimestamp().longValue() * 1000;
 
             return System.currentTimeMillis() - syncThreshold < timestamp;
         }

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -252,7 +252,9 @@ public class Transaction {
     // https://github.com/ethereum/go-ethereum/issues/3339
     public void setV(Object v) {
         if (v instanceof String) {
-            this.v = Numeric.toBigInt((String) v).longValueExact();
+            // longValueExact() is not implemented on android 11 or later only on 12 so it was
+            // replaced with longValue.
+            this.v = Numeric.toBigInt((String) v).longValue();
         } else if (v instanceof Integer) {
             this.v = ((Integer) v).longValue();
         } else {
@@ -260,9 +262,9 @@ public class Transaction {
         }
     }
 
-    // public void setV(byte v) {
-    //     this.v = v;
-    // }
+    //    public void setV(byte v) {
+    //        this.v = v;
+    //    }
 
     public Long getChainId() {
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {


### PR DESCRIPTION

## What does this PR do?
Fix No virtual method longValueExact() on android

### Where should the reviewer start?
Changed files

### Why is it needed?
`longValueExact` is not implemented in android yet and transactions cannot be deserialized, but l`ongValue  is  
