### PR TITLE
JSON-RPC error details

### DIFF
--- a/core/src/main/java/org/web3j/protocol/exceptions/JsonRpcError.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/JsonRpcError.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.exceptions;
+
+import org.web3j.protocol.core.Response;
+
+/**
+ * Exception encapsulating JSON-RPC error object.
+ *
+ * @see <a href="https://www.jsonrpc.org/specification#error_object">error_object</a>
+ */
+public class JsonRpcError extends RuntimeException {
+
+    private final int code;
+    private final Object data;
+
+    public JsonRpcError(int code, String message, Object data) {
+        super(message);
+        this.code = code;
+        this.data = data;
+    }
+
+    public JsonRpcError(Response.Error error) {
+        this(error.getCode(), error.getMessage(), error.getData());
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public Object getData() {
+        return data;
+    }
+}

--- a/core/src/main/java/org/web3j/tx/TransactionManager.java
+++ b/core/src/main/java/org/web3j/tx/TransactionManager.java
@@ -21,6 +21,7 @@ import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.JsonRpcError;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.tx.response.PollingTransactionReceiptProcessor;
@@ -171,9 +172,7 @@ public abstract class TransactionManager {
     protected TransactionReceipt processResponse(EthSendTransaction transactionResponse)
             throws IOException, TransactionException {
         if (transactionResponse.hasError()) {
-            throw new RuntimeException(
-                    "Error processing transaction request: "
-                            + transactionResponse.getError().getMessage());
+            throw new JsonRpcError(transactionResponse.getError());
         }
 
         String transactionHash = transactionResponse.getTransactionHash();


### PR DESCRIPTION
### What does this PR do?
It encapsulates all fields in JSON-RPC error into an Exception so that they are available to the caller.

### Where should the reviewer start?
[issue 1531](https://github.com/web3j/web3j/issues/1531)

### Why is it needed?
Fix for [issue 1531](https://github.com/web3j/web3j/issues/1531)

