### PR TITLE
generate call and send for transaction functions

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -1333,7 +1333,7 @@ public class SolidityFunctionWrapper extends Generator {
 
         if (generateBothCallAndSend) {
             final String funcNamePrefix;
-            if (isFunctionDefinitionConstant ^ generateViceversa) {
+            if (isFunctionDefinitionConstant || generateViceversa) {
                 funcNamePrefix = "call";
             } else {
                 funcNamePrefix = "send";
@@ -1355,7 +1355,7 @@ public class SolidityFunctionWrapper extends Generator {
         final List<TypeName> outputParameterTypes =
                 buildTypeNames(functionDefinition.getOutputs(), useJavaPrimitiveTypes);
 
-        if (isFunctionDefinitionConstant ^ generateViceversa) {
+        if (isFunctionDefinitionConstant || generateViceversa) {
             // Avoid generating runtime exception call
             if (functionDefinition.hasOutputs()) {
                 buildConstantFunction(
@@ -1377,7 +1377,7 @@ public class SolidityFunctionWrapper extends Generator {
             results.add(methodBuilder.build());
         }
 
-        if (generateBothCallAndSend && !generateViceversa) {
+        if (generateBothCallAndSend && !generateViceversa && !isFunctionDefinitionConstant) {
             results.addAll(buildFunctions(functionDefinition, useUpperCase, true));
         }
 

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -116,7 +116,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
                 abiFuncs);
     }
 
-    protected SolidityFunctionWrapperGenerator(
+    public SolidityFunctionWrapperGenerator(
             File binFile,
             File abiFile,
             File destinationDir,

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -872,17 +872,7 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
                         + "  return executeRemoteCallSingleValueReturn(function, java.math.BigInteger.class);\n"
                         + "}\n";
 
-        String expectedSend =
-                "public org.web3j.protocol.core.RemoteFunctionCall<org.web3j.protocol.core.methods.response.TransactionReceipt> send_functionName(java.math.BigInteger param) {\n"
-                        + "  final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(\n"
-                        + "      FUNC_FUNCTIONNAME, \n"
-                        + "      java.util.Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint8(param)), \n"
-                        + "      java.util.Collections.<org.web3j.abi.TypeReference<?>>emptyList());\n"
-                        + "  return executeRemoteCallTransaction(function);\n"
-                        + "}\n";
-
-        assertEquals(2, methodSpecs.size());
+        assertEquals(1, methodSpecs.size());
         assertEquals(expectedCall, methodSpecs.get(0).toString());
-        assertEquals(expectedSend, methodSpecs.get(1).toString());
     }
 }


### PR DESCRIPTION
### What does this PR do?
It allows the java code generator to generate both call and send functions for functions which do transactions (similar to staticcall in ethers.js). Before this change it didn't work because the constructor was protected so the CLI didn't allow the "generateBothCallAndSend" parameter. Also it generated the call_ and send_ functions for "view" and "pure" functions and not for transacting functions.

### Where should the reviewer start?


### Why is it needed?
Because at the moment "generateBothCallAndSend" parameter doesn't work at all.

