### PR TITLE
debugTraceTransaction is JsonMappingException

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/response/FullDebugTraceInfo.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/FullDebugTraceInfo.java
@@ -21,6 +21,8 @@ public class FullDebugTraceInfo {
     private String returnValue;
     private List<StructLogs> structLogs;
 
+    public FullDebugTraceInfo() {
+    }
     public FullDebugTraceInfo(
             int gas, boolean failed, String returnValue, List<StructLogs> structLogs) {
         this.gas = gas;

--- a/besu/src/main/java/org/web3j/protocol/besu/response/StructLogs.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/StructLogs.java
@@ -26,7 +26,8 @@ public class StructLogs {
     private List<String> stack;
     private List<String> memory;
     private Map<BigInteger, String> storage;
-
+    public StructLogs() {
+    }
     public StructLogs(
             int pc,
             String op,


### PR DESCRIPTION
### What does this PR do?
*required*
Error when executing web3j2.debugTraceTransaction(),
the error info are :
 Can not construct instance of org.web3j.protocol.besu.response.FullDebugTraceInfo: no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)
 at [Source: java.io.ByteArrayInputStream@3a1d593e; line: 1, column: 35]
### Where should the reviewer start?
*required*
executing web3j2.debugTraceTransaction
### Why is it needed?
*required*
it is bug ,
We should fix it
