### PR TITLE
Don't pad filter id with leading zero

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -504,7 +504,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthUninstallFilter> ethUninstallFilter(BigInteger filterId) {
         return new Request<>(
                 "eth_uninstallFilter",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthUninstallFilter.class);
     }
@@ -513,7 +513,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterChanges(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterChanges",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthLog.class);
     }
@@ -522,7 +522,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterLogs(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterLogs",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthLog.class);
     }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -512,7 +512,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"eth_uninstallFilter\","
-                        + "\"params\":[\"0x0b\"],\"id\":1}");
+                        + "\"params\":[\"0xb\"],\"id\":1}");
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
This PR causes ethUninstallFilter, ethGetFilterChanges, and ethGetFilterLogs to NOT pad a filter id's hexadecimal string representation with a zero when the hexadecimal string is less than two characters long. This is accomplished by using `Numeric.toHexStringWithPrefix` instead of `Numeric.toHexStringWithPrefixSafe`.

### Where should the reviewer start?
The reviewer should start by examining the changes in `JsonRpc2_0Web3j.java`.

### Why is it needed?
Resolves #1392 . As specified in Issue #1392 , Web3j currently cannot get filter changes or logs or uninstall a filter on a Hardhat network if that filter's hexadecimal id is less than "0x10". This PR will fix that issue by bringing Web3j into compliance with the [official Ethereum JSON-RPC specification](https://ethereum.org/en/developers/docs/apis/json-rpc/) for [eth_UninstallFilter, eth_getFilterChanges and eth_GetFilterLogs](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=true&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false), which explicitly specifies that filter ids in requests should NOT contain a leading "0".

