### PR TITLE
Upgrade java websocket dependencies to 1.5.2 (fix CVE-2020-11050)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext {
     okhttpVersion = '4.9.0'
     rxjavaVersion = '2.2.2'
     slf4jVersion = '1.7.30'
-    javaWebSocketVersion = '1.3.8'
+    javaWebSocketVersion = '1.5.2'
     picocliVersion = '3.0.0'
     web3jUnitVersion = version
     // test dependencies


### PR DESCRIPTION
### What does this PR do?
* Fix [CVE-2020-11050](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11050) vulnerability detected in [org.java-websocket:Java-WebSocket](https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket/1.3.8) by upgrading dependency to version 1.5.2

### Where should the reviewer start?
* Changes are in `build.gradle` at root folder.
* Run tests (especially `WebSocketClientTest` ones)

### Why is it needed?
* In order to fix [CVE-2020-11050](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11050) vulnerability and get a better [OWASP Dependency Check](https://jeremylong.github.io/DependencyCheck/dependency-check-maven/index.html) score when using web3j.

