### PR TITLE
366 add chainid field, fix chainid calculation

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -567,9 +567,7 @@ public class EthBlock extends Response<EthBlock.Block> {
             implements TransactionResult<Transaction> {
         public TransactionObject() {}
 
-        /**
-         * Use constructor with ChainId
-         */
+        /** Use constructor with ChainId */
         @Deprecated
         public TransactionObject(
                 String hash,

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -567,6 +567,10 @@ public class EthBlock extends Response<EthBlock.Block> {
             implements TransactionResult<Transaction> {
         public TransactionObject() {}
 
+        /**
+         * Use constructor with ChainId
+         */
+        @Deprecated
         public TransactionObject(
                 String hash,
                 String nonce,
@@ -584,7 +588,7 @@ public class EthBlock extends Response<EthBlock.Block> {
                 String raw,
                 String r,
                 String s,
-                int v,
+                long v,
                 String type,
                 String maxFeePerGas,
                 String maxPriorityFeePerGas,
@@ -594,6 +598,54 @@ public class EthBlock extends Response<EthBlock.Block> {
                     nonce,
                     blockHash,
                     blockNumber,
+                    transactionIndex,
+                    from,
+                    to,
+                    value,
+                    gas,
+                    gasPrice,
+                    input,
+                    creates,
+                    publicKey,
+                    raw,
+                    r,
+                    s,
+                    v,
+                    type,
+                    maxFeePerGas,
+                    maxPriorityFeePerGas,
+                    accessList);
+        }
+
+        public TransactionObject(
+                String hash,
+                String nonce,
+                String blockHash,
+                String blockNumber,
+                String chainId,
+                String transactionIndex,
+                String from,
+                String to,
+                String value,
+                String gasPrice,
+                String gas,
+                String input,
+                String creates,
+                String publicKey,
+                String raw,
+                String r,
+                String s,
+                long v,
+                String type,
+                String maxFeePerGas,
+                String maxPriorityFeePerGas,
+                List<AccessListObject> accessList) {
+            super(
+                    hash,
+                    nonce,
+                    blockHash,
+                    blockNumber,
+                    chainId,
                     transactionIndex,
                     from,
                     to,

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -15,17 +15,16 @@ package org.web3j.protocol.core.methods.response;
 import java.math.BigInteger;
 import java.util.List;
 
+import org.web3j.crypto.TransactionUtils;
 import org.web3j.utils.Numeric;
 
 /** Transaction object used by both {@link EthTransaction} and {@link EthBlock}. */
 public class Transaction {
-    private static final int CHAIN_ID_INC = 35;
-    private static final int LOWER_REAL_V = 27;
-
     private String hash;
     private String nonce;
     private String blockHash;
     private String blockNumber;
+    private String chainId;
     private String transactionIndex;
     private String from;
     private String to;
@@ -46,6 +45,10 @@ public class Transaction {
 
     public Transaction() {}
 
+    /**
+     * Use constructor with ChainId
+     */
+    @Deprecated
     public Transaction(
             String hash,
             String nonce,
@@ -89,6 +92,57 @@ public class Transaction {
         this.maxFeePerGas = maxFeePerGas;
         this.maxPriorityFeePerGas = maxPriorityFeePerGas;
         this.accessList = accessList;
+    }
+
+    public Transaction(
+            String hash,
+            String nonce,
+            String blockHash,
+            String blockNumber,
+            String chainId,
+            String transactionIndex,
+            String from,
+            String to,
+            String value,
+            String gas,
+            String gasPrice,
+            String input,
+            String creates,
+            String publicKey,
+            String raw,
+            String r,
+            String s,
+            long v,
+            String type,
+            String maxFeePerGas,
+            String maxPriorityFeePerGas,
+            List accessList) {
+        this.hash = hash;
+        this.nonce = nonce;
+        this.blockHash = blockHash;
+        this.blockNumber = blockNumber;
+        this.chainId = chainId;
+        this.transactionIndex = transactionIndex;
+        this.from = from;
+        this.to = to;
+        this.value = value;
+        this.gasPrice = gasPrice;
+        this.gas = gas;
+        this.input = input;
+        this.creates = creates;
+        this.publicKey = publicKey;
+        this.raw = raw;
+        this.r = r;
+        this.s = s;
+        this.v = v;
+        this.type = type;
+        this.maxFeePerGas = maxFeePerGas;
+        this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        this.accessList = accessList;
+    }
+
+    public void setChainId(String chainId) {
+        this.chainId = chainId;
     }
 
     public String getHash() {
@@ -267,11 +321,11 @@ public class Transaction {
     //    }
 
     public Long getChainId() {
-        if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
-            return null;
+        if (chainId != null) {
+            return Numeric.decodeQuantity(chainId).longValue();
         }
-        Long chainId = (v - CHAIN_ID_INC) / 2;
-        return chainId;
+
+        return TransactionUtils.deriveChainId(v);
     }
 
     public String getType() {

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -45,9 +45,7 @@ public class Transaction {
 
     public Transaction() {}
 
-    /**
-     * Use constructor with ChainId
-     */
+    /** Use constructor with ChainId */
     @Deprecated
     public Transaction(
             String hash,

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -326,6 +326,10 @@ public class Transaction {
         return TransactionUtils.deriveChainId(v);
     }
 
+    public String getChainIdRaw() {
+        return this.chainId;
+    }
+
     public String getType() {
         return type;
     }
@@ -393,6 +397,13 @@ public class Transaction {
                 : that.getBlockHash() != null) {
             return false;
         }
+
+        if (getChainIdRaw() != null
+                ? !getChainIdRaw().equals(that.getChainIdRaw())
+                : that.getChainIdRaw() != null) {
+            return false;
+        }
+
         if (getBlockNumberRaw() != null
                 ? !getBlockNumberRaw().equals(that.getBlockNumberRaw())
                 : that.getBlockNumberRaw() != null) {
@@ -470,6 +481,7 @@ public class Transaction {
         result = 31 * result + (getNonceRaw() != null ? getNonceRaw().hashCode() : 0);
         result = 31 * result + (getBlockHash() != null ? getBlockHash().hashCode() : 0);
         result = 31 * result + (getBlockNumberRaw() != null ? getBlockNumberRaw().hashCode() : 0);
+        result = 31 * result + (getChainIdRaw() != null ? getChainIdRaw().hashCode() : 0);
         result =
                 31 * result
                         + (getTransactionIndexRaw() != null

--- a/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
@@ -16,6 +16,8 @@ import org.web3j.utils.Numeric;
 
 /** Transaction utility functions. */
 public class TransactionUtils {
+    private static final int CHAIN_ID_INC = 35;
+    private static final int LOWER_REAL_V = 27;
 
     /**
      * Utility method to provide the transaction hash for a given transaction.
@@ -67,5 +69,18 @@ public class TransactionUtils {
     public static String generateTransactionHashHexEncoded(
             RawTransaction rawTransaction, byte chainId, Credentials credentials) {
         return Numeric.toHexString(generateTransactionHash(rawTransaction, chainId, credentials));
+    }
+
+
+    /**
+     * Utility method to derive chain id from v parameter
+     * @param v recovery identifier
+     * @return Chain id
+     */
+    public static long deriveChainId(long v){
+        if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
+            return 0L;
+        }
+        return  (v - CHAIN_ID_INC) / 2;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionUtils.java
@@ -71,16 +71,16 @@ public class TransactionUtils {
         return Numeric.toHexString(generateTransactionHash(rawTransaction, chainId, credentials));
     }
 
-
     /**
      * Utility method to derive chain id from v parameter
+     *
      * @param v recovery identifier
      * @return Chain id
      */
-    public static long deriveChainId(long v){
+    public static long deriveChainId(long v) {
         if (v == LOWER_REAL_V || v == (LOWER_REAL_V + 1)) {
             return 0L;
         }
-        return  (v - CHAIN_ID_INC) / 2;
+        return (v - CHAIN_ID_INC) / 2;
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
@@ -37,14 +37,13 @@ public class TransactionUtilsTest {
                 ("0x568c7f6920c1cee8332e245c473657b9c53044eb96ed7532f5550f1139861e9e"));
     }
 
-
     @Test
     void deriveChainIdWhenMainNet() {
         long v = 37;
 
         long chainId = TransactionUtils.deriveChainId(v);
 
-        assertEquals(1 , chainId);
+        assertEquals(1, chainId);
     }
 
     @Test
@@ -53,7 +52,7 @@ public class TransactionUtilsTest {
 
         long chainId = TransactionUtils.deriveChainId(v);
 
-        assertEquals(3 , chainId);
+        assertEquals(3, chainId);
     }
 
     @Test
@@ -64,7 +63,7 @@ public class TransactionUtilsTest {
         long chainId_1 = TransactionUtils.deriveChainId(v1);
         long chainId_2 = TransactionUtils.deriveChainId(v2);
 
-        assertEquals(0 , chainId_1);
-        assertEquals(0 , chainId_2);
+        assertEquals(0, chainId_1);
+        assertEquals(0, chainId_2);
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionUtilsTest.java
@@ -36,4 +36,35 @@ public class TransactionUtilsTest {
                         SampleKeys.CREDENTIALS),
                 ("0x568c7f6920c1cee8332e245c473657b9c53044eb96ed7532f5550f1139861e9e"));
     }
+
+
+    @Test
+    void deriveChainIdWhenMainNet() {
+        long v = 37;
+
+        long chainId = TransactionUtils.deriveChainId(v);
+
+        assertEquals(1 , chainId);
+    }
+
+    @Test
+    void deriveChainIdWhenRopstenNet() {
+        long v = 42;
+
+        long chainId = TransactionUtils.deriveChainId(v);
+
+        assertEquals(3 , chainId);
+    }
+
+    @Test
+    void deriveChainIdWhenLegacySignature() {
+        long v1 = 27;
+        long v2 = 28;
+
+        long chainId_1 = TransactionUtils.deriveChainId(v1);
+        long chainId_2 = TransactionUtils.deriveChainId(v2);
+
+        assertEquals(0 , chainId_1);
+        assertEquals(0 , chainId_2);
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Fix chainId calculation


### Why is it needed?
Current Geth implementation has a new field "ChainId"
Web3j calculates chainId incorrectly

### Other

Links on Geth:
ChainId field - https://github.com/ethereum/go-ethereum/blob/c503f98f6d5e80e079c1d8a3601d188af2a899da/core/types/transaction_marshalling.go#L46
ChainId calculation - https://github.com/ethereum/go-ethereum/blob/4e599ee469223ccc452f40f36c85bac3bea9c16b/core/types/transaction_signing.go#L510

