### PR TITLE
368 upgrade jnr unixsocket to 0.38.17 (fix CVE-2020-15250) (#1616)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext {
     javaPoetVersion = '1.7.0'
     kotlinVersion = '1.3.72'
     kotlinPoetVersion = '1.5.0'
-    jnr_unixsocketVersion = '0.21'
+    jnr_unixsocketVersion = '0.38.17'
     okhttpVersion = '4.9.0'
     rxjavaVersion = '2.2.2'
     slf4jVersion = '1.7.30'


### PR DESCRIPTION
### What does this PR do?
Fix vulnerabilities with com.github.jnr:jnr-unixsocket@0.21

### Why is it needed?
To avoid having vulnerabilities with jnr unixsocket.

