### PR TITLE
Add support for EIP-1559 smart contract transactions.

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -45,6 +45,7 @@ import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
+import org.web3j.tx.gas.ContractEIP1559GasProvider;
 import org.web3j.tx.gas.ContractGasProvider;
 import org.web3j.tx.gas.StaticGasProvider;
 import org.web3j.utils.Numeric;
@@ -363,14 +364,33 @@ public abstract class Contract extends ManagedTransaction {
             String data, BigInteger weiValue, String funcName, boolean constructor)
             throws TransactionException, IOException {
 
-        TransactionReceipt receipt =
-                send(
-                        contractAddress,
-                        data,
-                        weiValue,
-                        gasProvider.getGasPrice(funcName),
-                        gasProvider.getGasLimit(funcName),
-                        constructor);
+        TransactionReceipt receipt = null;
+        if (gasProvider instanceof ContractEIP1559GasProvider) {
+            ContractEIP1559GasProvider eip1559GasProvider =
+                    (ContractEIP1559GasProvider) gasProvider;
+            if (eip1559GasProvider.isEIP1559Enabled()) {
+                receipt =
+                        sendEIP1559(
+                                eip1559GasProvider.getChainId(),
+                                contractAddress,
+                                data,
+                                weiValue,
+                                eip1559GasProvider.getGasLimit(funcName),
+                                eip1559GasProvider.getMaxPriorityFeePerGas(funcName),
+                                eip1559GasProvider.getMaxFeePerGas(funcName),
+                                constructor);
+            }
+        }
+        if (receipt == null) {
+            receipt =
+                    send(
+                            contractAddress,
+                            data,
+                            weiValue,
+                            gasProvider.getGasPrice(funcName),
+                            gasProvider.getGasLimit(funcName),
+                            constructor);
+        }
 
         if (!receipt.isStatusOK()) {
             throw new TransactionException(

--- a/core/src/main/java/org/web3j/tx/ManagedTransaction.java
+++ b/core/src/main/java/org/web3j/tx/ManagedTransaction.java
@@ -129,6 +129,28 @@ public abstract class ManagedTransaction {
                 gasPrice, gasLimit, to, data, value, constructor);
     }
 
+    protected TransactionReceipt sendEIP1559(
+            long chainId,
+            String to,
+            String data,
+            BigInteger value,
+            BigInteger gasLimit,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            boolean constructor)
+            throws IOException, TransactionException {
+
+        return transactionManager.executeTransactionEIP1559(
+                chainId,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                data,
+                value,
+                constructor);
+    }
+
     protected String call(String to, String data, DefaultBlockParameter defaultBlockParameter)
             throws IOException {
 

--- a/core/src/main/java/org/web3j/tx/gas/ContractEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/ContractEIP1559GasProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import java.math.BigInteger;
+
+public interface ContractEIP1559GasProvider extends ContractGasProvider {
+    boolean isEIP1559Enabled();
+
+    long getChainId();
+
+    BigInteger getMaxFeePerGas(String contractFunc);
+
+    BigInteger getMaxPriorityFeePerGas(String contractFunc);
+}

--- a/core/src/main/java/org/web3j/tx/gas/StaticEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticEIP1559GasProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import java.math.BigInteger;
+
+public class StaticEIP1559GasProvider implements ContractEIP1559GasProvider {
+    private long chainId;
+    private BigInteger maxFeePerGas;
+    private BigInteger maxPriorityFeePerGas;
+    private BigInteger gasLimit;
+
+    public StaticEIP1559GasProvider(
+            long chainId,
+            BigInteger maxFeePerGas,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger gasLimit) {
+        this.chainId = chainId;
+        this.maxFeePerGas = maxFeePerGas;
+        this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        this.gasLimit = gasLimit;
+    }
+
+    @Override
+    public BigInteger getGasPrice(String contractFunc) {
+        return maxFeePerGas;
+    }
+
+    @Override
+    public BigInteger getGasPrice() {
+        return maxFeePerGas;
+    }
+
+    @Override
+    public BigInteger getGasLimit(String contractFunc) {
+        return gasLimit;
+    }
+
+    @Override
+    public BigInteger getGasLimit() {
+        return gasLimit;
+    }
+
+    @Override
+    public boolean isEIP1559Enabled() {
+        return true;
+    }
+
+    @Override
+    public long getChainId() {
+        return chainId;
+    }
+
+    @Override
+    public BigInteger getMaxFeePerGas(String contractFunc) {
+        return maxFeePerGas;
+    }
+
+    @Override
+    public BigInteger getMaxPriorityFeePerGas(String contractFunc) {
+        return maxPriorityFeePerGas;
+    }
+}

--- a/core/src/test/java/org/web3j/tx/ContractTest.java
+++ b/core/src/test/java/org/web3j/tx/ContractTest.java
@@ -49,6 +49,7 @@ import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.tx.gas.ContractGasProvider;
 import org.web3j.tx.gas.DefaultGasProvider;
+import org.web3j.tx.gas.StaticEIP1559GasProvider;
 import org.web3j.tx.gas.StaticGasProvider;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
@@ -475,6 +476,42 @@ public class ContractTest extends ManagedTransactionTester {
 
         verify(txManager)
                 .executeTransaction(
+                        eq(BigInteger.TEN),
+                        eq(BigInteger.ONE),
+                        anyString(),
+                        anyString(),
+                        any(BigInteger.class),
+                        anyBoolean());
+    }
+
+    @Test
+    public void testStaticEIP1559GasProvider() throws IOException, TransactionException {
+        StaticEIP1559GasProvider gasProvider =
+                new StaticEIP1559GasProvider(1L, BigInteger.TEN, BigInteger.ZERO, BigInteger.ONE);
+        TransactionManager txManager = mock(TransactionManager.class);
+
+        when(txManager.executeTransaction(
+                        any(BigInteger.class),
+                        any(BigInteger.class),
+                        anyString(),
+                        anyString(),
+                        any(BigInteger.class),
+                        anyBoolean()))
+                .thenReturn(new TransactionReceipt());
+
+        contract = new TestContract(ADDRESS, web3j, txManager, gasProvider);
+
+        Function func =
+                new Function(
+                        "test",
+                        Collections.<Type>emptyList(),
+                        Collections.<TypeReference<?>>emptyList());
+        contract.executeTransaction(func);
+
+        verify(txManager)
+                .executeTransactionEIP1559(
+                        eq(1L),
+                        eq(BigInteger.ZERO),
                         eq(BigInteger.TEN),
                         eq(BigInteger.ONE),
                         anyString(),


### PR DESCRIPTION
### What does this PR do?
It allows to send EIP-1559 transactions from smart contract wrappers.

### Where should the reviewer start?
Instantiate the `StaticEIP1559GasProvider` and pass it when loading the contract wrapper.

### Why is it needed?
https://github.com/web3j/web3j/issues/1517

