### PR TITLE
Fix reconnect on refused connection

### DIFF
--- a/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/org/web3j/protocol/websocket/WebSocketService.java
@@ -128,11 +128,10 @@ public class WebSocketService implements Web3jService {
                         ? webSocketClient.reconnectBlocking()
                         : webSocketClient.connectBlocking();
 
+        shouldReConnect = true;
         if (!connected) {
             throw new ConnectException("Failed to connect to WebSocket");
         }
-
-        shouldReConnect = true;
     }
 
     private void setWebSocketListener(

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -51,6 +51,7 @@ import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -119,6 +120,21 @@ public class WebSocketServiceTest {
                 () -> {
                     service.connect();
                 });
+    }
+
+    @Test
+    public void testReconnectIfFirstConnectionFailed() throws Exception {
+        when(webSocketClient.connectBlocking()).thenReturn(false);
+        assertThrows(
+                ConnectException.class,
+                () -> {
+                    service.connect();
+                });
+        service.connect();
+        // reconnectBlocking() should be called if 1st attempt was failed, if we call
+        // connectBlocking() for a second time, we will get IllegalStateException with real
+        // webSocketClient
+        verify(webSocketClient, times(1)).reconnectBlocking();
     }
 
     @Test

--- a/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/websocket/WebSocketServiceTest.java
@@ -51,7 +51,6 @@ import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
### What does this PR do?
Toggles `shouldReConnect` for connection refused case too.
Without it I get something like this in logs when trying to reconnect node 2nd time after 1st attempt got connection refused:
```
Caused by: java.lang.IllegalStateException: WebSocketClient objects are not reuseable
at org.java_websocket.client.WebSocketClient.connect(WebSocketClient.java:372) ~[Java-WebSocket-1.5.2.jar:?]
at org.java_websocket.client.WebSocketClient.connectBlocking(WebSocketClient.java:386) ~[Java-WebSocket-1.5.2.jar:?]
at org.web3j.protocol.websocket.WebSocketService.connectToWebSocket(WebSocketService.java:129) ~[core-4.8.9.jar:?]
at org.web3j.protocol.websocket.WebSocketService.connect(WebSocketService.java:117) ~[core-4.8.9.jar:?]
``` 

### Where should the reviewer start?
`WebSocketClient.java`

### Why is it needed?
Otherwise user needs to recreate `WebSocketClient` and `WebSocketService` instances for every reconnection attempt when connection is refused.
Also will fix #1356 I guess

