### PR TITLE
Add support for new EIP-1559 RPC methods.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -13,6 +13,7 @@
 package org.web3j.protocol.core;
 
 import java.math.BigInteger;
+import java.util.List;
 
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.response.BooleanResponse;
@@ -29,6 +30,7 @@ import org.web3j.protocol.core.methods.response.EthCompileLLL;
 import org.web3j.protocol.core.methods.response.EthCompileSerpent;
 import org.web3j.protocol.core.methods.response.EthCompileSolidity;
 import org.web3j.protocol.core.methods.response.EthEstimateGas;
+import org.web3j.protocol.core.methods.response.EthFeeHistory;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
@@ -44,6 +46,7 @@ import org.web3j.protocol.core.methods.response.EthGetUncleCountByBlockNumber;
 import org.web3j.protocol.core.methods.response.EthGetWork;
 import org.web3j.protocol.core.methods.response.EthHashrate;
 import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
 import org.web3j.protocol.core.methods.response.EthMining;
 import org.web3j.protocol.core.methods.response.EthProtocolVersion;
 import org.web3j.protocol.core.methods.response.EthSign;
@@ -105,6 +108,11 @@ public interface Ethereum {
     Request<?, EthHashrate> ethHashrate();
 
     Request<?, EthGasPrice> ethGasPrice();
+
+    Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas();
+
+    Request<?, EthFeeHistory> ethFeeHistory(
+            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
 
     Request<?, EthAccounts> ethAccounts();
 

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -42,6 +42,7 @@ import org.web3j.protocol.core.methods.response.EthCompileLLL;
 import org.web3j.protocol.core.methods.response.EthCompileSerpent;
 import org.web3j.protocol.core.methods.response.EthCompileSolidity;
 import org.web3j.protocol.core.methods.response.EthEstimateGas;
+import org.web3j.protocol.core.methods.response.EthFeeHistory;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
@@ -57,6 +58,7 @@ import org.web3j.protocol.core.methods.response.EthGetUncleCountByBlockNumber;
 import org.web3j.protocol.core.methods.response.EthGetWork;
 import org.web3j.protocol.core.methods.response.EthHashrate;
 import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
 import org.web3j.protocol.core.methods.response.EthMining;
 import org.web3j.protocol.core.methods.response.EthProtocolVersion;
 import org.web3j.protocol.core.methods.response.EthSign;
@@ -219,6 +221,25 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthGasPrice> ethGasPrice() {
         return new Request<>(
                 "eth_gasPrice", Collections.<String>emptyList(), web3jService, EthGasPrice.class);
+    }
+
+    @Override
+    public Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas() {
+        return new Request<>(
+                "eth_maxPriorityFeePerGas",
+                Collections.<String>emptyList(),
+                web3jService,
+                EthMaxPriorityFeePerGas.class);
+    }
+
+    @Override
+    public Request<?, EthFeeHistory> ethFeeHistory(
+            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
+        return new Request<>(
+                "eth_feeHistory",
+                Arrays.asList(blockCount, newestBlock.getValue(), rewardPercentiles),
+                web3jService,
+                EthFeeHistory.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthFeeHistory.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthFeeHistory.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.web3j.protocol.ObjectMapperFactory;
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
+
+/** eth_feeHistory. */
+public class EthFeeHistory extends Response<EthFeeHistory.FeeHistory> {
+
+    @Override
+    @JsonDeserialize(using = EthFeeHistory.ResponseDeserialiser.class)
+    public void setResult(FeeHistory result) {
+        super.setResult(result);
+    }
+
+    public FeeHistory getFeeHistory() {
+        return getResult();
+    }
+
+    public static class FeeHistory {
+        private String oldestBlock;
+        private List<List<String>> reward;
+        private List<String> baseFeePerGas;
+        private List<Double> gasUsedRatio;
+
+        public FeeHistory() {}
+
+        public FeeHistory(
+                String oldestBlock,
+                List<List<String>> reward,
+                List<String> baseFeePerGas,
+                List<Double> gasUsedRatio) {
+            this.oldestBlock = oldestBlock;
+            this.reward = reward;
+            this.baseFeePerGas = baseFeePerGas;
+            this.gasUsedRatio = gasUsedRatio;
+        }
+
+        public BigInteger getOldestBlock() {
+            return Numeric.decodeQuantity(oldestBlock);
+        }
+
+        public String getOldestBlockRaw() {
+            return oldestBlock;
+        }
+
+        public void setOldestBlock(String oldestBlock) {
+            this.oldestBlock = oldestBlock;
+        }
+
+        public List<List<BigInteger>> getReward() {
+            List<List<BigInteger>> retValue = new ArrayList<>(reward.size());
+            for (int i = 0; i < reward.size(); i++) {
+                List<String> r = reward.get(i);
+                List<BigInteger> tmp = new ArrayList<>(r.size());
+                for (int j = 0; j < r.size(); j++) {
+                    tmp.add(Numeric.decodeQuantity(r.get(j)));
+                }
+                retValue.add(tmp);
+            }
+            return retValue;
+        }
+
+        public void setReward(List<List<String>> reward) {
+            this.reward = reward;
+        }
+
+        public List<List<String>> getRewardRaw() {
+            return reward;
+        }
+
+        public List<BigInteger> getBaseFeePerGas() {
+            List<BigInteger> retValue = new ArrayList<>(baseFeePerGas.size());
+            for (int i = 0; i < baseFeePerGas.size(); i++) {
+                retValue.add(Numeric.decodeQuantity(baseFeePerGas.get(i)));
+            }
+            return retValue;
+        }
+
+        public void setBaseFeePerGas(List<String> baseFeePerGas) {
+            this.baseFeePerGas = baseFeePerGas;
+        }
+
+        public List<String> getBaseFeePerGasRaw() {
+            return baseFeePerGas;
+        }
+
+        public List<Double> getGasUsedRatio() {
+            return gasUsedRatio;
+        }
+
+        public void setGasUsedRatio(List<Double> gasUsedRatio) {
+            this.gasUsedRatio = gasUsedRatio;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FeeHistory)) {
+                return false;
+            }
+
+            FeeHistory feeHistory = (FeeHistory) o;
+
+            if (getOldestBlockRaw() != null
+                    ? !getOldestBlockRaw().equals(feeHistory.getOldestBlockRaw())
+                    : feeHistory.getOldestBlockRaw() != null) {
+                return false;
+            }
+
+            if (getRewardRaw() != null
+                    ? !getRewardRaw().equals(feeHistory.getRewardRaw())
+                    : feeHistory.getRewardRaw() != null) {
+                return false;
+            }
+
+            if (getBaseFeePerGasRaw() != null
+                    ? !getBaseFeePerGasRaw().equals(feeHistory.getBaseFeePerGasRaw())
+                    : feeHistory.getBaseFeePerGasRaw() != null) {
+                return false;
+            }
+
+            return getGasUsedRatio() != null
+                    ? getGasUsedRatio().equals(feeHistory.getGasUsedRatio())
+                    : feeHistory.getGasUsedRatio() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = getOldestBlockRaw() != null ? getOldestBlockRaw().hashCode() : 0;
+            result = 31 * result + (getRewardRaw() != null ? getRewardRaw().hashCode() : 0);
+            result =
+                    31 * result
+                            + (getBaseFeePerGasRaw() != null
+                                    ? getBaseFeePerGasRaw().hashCode()
+                                    : 0);
+            result = 31 * result + (getGasUsedRatio() != null ? getGasUsedRatio().hashCode() : 0);
+            return result;
+        }
+    }
+
+    public static class ResponseDeserialiser extends JsonDeserializer<FeeHistory> {
+
+        private ObjectReader objectReader = ObjectMapperFactory.getObjectReader();
+
+        @Override
+        public FeeHistory deserialize(
+                JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            if (jsonParser.getCurrentToken() != JsonToken.VALUE_NULL) {
+                return objectReader.readValue(jsonParser, FeeHistory.class);
+            } else {
+                return null; // null is wrapped by Optional in above getter
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthFeeHistory.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthFeeHistory.java
@@ -14,8 +14,8 @@ package org.web3j.protocol.core.methods.response;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -73,16 +73,13 @@ public class EthFeeHistory extends Response<EthFeeHistory.FeeHistory> {
         }
 
         public List<List<BigInteger>> getReward() {
-            List<List<BigInteger>> retValue = new ArrayList<>(reward.size());
-            for (int i = 0; i < reward.size(); i++) {
-                List<String> r = reward.get(i);
-                List<BigInteger> tmp = new ArrayList<>(r.size());
-                for (int j = 0; j < r.size(); j++) {
-                    tmp.add(Numeric.decodeQuantity(r.get(j)));
-                }
-                retValue.add(tmp);
-            }
-            return retValue;
+            return reward.stream()
+                    .map(
+                            rewardPercentile ->
+                                    rewardPercentile.stream()
+                                            .map(Numeric::decodeQuantity)
+                                            .collect(Collectors.toList()))
+                    .collect(Collectors.toList());
         }
 
         public void setReward(List<List<String>> reward) {
@@ -94,11 +91,7 @@ public class EthFeeHistory extends Response<EthFeeHistory.FeeHistory> {
         }
 
         public List<BigInteger> getBaseFeePerGas() {
-            List<BigInteger> retValue = new ArrayList<>(baseFeePerGas.size());
-            for (int i = 0; i < baseFeePerGas.size(); i++) {
-                retValue.add(Numeric.decodeQuantity(baseFeePerGas.get(i)));
-            }
-            return retValue;
+            return baseFeePerGas.stream().map(Numeric::decodeQuantity).collect(Collectors.toList());
         }
 
         public void setBaseFeePerGas(List<String> baseFeePerGas) {

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.core.methods.response;
+
+import java.math.BigInteger;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
+
+/** eth_maxPriorityFeePerGas. */
+public class EthMaxPriorityFeePerGas extends Response<String> {
+    public BigInteger getMaxPriorityFeePerGas() {
+        return Numeric.decodeQuantity(getResult());
+    }
+}

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -147,6 +147,22 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
+    public void testEthMaxPriorityFeePerGas() throws Exception {
+        web3j.ethMaxPriorityFeePerGas().send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_maxPriorityFeePerGas\",\"params\":[],\"id\":1}");
+    }
+
+    @Test
+    public void testEthFeeHistory() throws Exception {
+        web3j.ethFeeHistory(1, DefaultBlockParameterName.LATEST, null).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_feeHistory\",\"params\":[1,\"latest\",null],\"id\":1}");
+    }
+
+    @Test
     public void testEthAccounts() throws Exception {
         web3j.ethAccounts().send();
 


### PR DESCRIPTION
### What does this PR do?
It adds support for the following two new RPC methods introduced by EIP-1559:
- eth_maxPriorityFeePerGas
- eth_feeHistory

### Where should the reviewer start?
Please review the response types.

### Why is it needed?
They can be used in addition to https://github.com/web3j/web3j/pull/1638 to set correct (priority) gas price
