### PR TITLE
updates vulnerable jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 ext {
     bouncycastleVersion = '1.68'
-    jacksonVersion = '2.10.0'
+    jacksonVersion = '2.13.1'
     javaPoetVersion = '1.7.0'
     kotlinVersion = '1.3.72'
     kotlinPoetVersion = '1.5.0'


### PR DESCRIPTION
### What does this PR do?
Updates jackson library dependency to a more recent version

### Where should the reviewer start?
`build.gradle`

### Why is it needed?
Critical vulnerable Jackson version.
Closes: https://github.com/web3j/web3j/issues/1641

