### PR TITLE
Fix retrieval of revert reason by using the same weiAmount in the call.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/Transaction.java
@@ -132,6 +132,12 @@ public class Transaction {
         return new Transaction(from, nonce, gasPrice, gasLimit, to, null, data);
     }
 
+    public static Transaction createEthCallTransaction(
+            String from, String to, String data, BigInteger weiValue) {
+
+        return new Transaction(from, null, null, null, to, weiValue, data);
+    }
+
     public static Transaction createEthCallTransaction(String from, String to, String data) {
 
         return new Transaction(from, null, null, null, to, null, data);

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -383,7 +383,7 @@ public abstract class Contract extends ManagedTransaction {
                             receipt.getGasUsedRaw() != null
                                     ? receipt.getGasUsed().toString()
                                     : "unknown",
-                            extractRevertReason(receipt, data, web3j, true)),
+                            extractRevertReason(receipt, data, web3j, true, weiValue)),
                     receipt);
         }
         return receipt;

--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -43,6 +43,7 @@ import org.web3j.protocol.core.RemoteFunctionCall;
 import org.web3j.protocol.core.methods.response.EthGetCode;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.protocol.exceptions.JsonRpcError;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.tx.gas.ContractGasProvider;
@@ -363,29 +364,34 @@ public abstract class Contract extends ManagedTransaction {
             String data, BigInteger weiValue, String funcName, boolean constructor)
             throws TransactionException, IOException {
 
-        TransactionReceipt receipt =
-                send(
-                        contractAddress,
-                        data,
-                        weiValue,
-                        gasProvider.getGasPrice(funcName),
-                        gasProvider.getGasLimit(funcName),
-                        constructor);
+        TransactionReceipt receipt;
+                try {
+                    receipt =
+                            send(
+                                    contractAddress,
+                                    data,
+                                    weiValue,
+                                    gasProvider.getGasPrice(funcName),
+                                    gasProvider.getGasLimit(funcName),
+                                    constructor);
+                } catch (JsonRpcError error){
+                    throw new TransactionException(error.getData().toString());
+                }
 
-        if (!receipt.isStatusOK()) {
-            throw new TransactionException(
-                    String.format(
-                            "Transaction %s has failed with status: %s. "
-                                    + "Gas used: %s. "
-                                    + "Revert reason: '%s'.",
-                            receipt.getTransactionHash(),
-                            receipt.getStatus(),
-                            receipt.getGasUsedRaw() != null
-                                    ? receipt.getGasUsed().toString()
-                                    : "unknown",
-                            extractRevertReason(receipt, data, web3j, true, weiValue)),
-                    receipt);
-        }
+                if (receipt != null && !receipt.isStatusOK()) {
+                    throw new TransactionException(
+                            String.format(
+                                    "Transaction %s has failed with status: %s. "
+                                            + "Gas used: %s. "
+                                            + "Revert reason: '%s'.",
+                                    receipt.getTransactionHash(),
+                                    receipt.getStatus(),
+                                    receipt.getGasUsedRaw() != null
+                                            ? receipt.getGasUsed().toString()
+                                            : "unknown",
+                                    extractRevertReason(receipt, data, web3j, true, weiValue)),
+                            receipt);
+                }
         return receipt;
     }
 


### PR DESCRIPTION
### What does this PR do?
It fixes the retrieval of the tx revert reason, by using the same weiValue amount that was used in the failed transaction.

### Where should the reviewer start?
Consider this simplified test case contract:
```
contract Test {

    function test(uint n) external payable {
        require(msg.value > 0, 'msg.value must be positive');
        require(msg.value == n, 'msg.value must be equal to n');
    }
}
```
Then call it with `n == 2` and `weiAmount == 1`, and you'll get a super misleading `msg.value must be positive` error message.

### Why is it needed?
Because it drove me crazy for 24h to debug a complex smart contract when the thrown errors were in completely different code locations.

