### PR TITLE
support EIP 1559 eth_maxPriorityFeePerGas method

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -13,6 +13,7 @@
 package org.web3j.protocol.core;
 
 import java.math.BigInteger;
+import java.util.Collections;
 
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.response.BooleanResponse;
@@ -44,6 +45,7 @@ import org.web3j.protocol.core.methods.response.EthGetUncleCountByBlockNumber;
 import org.web3j.protocol.core.methods.response.EthGetWork;
 import org.web3j.protocol.core.methods.response.EthHashrate;
 import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
 import org.web3j.protocol.core.methods.response.EthMining;
 import org.web3j.protocol.core.methods.response.EthProtocolVersion;
 import org.web3j.protocol.core.methods.response.EthSign;
@@ -105,6 +107,8 @@ public interface Ethereum {
     Request<?, EthHashrate> ethHashrate();
 
     Request<?, EthGasPrice> ethGasPrice();
+
+    Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas();
 
     Request<?, EthAccounts> ethAccounts();
 

--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -13,7 +13,6 @@
 package org.web3j.protocol.core;
 
 import java.math.BigInteger;
-import java.util.Collections;
 
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.response.BooleanResponse;

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -57,6 +57,7 @@ import org.web3j.protocol.core.methods.response.EthGetUncleCountByBlockNumber;
 import org.web3j.protocol.core.methods.response.EthGetWork;
 import org.web3j.protocol.core.methods.response.EthHashrate;
 import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.core.methods.response.EthMaxPriorityFeePerGas;
 import org.web3j.protocol.core.methods.response.EthMining;
 import org.web3j.protocol.core.methods.response.EthProtocolVersion;
 import org.web3j.protocol.core.methods.response.EthSign;
@@ -219,6 +220,12 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthGasPrice> ethGasPrice() {
         return new Request<>(
                 "eth_gasPrice", Collections.<String>emptyList(), web3jService, EthGasPrice.class);
+    }
+
+    @Override
+    public Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas() {
+        return new Request<>(
+            "eth_maxPriorityFeePerGas", Collections.<String>emptyList(), web3jService, EthMaxPriorityFeePerGas.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -225,7 +225,10 @@ public class JsonRpc2_0Web3j implements Web3j {
     @Override
     public Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas() {
         return new Request<>(
-            "eth_maxPriorityFeePerGas", Collections.<String>emptyList(), web3jService, EthMaxPriorityFeePerGas.class);
+                "eth_maxPriorityFeePerGas",
+                Collections.<String>emptyList(),
+                web3jService,
+                EthMaxPriorityFeePerGas.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+
+/** eth_maxPriorityFeePerGas. */
+public class EthMaxPriorityFeePerGas extends Response<String> {
+    public BigInteger getMaxPriorityFeePerGas() {
+        return Numeric.decodeQuantity(this.getResult());
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthMaxPriorityFeePerGas.java
@@ -10,17 +10,16 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-
 package org.web3j.protocol.core.methods.response;
+
+import java.math.BigInteger;
 
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
 
-import java.math.BigInteger;
-
 /** eth_maxPriorityFeePerGas. */
 public class EthMaxPriorityFeePerGas extends Response<String> {
     public BigInteger getMaxPriorityFeePerGas() {
-        return Numeric.decodeQuantity(this.getResult());
+        return Numeric.decodeQuantity(getResult());
     }
 }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -150,7 +150,8 @@ public class RequestTest extends RequestTester {
     public void testEthMaxPriorityFeePerGas() throws Exception {
         web3j.ethMaxPriorityFeePerGas().send();
 
-        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"eth_maxPriorityFeePerGas\",\"params\":[],\"id\":1}");
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_maxPriorityFeePerGas\",\"params\":[],\"id\":1}");
     }
 
     @Test

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -147,6 +147,13 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
+    public void testEthMaxPriorityFeePerGas() throws Exception {
+        web3j.ethMaxPriorityFeePerGas().send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\",\"method\":\"eth_maxPriorityFeePerGas\",\"params\":[],\"id\":1}");
+    }
+
+    @Test
     public void testEthAccounts() throws Exception {
         web3j.ethAccounts().send();
 


### PR DESCRIPTION
### What does this PR do?
To support [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) eth_maxPriorityFeePerGas method

### Where should the reviewer start?
Start from core/src/main/java/org/web3j/protocol/core/Ethereum.java

### Why is it needed?
Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or "tip", to get a transaction included in the current block. See [eth_maxpriorityfeepergas](https://docs.alchemy.com/alchemy/apis/ethereum/eth_maxpriorityfeepergas)

