### PR TITLE
Allow to set `generateBothCallAndSend` via API.

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -116,6 +116,32 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
                 abiFuncs);
     }
 
+    public SolidityFunctionWrapperGenerator(
+            File binFile,
+            File abiFile,
+            File destinationDir,
+            String contractName,
+            String basePackageName,
+            boolean useJavaNativeTypes,
+            boolean useJavaPrimitiveTypes,
+            boolean generateBothCallAndSend,
+            int addressLength,
+            boolean abiFuncs) {
+
+        this(
+                binFile,
+                abiFile,
+                destinationDir,
+                contractName,
+                basePackageName,
+                useJavaNativeTypes,
+                useJavaPrimitiveTypes,
+                generateBothCallAndSend,
+                Contract.class,
+                addressLength,
+                abiFuncs);
+    }
+
     protected SolidityFunctionWrapperGenerator(
             File binFile,
             File abiFile,


### PR DESCRIPTION
### What does this PR do?
It allows to generate wrappers with both `call_` and `send_` transactions using the API. Previously it was allowed only via the CLI.

### Where should the reviewer start?
There is just a new public constructor.

### Why is it needed?
Self-evident.

