### PR TITLE
Downgrade log level from error to warn

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -94,7 +94,7 @@ public abstract class Filter<T> {
                                     // All exceptions must be caught, otherwise our job terminates
                                     // without
                                     // any notification
-                                    log.error("Error sending request", e);
+                                    log.warn("Error sending request", e);
                                 }
                             },
                             0,


### PR DESCRIPTION
### What does this PR do?
Downgrade log level from error to warn

### Where should the reviewer start?
https://github.com/web3j/web3j/blob/master/core/src/main/java/org/web3j/protocol/core/filters/Filter.java#L97

### Why is it needed?
Log error will page(pageduty),  this is recoverable exception, downgrading the level of logging to warn.

