### PR TITLE
Don't allow leading zeroes for quantities

### DIFF
--- a/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/ResponseTest.java
@@ -115,16 +115,16 @@ public class ResponseTest extends ResponseTester {
                         + "    \"jsonrpc\":\"2.0\",\n"
                         + "    \"result\": {\n"
                         + "        \"hash\":\"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b\",\n"
-                        + "        \"nonce\":\"0x00\",\n"
+                        + "        \"nonce\":\"0x0\",\n"
                         + "        \"from\":\"0x407d73d8a49eeb85d32cf465507dd71d507100c1\",\n"
                         + "        \"to\":\"0x85h43d8a49eeb85d32cf465507dd71d507100c1\",\n"
                         + "        \"value\":\"0x7f110\",\n"
                         + "        \"gas\": \"0x7f110\",\n"
-                        + "        \"gasPrice\":\"0x09184e72a000\",\n"
+                        + "        \"gasPrice\":\"0x9184e72a000\",\n"
                         + "        \"input\":\"0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360\",\n"
                         + "        \"r\":\"0xf115cc4d7516dd430046504e1c888198e0323e8ded016d755f89c226ba3481dc\",\n"
                         + "        \"s\":\"0x4a2ae8ee49f1100b5c0202b37ed8bacf4caeddebde6b7f77e12e7a55893e9f62\",\n"
-                        + "        \"v\":\"0x00\",\n"
+                        + "        \"v\":\"0x0\",\n"
                         + "        \"privateFrom\":\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\n"
                         + "        \"privateFor\":[\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\"Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=\"],\n"
                         + "        \"restriction\":\"restricted\""
@@ -133,16 +133,16 @@ public class ResponseTest extends ResponseTester {
         PrivateTransactionLegacy privateTransaction =
                 new PrivateTransactionLegacy(
                         "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-                        "0x00",
+                        "0x0",
                         "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
                         "0x85h43d8a49eeb85d32cf465507dd71d507100c1",
                         "0x7f110",
                         "0x7f110",
-                        "0x09184e72a000",
+                        "0x9184e72a000",
                         "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360",
                         "0xf115cc4d7516dd430046504e1c888198e0323e8ded016d755f89c226ba3481dc",
                         "0x4a2ae8ee49f1100b5c0202b37ed8bacf4caeddebde6b7f77e12e7a55893e9f62",
-                        "0x00",
+                        "0x0",
                         Base64String.wrap("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo="),
                         Base64String.wrapList(
                                 "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=",
@@ -162,16 +162,16 @@ public class ResponseTest extends ResponseTester {
                         + "    \"jsonrpc\":\"2.0\",\n"
                         + "    \"result\": {\n"
                         + "        \"hash\":\"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b\",\n"
-                        + "        \"nonce\":\"0x00\",\n"
+                        + "        \"nonce\":\"0x0\",\n"
                         + "        \"from\":\"0x407d73d8a49eeb85d32cf465507dd71d507100c1\",\n"
                         + "        \"to\":\"0x85h43d8a49eeb85d32cf465507dd71d507100c1\",\n"
                         + "        \"value\":\"0x7f110\",\n"
                         + "        \"gas\": \"0x7f110\",\n"
-                        + "        \"gasPrice\":\"0x09184e72a000\",\n"
+                        + "        \"gasPrice\":\"0x9184e72a000\",\n"
                         + "        \"input\":\"0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360\",\n"
                         + "        \"r\":\"0xf115cc4d7516dd430046504e1c888198e0323e8ded016d755f89c226ba3481dc\",\n"
                         + "        \"s\":\"0x4a2ae8ee49f1100b5c0202b37ed8bacf4caeddebde6b7f77e12e7a55893e9f62\",\n"
-                        + "        \"v\":\"0x00\",\n"
+                        + "        \"v\":\"0x0\",\n"
                         + "        \"privateFrom\":\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\n"
                         + "        \"privateFor\":\"A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=\",\n"
                         + "        \"restriction\":\"restricted\""
@@ -180,16 +180,16 @@ public class ResponseTest extends ResponseTester {
         PrivateTransactionWithPrivacyGroup privateTransaction =
                 new PrivateTransactionWithPrivacyGroup(
                         "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-                        "0x00",
+                        "0x0",
                         "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
                         "0x85h43d8a49eeb85d32cf465507dd71d507100c1",
                         "0x7f110",
                         "0x7f110",
-                        "0x09184e72a000",
+                        "0x9184e72a000",
                         "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360",
                         "0xf115cc4d7516dd430046504e1c888198e0323e8ded016d755f89c226ba3481dc",
                         "0x4a2ae8ee49f1100b5c0202b37ed8bacf4caeddebde6b7f77e12e7a55893e9f62",
-                        "0x00",
+                        "0x0",
                         Base64String.wrap("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo="),
                         Base64String.wrap("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo="),
                         "restricted");

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -525,7 +525,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthUninstallFilter> ethUninstallFilter(BigInteger filterId) {
         return new Request<>(
                 "eth_uninstallFilter",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthUninstallFilter.class);
     }
@@ -534,7 +534,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterChanges(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterChanges",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthLog.class);
     }
@@ -543,7 +543,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterLogs(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterLogs",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 EthLog.class);
     }
@@ -671,7 +671,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhUninstallFilter> shhUninstallFilter(BigInteger filterId) {
         return new Request<>(
                 "shh_uninstallFilter",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 ShhUninstallFilter.class);
     }
@@ -680,7 +680,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhMessages> shhGetFilterChanges(BigInteger filterId) {
         return new Request<>(
                 "shh_getFilterChanges",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 ShhMessages.class);
     }
@@ -689,7 +689,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, ShhMessages> shhGetMessages(BigInteger filterId) {
         return new Request<>(
                 "shh_getMessages",
-                Arrays.asList(Numeric.toHexStringWithPrefixSafe(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefix(filterId)),
                 web3jService,
                 ShhMessages.class);
     }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -528,7 +528,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"eth_uninstallFilter\","
-                        + "\"params\":[\"0x0b\"],\"id\":1}");
+                        + "\"params\":[\"0xb\"],\"id\":1}");
     }
 
     @Test
@@ -750,7 +750,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shh_uninstallFilter\","
-                        + "\"params\":[\"0x07\"],\"id\":1}");
+                        + "\"params\":[\"0x7\"],\"id\":1}");
     }
 
     @Test
@@ -759,7 +759,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shh_getFilterChanges\","
-                        + "\"params\":[\"0x07\"],\"id\":1}");
+                        + "\"params\":[\"0x7\"],\"id\":1}");
     }
 
     @Test
@@ -768,7 +768,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shh_getMessages\","
-                        + "\"params\":[\"0x07\"],\"id\":1}");
+                        + "\"params\":[\"0x7\"],\"id\":1}");
     }
 
     @Test

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -76,11 +76,9 @@ public final class Numeric {
             return false;
         }
 
-        // If TestRpc resolves the following issue, we can reinstate this code
-        // https://github.com/ethereumjs/testrpc/issues/220
-        // if (value.length() > 3 && value.charAt(2) == '0') {
-        //    return false;
-        // }
+        if (value.length() > 3 && value.charAt(2) == '0') {
+            return false;
+        }
 
         return true;
     }
@@ -141,6 +139,11 @@ public final class Numeric {
         return toHexStringZeroPadded(value, size, true);
     }
 
+    /**
+     * @deprecated use {@link #toHexStringNoPrefix(BigInteger value)} instead, more details <a
+     *     href="https://github.com/web3j/web3j/pull/1679">here</a>
+     */
+    @Deprecated
     public static String toHexStringWithPrefixSafe(BigInteger value) {
         String result = toHexStringNoPrefix(value);
         if (result.length() < 2) {

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -15,7 +15,6 @@ package org.web3j.utils;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.web3j.exceptions.MessageDecodingException;
@@ -60,8 +59,8 @@ public class NumericTest {
     @Test
     public void testQuantityDecode() {
         assertEquals(Numeric.decodeQuantity("0x0"), (BigInteger.valueOf(0L)));
-        assertEquals(Numeric.decodeQuantity("0x400"), (BigInteger.valueOf((1024L))));
-        assertEquals(Numeric.decodeQuantity("0x0"), (BigInteger.valueOf((0L))));
+        assertEquals(Numeric.decodeQuantity("0x400"), (BigInteger.valueOf(1024L)));
+        assertEquals(Numeric.decodeQuantity("0x41"), (BigInteger.valueOf(65L)));
         assertEquals(
                 Numeric.decodeQuantity("0x7fffffffffffffff"),
                 (BigInteger.valueOf((Long.MAX_VALUE))));
@@ -72,13 +71,10 @@ public class NumericTest {
 
     @Test
     public void testQuantityDecodeLeadingZero() {
-        assertEquals(Numeric.decodeQuantity("0x0400"), (BigInteger.valueOf(1024L)));
-        assertEquals(Numeric.decodeQuantity("0x001"), (BigInteger.valueOf(1L)));
+        assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("0x0400"));
+        assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("0x001"));
     }
 
-    // If TestRpc resolves the following issue, we can reinstate this code
-    // https://github.com/ethereumjs/testrpc/issues/220
-    @Disabled
     @Test
     public void testQuantityDecodeLeadingZeroException() {
 
@@ -141,6 +137,9 @@ public class NumericTest {
     @Test
     public void testToHexStringWithPrefix() {
         assertEquals(Numeric.toHexStringWithPrefix(BigInteger.TEN), ("0xa"));
+        assertEquals(Numeric.toHexStringWithPrefix(BigInteger.valueOf(1024)), ("0x400"));
+        assertEquals(Numeric.toHexStringWithPrefix(BigInteger.valueOf(65)), ("0x41"));
+        assertEquals(Numeric.toHexStringWithPrefix(BigInteger.valueOf(0)), ("0x0"));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
- parameters for the quantities in `ethUninstallFilter`, `ethGetFilterChanges` and `ethGetFilterLogs` calls are no longer zero padded
- the `isValidHexQuantity` validator is updated to match the specification
- test cases that are currently validating incorrect behavior are corrected

### Where should the reviewer start?
Start by observing that the changes being done were already planned for (the deleted comments), the issues were observed multiple times and some fixes were already proposed.

There are not many changes, so check the source code changes first and the updated tests should make it clear what is different.

### Why is it needed?
Currently, some quantities and parameters are zero padded (not in the most compact representation). Currently 1 is specified as 0x01 instead of 0x1. This is not compliant with the specification, quoted from [here](https://eth.wiki/json-rpc/API):

> HEX value encoding
> At present there are two key datatypes that are passed over JSON: unformatted byte arrays and quantities. Both are passed with a hex encoding, however with different requirements to formatting:
> 
> When encoding QUANTITIES (integers, numbers): encode as hex, prefix with “0x”, the most compact representation (slight exception: zero should be represented as “0x0”). Examples:
> 
> 0x41 (65 in decimal)
> 0x400 (1024 in decimal)
> WRONG: 0x (should always have at least one digit - zero is “0x0”)
> WRONG: 0x0400 (no leading zeroes allowed)
> WRONG: ff (must be prefixed 0x)
> When encoding UNFORMATTED DATA (byte arrays, account addresses, hashes, bytecode arrays): encode as hex, prefix with “0x”, two hex digits per byte. Examples:
> 
> 0x41 (size 1, “A”)
> 0x004200 (size 3, “\0B\0”)
> 0x (size 0, “”)
> WRONG: 0xf0f0f (must be even number of digits)
> WRONG: 004200 (must be prefixed 0x)

There are multiple open issues and PRs already documenting instances of issues, some of them linked below. 
Fixes #1392, fixes #1631, fixes #1665, duplicates #1580