### PR TITLE
Typo in web3j documentation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.web3j
-version=4.9.1-SNAPSHOT
+version=4.9.1


### PR DESCRIPTION
### What does this PR do?
Points out a typo in the web3j docs.

### Where should the reviewer start?
https://docs.web3j.io/4.8.7/transactions/credentials/#use-walletutils-functionality
cna instead of can in this section.

### Why is it needed?
To fix the typo to avoid confusion.

