### PR TITLE
Fix EIP712 encodeType with Array

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -88,14 +88,15 @@ public class StructuredDataEncoder {
             remainingTypes.remove(remainingTypes.size() - 1);
             deps.add(structName);
 
-            for (StructuredData.Entry entry : types.get(primaryType)) {
-                if (!types.containsKey(entry.getType())) {
+            for (StructuredData.Entry entry : types.get(structName)) {
+                String baseDeclarationTypeName = getBaseTypeNameFromDeclaration(entry.getType());
+                if (!types.containsKey(baseDeclarationTypeName)) {
                     // Don't expand on non-user defined types
-                } else if (deps.contains(entry.getType())) {
+                } else if (deps.contains(baseDeclarationTypeName)) {
                     // Skip types which are already expanded
                 } else {
                     // Encountered a user defined type
-                    remainingTypes.add(entry.getType());
+                    remainingTypes.add(baseDeclarationTypeName);
                 }
             }
         }
@@ -156,6 +157,15 @@ public class StructuredDataEncoder {
         }
 
         return dimensions;
+    }
+
+
+    public String getBaseTypeNameFromDeclaration(String declaration) {
+        if (arrayTypePattern.matcher(declaration).find()) {
+            return declaration.substring(0, declaration.indexOf('['));
+        } else {
+            return declaration;
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -89,7 +89,8 @@ public class StructuredDataEncoder {
             deps.add(structName);
 
             for (StructuredData.Entry entry : types.get(structName)) {
-                String baseDeclarationTypeName = getBaseTypeNameFromDeclaration(entry.getType());
+                String declarationFieldTypeName = entry.getType();
+                String baseDeclarationTypeName = arrayTypePattern.matcher(declarationFieldTypeName).find() ? declarationFieldTypeName.substring(0, declarationFieldTypeName.indexOf('[')) : declarationFieldTypeName;
                 if (!types.containsKey(baseDeclarationTypeName)) {
                     // Don't expand on non-user defined types
                 } else if (deps.contains(baseDeclarationTypeName)) {
@@ -159,14 +160,6 @@ public class StructuredDataEncoder {
         return dimensions;
     }
 
-
-    public String getBaseTypeNameFromDeclaration(String declaration) {
-        if (arrayTypePattern.matcher(declaration).find()) {
-            return declaration.substring(0, declaration.indexOf('['));
-        } else {
-            return declaration;
-        }
-    }
 
     @SuppressWarnings("unchecked")
     public List<Pair> getDepthsAndDimensions(Object data, int depth) {

--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -90,7 +90,11 @@ public class StructuredDataEncoder {
 
             for (StructuredData.Entry entry : types.get(structName)) {
                 String declarationFieldTypeName = entry.getType();
-                String baseDeclarationTypeName = arrayTypePattern.matcher(declarationFieldTypeName).find() ? declarationFieldTypeName.substring(0, declarationFieldTypeName.indexOf('[')) : declarationFieldTypeName;
+                String baseDeclarationTypeName =
+                        arrayTypePattern.matcher(declarationFieldTypeName).find()
+                                ? declarationFieldTypeName.substring(
+                                        0, declarationFieldTypeName.indexOf('['))
+                                : declarationFieldTypeName;
                 if (!types.containsKey(baseDeclarationTypeName)) {
                     // Don't expand on non-user defined types
                 } else if (deps.contains(baseDeclarationTypeName)) {
@@ -159,7 +163,6 @@ public class StructuredDataEncoder {
 
         return dimensions;
     }
-
 
     @SuppressWarnings("unchecked")
     public List<Pair> getDepthsAndDimensions(Object data, int depth) {

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -222,6 +222,29 @@ public class StructuredDataTest {
                 Numeric.toHexString(dataEncoder.hashStructuredData()));
     }
 
+
+    // EIP712 v4
+    @Test
+    public void testEncodeTypeWithArrays() throws IOException {
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(
+                        getResource(
+                                "build/resources/test/"
+                                        + "structured_data_json_files/ValidStructuredDataWithArrays.json")); // taken from https://danfinlay.github.io/js-eth-personal-sign-examples/ and updated to int,uint arrays
+        String expectedMailType = "Mail(Person from,Group[] to,string contents)"
+                + "Group(string name,Person[] members)"
+                + "Person(string name,address[] wallets)";
+
+
+        assertEquals(dataEncoder.encodeType("Mail"), expectedMailType);
+
+        String expectedGroupType = "Group(string name,Person[] members)"
+                + "Person(string name,address[] wallets)";
+
+
+        assertEquals(dataEncoder.encodeType("Group"), expectedGroupType);
+    }
+
     // EIP712 v4
     @Test
     public void testValidStructureWithArrays() throws IOException {

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -222,7 +222,6 @@ public class StructuredDataTest {
                 Numeric.toHexString(dataEncoder.hashStructuredData()));
     }
 
-
     // EIP712 v4
     @Test
     public void testEncodeTypeWithArrays() throws IOException {
@@ -231,16 +230,15 @@ public class StructuredDataTest {
                         getResource(
                                 "build/resources/test/"
                                         + "structured_data_json_files/ValidStructuredDataWithArrays.json")); // taken from https://danfinlay.github.io/js-eth-personal-sign-examples/ and updated to int,uint arrays
-        String expectedMailType = "Mail(Person from,Group[] to,string contents)"
-                + "Group(string name,Person[] members)"
-                + "Person(string name,address[] wallets)";
-
+        String expectedMailType =
+                "Mail(Person from,Group[] to,string contents)"
+                        + "Group(string name,Person[] members)"
+                        + "Person(string name,address[] wallets)";
 
         assertEquals(dataEncoder.encodeType("Mail"), expectedMailType);
 
-        String expectedGroupType = "Group(string name,Person[] members)"
-                + "Person(string name,address[] wallets)";
-
+        String expectedGroupType =
+                "Group(string name,Person[] members)" + "Person(string name,address[] wallets)";
 
         assertEquals(dataEncoder.encodeType("Group"), expectedGroupType);
     }

--- a/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithArrays.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidStructuredDataWithArrays.json
@@ -16,11 +16,16 @@
     },
     "to": [
       {
-        "name": "Bob",
-        "wallets": [
-          "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
-          "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
-          "0xB0B0b0b0b0b0B000000000000000000000000000"
+        "name": "Group A",
+        "members": [
+          {
+            "name": "Bob",
+            "wallets": [
+              "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+              "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
+              "0xB0B0b0b0b0b0B000000000000000000000000000"
+            ]
+          }
         ]
       }
     ]
@@ -62,7 +67,7 @@
       },
       {
         "name": "to",
-        "type": "Person[]"
+        "type": "Group[]"
       },
       {
         "name": "contents",


### PR DESCRIPTION
### What does this PR do?
if types define as below
``` JSON
types: {
  "Group": [
    {
      "name": "name",
      "type": "string"
    },
    {
      "name": "members",
      "type": "Person[]"
    }
  ],
  "Mail": [
    {
      "name": "from",
      "type": "Person"
    },
    {
      "name": "to",
      "type": "Group[]"
    },
    {
      "name": "contents",
      "type": "string"
    }
  ],
  "Person": [
    {
      "name": "name",
      "type": "string"
    },
    {
      "name": "wallets",
      "type": "address[]"
    }
  ]
}
```
`encodeType("Group")` result
expect: `"Group(string name,Person[] members)Person(string name,address[] wallets)"`
actual: `"Group(string name,Person[] members)"`

because `StructuredDataEncoder.getDependencies` does not handle the case where the fields are arrays

This PR contains Fix and Test code.


### Where should the reviewer start?
Changed Files

### Why is it needed?
EIP-712 with Array leads to the wrong result.
This PR fix it.

