### PR TITLE
Make ClientConnectionException an IOException

### DIFF
--- a/core/src/main/java/org/web3j/protocol/exceptions/ClientConnectionException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/ClientConnectionException.java
@@ -12,8 +12,10 @@
  */
 package org.web3j.protocol.exceptions;
 
+import java.io.IOException;
+
 /** Client connection exception. */
-public class ClientConnectionException extends RuntimeException {
+public class ClientConnectionException extends IOException {
     public ClientConnectionException(String message) {
         super(message);
     }


### PR DESCRIPTION
A ClientConnectionException happens when there is a failure to connect to the target url. For example, it could happen if the server responds with an 503 error code. Therefore, it is a typical IOException and not a RuntimeException.

### What does this PR do?
Make ClientConnectionException an IOException

### Where should the reviewer start?
There is only one line of code plus an import statement that changed.

### Why is it needed?
To better conform to general Java design conventions and the principle of the least surprise. If a connection problem happens, an IOException and not a RuntimeException is the expected exception type.

