### PR TITLE
Fix crash in android version < 28 

### DIFF
--- a/abi/src/main/java/org/web3j/abi/Utils.java
+++ b/abi/src/main/java/org/web3j/abi/Utils.java
@@ -12,18 +12,6 @@
  */
 package org.web3j.abi;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
 import org.web3j.abi.datatypes.Fixed;
@@ -35,6 +23,18 @@ import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Ufixed;
 import org.web3j.abi.datatypes.Uint;
 import org.web3j.abi.datatypes.Utf8String;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** Utility functions. */
 public class Utils {
@@ -49,7 +49,7 @@ public class Utils {
                 type = (Class<?>) ((ParameterizedType) reflectedType).getRawType();
                 return getParameterizedTypeName(typeReference, type);
             } else {
-                type = Class.forName(reflectedType.getTypeName());
+                type = Class.forName(getTypeName(reflectedType));
                 return getSimpleTypeName(type);
             }
         } catch (ClassNotFoundException e) {
@@ -107,7 +107,7 @@ public class Utils {
         java.lang.reflect.Type[] typeArguments =
                 ((ParameterizedType) type).getActualTypeArguments();
 
-        String parameterizedTypeName = typeArguments[0].getTypeName();
+        String parameterizedTypeName = getTypeName(typeArguments[0]);
         return (Class<T>) Class.forName(parameterizedTypeName);
     }
 
@@ -200,4 +200,45 @@ public class Utils {
         return Stream.concat(canonicalFields.stream(), nestedFields.stream())
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Ports {@link java.lang.reflect.Type#getTypeName()}.
+     */
+    public static String getTypeName(java.lang.reflect.Type type) {
+
+        try {
+            return type.getTypeName();
+        } catch (NoSuchMethodError e) {
+            return getClassName((Class) type);
+        }
+    }
+
+    /**
+     * Support java version < 8
+     * Copied from {@link Class#getTypeName()}.
+     */
+    private static String getClassName(Class type) {
+
+        if (type.isArray()) {
+            try {
+                Class<?> cl = type;
+                int dimensions = 0;
+                while (cl.isArray()) {
+                    dimensions++;
+                    cl = cl.getComponentType();
+                }
+                StringBuilder sb = new StringBuilder();
+                sb.append(cl.getName());
+                for (int i = 0; i < dimensions; i++) {
+                    sb.append("[]");
+                }
+                return sb.toString();
+            } catch (Throwable e) {
+                /*FALLTHRU*/
+            }
+        }
+
+        return type.getName();
+    }
+
 }


### PR DESCRIPTION
### What does this PR do?
My project is crashing on all devices with android version < 28, caused by getTypeName() function not found. Even though I have my project set up in java 8

### Where should the reviewer start?
Utils.java in module abi

### Why is it needed?
Help the system run stably and without crashing on devices with android version < 28

