### PR TITLE
Support EmptyTransactionReceipt in Contract

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -49,6 +49,7 @@ import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.tx.gas.ContractEIP1559GasProvider;
 import org.web3j.tx.gas.ContractGasProvider;
 import org.web3j.tx.gas.StaticGasProvider;
+import org.web3j.tx.response.EmptyTransactionReceipt;
 import org.web3j.utils.Numeric;
 
 import static org.web3j.utils.RevertReasonExtractor.extractRevertReason;
@@ -403,7 +404,9 @@ public abstract class Contract extends ManagedTransaction {
             throw new TransactionException(error.getData().toString());
         }
 
-        if (receipt != null && !receipt.isStatusOK()) {
+        if (!(receipt instanceof EmptyTransactionReceipt)
+                && receipt != null
+                && !receipt.isStatusOK()) {
             throw new TransactionException(
                     String.format(
                             "Transaction %s has failed with status: %s. "

--- a/core/src/test/java/org/web3j/tx/ContractTest.java
+++ b/core/src/test/java/org/web3j/tx/ContractTest.java
@@ -51,6 +51,7 @@ import org.web3j.tx.gas.ContractGasProvider;
 import org.web3j.tx.gas.DefaultGasProvider;
 import org.web3j.tx.gas.StaticEIP1559GasProvider;
 import org.web3j.tx.gas.StaticGasProvider;
+import org.web3j.tx.response.EmptyTransactionReceipt;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
 
@@ -577,6 +578,19 @@ public class ContractTest extends ManagedTransactionTester {
 
         assertEquals(eventValuesWithLogs2.size(), 1);
         assertEquals(eventValuesWithLogs2.get(0).getLog(), logs.get(1));
+    }
+
+    @Test
+    public void testEmptyTransactionReceipt() throws Exception {
+        TransactionReceipt transactionReceipt = new EmptyTransactionReceipt(TRANSACTION_HASH);
+
+        prepareTransaction(transactionReceipt);
+
+        assertEquals(
+                transactionReceipt,
+                contract.performTransaction(
+                                new Address(BigInteger.TEN), new Uint256(BigInteger.ONE))
+                        .send());
     }
 
     void testErrorScenario() throws Throwable {


### PR DESCRIPTION
### What does this PR do?
Make `Contract.java` supports `NoOpProcessor` and `QueuingTransactionReceiptProcessor`

### Where should the reviewer start?
[Contract.java Line 407](https://github.com/rymuff/web3j/blob/supportNoOpProcessor/core/src/main/java/org/web3j/tx/Contract.java#L407)

### Why is it needed?
I found that Contract dose not support `TransactionManager` with `NoOpProcessor` or `QueuingTransactionReceiptProcessor`.

In `Contract` class, `executeTransaction()` checks the status of receipt with `!receipt.isStatusOK()`
(https://github.com/web3j/web3j/blob/master/core/src/main/java/org/web3j/tx/Contract.java#L406)

and `.isStatusOK()` calls `getStatus()`
(https://github.com/web3j/web3j/blob/master/core/src/main/java/org/web3j/protocol/core/methods/response/TransactionReceipt.java#L167)

while `getStatus()` is unsupported operation in `EmptyTransactionReceipt` which is produced by `NoOpProcessor` and `QueuingTransactionReceiptProcessor`.
(https://github.com/web3j/web3j/blob/master/core/src/main/java/org/web3j/tx/response/EmptyTransactionReceipt.java#L138)

To solve this problem, it can be bypassed by checking the receipt is instance of `EmptyTransactionReceipt`.
`if (!(receipt instanceof EmptyTransactionReceipt) && receipt != null && !receipt.isStatusOK()) { `

Also fix #1636, fix #1548, fix #1207 