### PR TITLE
Fix Android compatibility for API < 26

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -413,7 +413,8 @@ public class TypeDecoder {
             return consumer.apply(elements, typeName);
         } catch (ClassNotFoundException e) {
             throw new UnsupportedOperationException(
-                    "Unable to access parameterized type " + typeReference.getType().getTypeName(),
+                    "Unable to access parameterized type "
+                            + Utils.getTypeName(typeReference.getType()),
                     e);
         }
     }
@@ -562,7 +563,8 @@ public class TypeDecoder {
             return consumer.apply(elements, typeName);
         } catch (ClassNotFoundException e) {
             throw new UnsupportedOperationException(
-                    "Unable to access parameterized type " + typeReference.getType().getTypeName(),
+                    "Unable to access parameterized type "
+                            + Utils.getTypeName(typeReference.getType()),
                     e);
         }
     }
@@ -706,7 +708,8 @@ public class TypeDecoder {
             }
         } catch (ClassNotFoundException e) {
             throw new UnsupportedOperationException(
-                    "Unable to access parameterized type " + typeReference.getType().getTypeName(),
+                    "Unable to access parameterized type "
+                            + Utils.getTypeName(typeReference.getType()),
                     e);
         }
     }

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -91,7 +91,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
         if (getType() instanceof ParameterizedType) {
             return (Class<T>) ((ParameterizedType) clsType).getRawType();
         } else {
-            return (Class<T>) Class.forName(clsType.getTypeName());
+            return (Class<T>) Class.forName(Utils.getTypeName(clsType));
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Fixes exceptions caused by the usage of `Type.getTypeName()` method which is available only since Java 8 and supported on Android since version 26. The fix is taken from this PR #1706, but is actually applied to the code in the library and makes it compile and go through the checks. It is also tested by integration with our app.

### Where should the reviewer start?
`Utils.java` from `org.web3j.abi` package

### Why is it needed?
To make the library work on Android devices with API level lower than 26

