### PR TITLE
Add QBFT API methods providing access to the QBFT consensus engine

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -101,6 +101,19 @@ public interface Besu extends Eea, BesuRx {
 
     Request<?, BooleanResponse> ibftProposeValidatorVote(String address, Boolean validatorAddition);
 
+    Request<?, BooleanResponse> qbftDiscardValidatorVote(String address);
+
+    Request<?, BesuEthAccountsMapResponse> qbftGetPendingVotes();
+
+    Request<?, BesuSignerMetrics> qbftGetSignerMetrics();
+
+    Request<?, EthAccounts> qbftGetValidatorsByBlockNumber(
+            DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, EthAccounts> qbftGetValidatorsByBlockHash(String blockHash);
+
+    Request<?, BooleanResponse> qbftProposeValidatorVote(String address, Boolean validatorAddition);
+
     Request<?, EthGetTransactionCount> privGetTransactionCount(
             final String address, final Base64String privacyGroupId);
 

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -210,6 +210,56 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 BooleanResponse.class);
     }
 
+    public Request<?, BooleanResponse> qbftDiscardValidatorVote(String address) {
+        return new Request<>(
+                "qbft_discardValidatorVote",
+                Arrays.asList(address),
+                web3jService,
+                BooleanResponse.class);
+    }
+
+    public Request<?, BesuEthAccountsMapResponse> qbftGetPendingVotes() {
+        return new Request<>(
+                "qbft_getPendingVotes",
+                Collections.<String>emptyList(),
+                web3jService,
+                BesuEthAccountsMapResponse.class);
+    }
+
+    public Request<?, BesuSignerMetrics> qbftGetSignerMetrics() {
+        return new Request<>(
+                "qbft_getSignerMetrics",
+                Collections.<String>emptyList(),
+                web3jService,
+                BesuSignerMetrics.class);
+    }
+
+    public Request<?, EthAccounts> qbftGetValidatorsByBlockNumber(
+            DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "qbft_getValidatorsByBlockNumber",
+                Arrays.asList(defaultBlockParameter.getValue()),
+                web3jService,
+                EthAccounts.class);
+    }
+
+    public Request<?, EthAccounts> qbftGetValidatorsByBlockHash(String blockHash) {
+        return new Request<>(
+                "qbft_getValidatorsByBlockHash",
+                Arrays.asList(blockHash),
+                web3jService,
+                EthAccounts.class);
+    }
+
+    public Request<?, BooleanResponse> qbftProposeValidatorVote(
+            String address, Boolean validatorAddition) {
+        return new Request<>(
+                "qbft_proposeValidatorVote",
+                Arrays.asList(address, validatorAddition),
+                web3jService,
+                BooleanResponse.class);
+    }
+
     @Override
     public Request<?, EthGetTransactionCount> privGetTransactionCount(
             final String address, final Base64String privacyGroupId) {

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -132,7 +132,7 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
- add-qbft    public void testIbftDiscardValidatorVote() throws Exception {
+    public void testIbftDiscardValidatorVote() throws Exception {
         final String accountId = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
         web3j.ibftDiscardValidatorVote(accountId).send();
 

--- a/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
+++ b/besu/src/test/java/org/web3j/protocol/besu/RequestTest.java
@@ -132,7 +132,7 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
-    public void testibftDiscardValidatorVote() throws Exception {
+ add-qbft    public void testIbftDiscardValidatorVote() throws Exception {
         final String accountId = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
         web3j.ibftDiscardValidatorVote(accountId).send();
 
@@ -179,6 +179,57 @@ public class RequestTest extends RequestTester {
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"ibft_proposeValidatorVote\","
+                        + "\"params\":[\"0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73\",true],\"id\":1}");
+    }
+
+    @Test
+    public void testQbftDiscardValidatorVote() throws Exception {
+        final String accountId = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
+        web3j.qbftDiscardValidatorVote(accountId).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"qbft_discardValidatorVote\","
+                        + "\"params\":[\"0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73\"],\"id\":1}");
+    }
+
+    @Test
+    public void testQbftGetPendingVotes() throws Exception {
+        web3j.qbftGetPendingVotes().send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"qbft_getPendingVotes\","
+                        + "\"params\":[],\"id\":1}");
+    }
+
+    @Test
+    public void testQbftGetValidatorsByBlockNumber() throws Exception {
+        final DefaultBlockParameter blockParameter = DefaultBlockParameter.valueOf("latest");
+        web3j.qbftGetValidatorsByBlockNumber(blockParameter).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"qbft_getValidatorsByBlockNumber\","
+                        + "\"params\":[\"latest\"],\"id\":1}");
+    }
+
+    @Test
+    public void testQbftGetValidatorsByBlockHash() throws Exception {
+        final String blockHash =
+                "0x98b2ddb5106b03649d2d337d42154702796438b3c74fd25a5782940e84237a48";
+        web3j.qbftGetValidatorsByBlockHash(blockHash).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"qbft_getValidatorsByBlockHash\",\"params\":"
+                        + "[\"0x98b2ddb5106b03649d2d337d42154702796438b3c74fd25a5782940e84237a48\"]"
+                        + ",\"id\":1}");
+    }
+
+    @Test
+    public void testQbftProposeValidatorVote() throws Exception {
+        final String validatorAddress = "0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73";
+        web3j.qbftProposeValidatorVote(validatorAddress, true).send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"qbft_proposeValidatorVote\","
                         + "\"params\":[\"0xFE3B557E8Fb62b89F4916B721be55cEb828dBd73\",true],\"id\":1}");
     }
 


### PR DESCRIPTION
### What does this PR do?
Add QBFT API methods to the Besu package.

### Where should the reviewer start?
Besu supports consensus engine specific endpoints for IBFT and QBFT. Web3j only supports IBFT. 

### Why is it needed?
It provides access to the QBFT consensus engine.
