### PR TITLE
secp256r1 support to create keys and sign transactions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 
 ext {
-    bouncycastleVersion = '1.68'
+    bouncycastleVersion = '1.69'
     jacksonVersion = '2.13.1'
     javaPoetVersion = '1.7.0'
     kotlinVersion = '1.3.72'

--- a/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
+++ b/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
@@ -117,7 +117,7 @@ public class Bip32ECKeyPair extends ECKeyPair {
             Arrays.fill(i, (byte) 0);
             BigInteger ilInt = new BigInteger(1, il);
             Arrays.fill(il, (byte) 0);
-            BigInteger privateKey = getPrivateKey().add(ilInt).mod(ECDSASignature.K1_CURVE.getN());
+            BigInteger privateKey = getPrivateKey().add(ilInt).mod(Sign.CURVE.getN());
 
             return new Bip32ECKeyPair(
                     privateKey,

--- a/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
+++ b/crypto/src/main/java/org/web3j/crypto/Bip32ECKeyPair.java
@@ -117,7 +117,7 @@ public class Bip32ECKeyPair extends ECKeyPair {
             Arrays.fill(i, (byte) 0);
             BigInteger ilInt = new BigInteger(1, il);
             Arrays.fill(il, (byte) 0);
-            BigInteger privateKey = getPrivateKey().add(ilInt).mod(Sign.CURVE.getN());
+            BigInteger privateKey = getPrivateKey().add(ilInt).mod(ECDSASignature.K1_CURVE.getN());
 
             return new Bip32ECKeyPair(
                     privateKey,

--- a/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
+++ b/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
@@ -16,8 +16,6 @@ import java.math.BigInteger;
 
 import org.bouncycastle.crypto.params.ECDomainParameters;
 
-import static org.web3j.crypto.Sign.CURVE;
-
 /** An ECDSA Signature. */
 public class ECDSASignature {
     public final BigInteger r;
@@ -56,13 +54,13 @@ public class ECDSASignature {
             //    N = 10
             //    s = 8, so (-8 % 10 == 2) thus both (r, 8) and (r, 2) are valid solutions.
             //    10 - 8 == 2, giving us always the latter solution, which is canonical.
-            return new ECDSASignature(r, CURVE.getN().subtract(s));
+            return new ECDSASignature(r, Sign.CURVE.getN().subtract(s));
         } else {
             return this;
         }
     }
 
     public ECDomainParameters getCurve() {
-        return CURVE;
+        return Sign.CURVE;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
+++ b/crypto/src/main/java/org/web3j/crypto/ECDSASignature.java
@@ -14,22 +14,12 @@ package org.web3j.crypto;
 
 import java.math.BigInteger;
 
-import org.bouncycastle.asn1.x9.X9ECParameters;
-import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+
+import static org.web3j.crypto.Sign.CURVE;
 
 /** An ECDSA Signature. */
 public class ECDSASignature {
-
-    public static final X9ECParameters K1_CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");
-    static final ECDomainParameters K1_CURVE =
-            new ECDomainParameters(
-                    K1_CURVE_PARAMS.getCurve(),
-                    K1_CURVE_PARAMS.getG(),
-                    K1_CURVE_PARAMS.getN(),
-                    K1_CURVE_PARAMS.getH());
-    static final BigInteger K1_HALF_CURVE_ORDER = K1_CURVE_PARAMS.getN().shiftRight(1);
-
     public final BigInteger r;
     public final BigInteger s;
 
@@ -40,12 +30,12 @@ public class ECDSASignature {
 
     /**
      * @return true if the S component is "low", that means it is below {@link
-     *     ECDSASignature#K1_HALF_CURVE_ORDER}. See <a
+     *     Sign#HALF_CURVE_ORDER}. See <a
      *     href="https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures">
      *     BIP62</a>.
      */
     public boolean isCanonical() {
-        return s.compareTo(K1_HALF_CURVE_ORDER) <= 0;
+        return s.compareTo(Sign.HALF_CURVE_ORDER) <= 0;
     }
 
     /**
@@ -66,13 +56,13 @@ public class ECDSASignature {
             //    N = 10
             //    s = 8, so (-8 % 10 == 2) thus both (r, 8) and (r, 2) are valid solutions.
             //    10 - 8 == 2, giving us always the latter solution, which is canonical.
-            return new ECDSASignature(r, ECDSASignature.K1_CURVE.getN().subtract(s));
+            return new ECDSASignature(r, CURVE.getN().subtract(s));
         } else {
             return this;
         }
     }
 
     public ECDomainParameters getCurve() {
-        return K1_CURVE;
+        return CURVE;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/ECKeyPair.java
+++ b/crypto/src/main/java/org/web3j/crypto/ECKeyPair.java
@@ -27,6 +27,8 @@ import org.bouncycastle.math.ec.ECCurve;
 
 import org.web3j.utils.Numeric;
 
+import static org.web3j.crypto.Sign.CURVE;
+
 /** Elliptic Curve SECP-256k1 or SECP-256r1 generated key pair. */
 public class ECKeyPair {
     private final BigInteger privateKey;
@@ -36,9 +38,7 @@ public class ECKeyPair {
     public ECKeyPair(BigInteger privateKey, BigInteger publicKey) {
         this.privateKey = privateKey;
         this.publicKey = publicKey;
-        this.ecCurve =
-                ECDSASignature.K1_CURVE
-                        .getCurve(); // usage of this constructor by default uses SECP-256k1
+        this.ecCurve = CURVE.getCurve(); // usage of this constructor by default uses SECP-256k1
     }
 
     public ECKeyPair(BigInteger privateKey, BigInteger publicKey, ECCurve ecCurve) {
@@ -73,7 +73,7 @@ public class ECKeyPair {
         signer.init(true, privKey);
         BigInteger[] components = signer.generateSignature(transactionHash);
 
-        if (curve == NistECDSASignature.R1_CURVE) {
+        if (curve == Sign.NIST_CURVE) {
             return new NistECDSASignature(components[0], components[1]).toCanonicalised();
         } else {
             return new ECDSASignature(components[0], components[1]).toCanonicalised();

--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -58,19 +58,19 @@ public class Keys {
      */
     static KeyPair createSecp256k1KeyPair()
             throws NoSuchProviderException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException {
+                    InvalidAlgorithmParameterException {
         return createSecp256k1KeyPair(secureRandom());
     }
 
     static KeyPair createSecp256r1KeyPair()
             throws NoSuchProviderException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException {
+                    InvalidAlgorithmParameterException {
         return createSecp256r1KeyPair(secureRandom());
     }
 
     static KeyPair createSecp256k1KeyPair(SecureRandom random)
             throws NoSuchProviderException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException {
+                    InvalidAlgorithmParameterException {
 
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
         ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256k1");
@@ -84,7 +84,7 @@ public class Keys {
 
     static KeyPair createSecp256r1KeyPair(SecureRandom random)
             throws NoSuchProviderException, NoSuchAlgorithmException,
-            InvalidAlgorithmParameterException {
+                    InvalidAlgorithmParameterException {
 
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
         ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256r1");
@@ -102,13 +102,13 @@ public class Keys {
 
     public static ECKeyPair createEcKeyPair()
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
-            NoSuchProviderException {
+                    NoSuchProviderException {
         return createEcKeyPair(secureRandom());
     }
 
     public static ECKeyPair createEcKeyPair(SecureRandom random)
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
-            NoSuchProviderException {
+                    NoSuchProviderException {
         KeyPair keyPair = createSecp256k1KeyPair(random);
         return ECKeyPair.create(keyPair);
     }

--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -58,13 +58,19 @@ public class Keys {
      */
     static KeyPair createSecp256k1KeyPair()
             throws NoSuchProviderException, NoSuchAlgorithmException,
-                    InvalidAlgorithmParameterException {
+            InvalidAlgorithmParameterException {
         return createSecp256k1KeyPair(secureRandom());
+    }
+
+    static KeyPair createSecp256r1KeyPair()
+            throws NoSuchProviderException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException {
+        return createSecp256r1KeyPair(secureRandom());
     }
 
     static KeyPair createSecp256k1KeyPair(SecureRandom random)
             throws NoSuchProviderException, NoSuchAlgorithmException,
-                    InvalidAlgorithmParameterException {
+            InvalidAlgorithmParameterException {
 
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
         ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256k1");
@@ -76,15 +82,33 @@ public class Keys {
         return keyPairGenerator.generateKeyPair();
     }
 
+    static KeyPair createSecp256r1KeyPair(SecureRandom random)
+            throws NoSuchProviderException, NoSuchAlgorithmException,
+            InvalidAlgorithmParameterException {
+
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
+        ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256r1");
+        if (random != null) {
+            keyPairGenerator.initialize(ecGenParameterSpec, random);
+        } else {
+            keyPairGenerator.initialize(ecGenParameterSpec);
+        }
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    public static ECKeyPair createEcKeyPair(KeyPair keyPair) {
+        return ECKeyPair.create(keyPair);
+    }
+
     public static ECKeyPair createEcKeyPair()
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
-                    NoSuchProviderException {
+            NoSuchProviderException {
         return createEcKeyPair(secureRandom());
     }
 
     public static ECKeyPair createEcKeyPair(SecureRandom random)
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException,
-                    NoSuchProviderException {
+            NoSuchProviderException {
         KeyPair keyPair = createSecp256k1KeyPair(random);
         return ECKeyPair.create(keyPair);
     }

--- a/crypto/src/main/java/org/web3j/crypto/NistECDSASignature.java
+++ b/crypto/src/main/java/org/web3j/crypto/NistECDSASignature.java
@@ -14,20 +14,12 @@ package org.web3j.crypto;
 
 import java.math.BigInteger;
 
-import org.bouncycastle.asn1.x9.X9ECParameters;
-import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 
-public class NistECDSASignature extends ECDSASignature {
+import static org.web3j.crypto.Sign.NIST_CURVE;
+import static org.web3j.crypto.Sign.NIST_HALF_CURVE_ORDER;
 
-    public static final X9ECParameters R1_CURVE_PARAMS = CustomNamedCurves.getByName("secp256r1");
-    static final ECDomainParameters R1_CURVE =
-            new ECDomainParameters(
-                    R1_CURVE_PARAMS.getCurve(),
-                    R1_CURVE_PARAMS.getG(),
-                    R1_CURVE_PARAMS.getN(),
-                    R1_CURVE_PARAMS.getH());
-    static final BigInteger R1_HALF_CURVE_ORDER = R1_CURVE_PARAMS.getN().shiftRight(1);
+public class NistECDSASignature extends ECDSASignature {
 
     public NistECDSASignature(BigInteger r, BigInteger s) {
         super(r, s);
@@ -35,13 +27,13 @@ public class NistECDSASignature extends ECDSASignature {
 
     /**
      * @return true if the S component is "low", that means it is below {@link
-     *     NistECDSASignature#R1_HALF_CURVE_ORDER}. See <a
+     *     Sign#NIST_HALF_CURVE_ORDER}. See <a
      *     href="https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Low_S_values_in_signatures">
      *     BIP62</a>.
      */
     @Override
     public boolean isCanonical() {
-        return s.compareTo(R1_HALF_CURVE_ORDER) <= 0;
+        return s.compareTo(NIST_HALF_CURVE_ORDER) <= 0;
     }
 
     /**
@@ -63,7 +55,7 @@ public class NistECDSASignature extends ECDSASignature {
             //    N = 10
             //    s = 8, so (-8 % 10 == 2) thus both (r, 8) and (r, 2) are valid solutions.
             //    10 - 8 == 2, giving us always the latter solution, which is canonical.
-            return new NistECDSASignature(r, R1_CURVE.getN().subtract(s));
+            return new NistECDSASignature(r, NIST_CURVE.getN().subtract(s));
         } else {
             return this;
         }
@@ -71,6 +63,6 @@ public class NistECDSASignature extends ECDSASignature {
 
     @Override
     public ECDomainParameters getCurve() {
-        return R1_CURVE;
+        return NIST_CURVE;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/NistECDSASignature.java
+++ b/crypto/src/main/java/org/web3j/crypto/NistECDSASignature.java
@@ -16,9 +16,6 @@ import java.math.BigInteger;
 
 import org.bouncycastle.crypto.params.ECDomainParameters;
 
-import static org.web3j.crypto.Sign.NIST_CURVE;
-import static org.web3j.crypto.Sign.NIST_HALF_CURVE_ORDER;
-
 public class NistECDSASignature extends ECDSASignature {
 
     public NistECDSASignature(BigInteger r, BigInteger s) {
@@ -33,7 +30,7 @@ public class NistECDSASignature extends ECDSASignature {
      */
     @Override
     public boolean isCanonical() {
-        return s.compareTo(NIST_HALF_CURVE_ORDER) <= 0;
+        return s.compareTo(Sign.NIST_HALF_CURVE_ORDER) <= 0;
     }
 
     /**
@@ -55,7 +52,7 @@ public class NistECDSASignature extends ECDSASignature {
             //    N = 10
             //    s = 8, so (-8 % 10 == 2) thus both (r, 8) and (r, 2) are valid solutions.
             //    10 - 8 == 2, giving us always the latter solution, which is canonical.
-            return new NistECDSASignature(r, NIST_CURVE.getN().subtract(s));
+            return new NistECDSASignature(r, Sign.NIST_CURVE.getN().subtract(s));
         } else {
             return this;
         }
@@ -63,6 +60,6 @@ public class NistECDSASignature extends ECDSASignature {
 
     @Override
     public ECDomainParameters getCurve() {
-        return NIST_CURVE;
+        return Sign.NIST_CURVE;
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/KeysTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/KeysTest.java
@@ -53,8 +53,42 @@ public class KeysTest {
     }
 
     @Test
+    public void testCreateSecp256r1KeyPair() throws Exception {
+        KeyPair keyPair = Keys.createSecp256r1KeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        assertNotNull(privateKey);
+        assertNotNull(publicKey);
+
+        assertEquals(privateKey.getEncoded().length, (150));
+        assertEquals(publicKey.getEncoded().length, (91));
+    }
+
+    @Test
+    public void testCreateSecp256r1KeyPairRandomNull() throws Exception {
+        KeyPair keyPair = Keys.createSecp256r1KeyPair(null);
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        assertNotNull(privateKey);
+        assertNotNull(publicKey);
+
+        assertEquals(privateKey.getEncoded().length, (150));
+        assertEquals(publicKey.getEncoded().length, (91));
+    }
+
+    @Test
     public void testCreateEcKeyPair() throws Exception {
         ECKeyPair ecKeyPair = Keys.createEcKeyPair();
+        assertEquals(ecKeyPair.getPublicKey().signum(), (1));
+        assertEquals(ecKeyPair.getPrivateKey().signum(), (1));
+    }
+
+    @Test
+    public void testCreateEcKeyPairR1() throws Exception {
+        KeyPair keyPair = Keys.createSecp256r1KeyPair();
+        ECKeyPair ecKeyPair = Keys.createEcKeyPair(keyPair);
         assertEquals(ecKeyPair.getPublicKey().signum(), (1));
         assertEquals(ecKeyPair.getPrivateKey().signum(), (1));
     }

--- a/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
+++ b/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
@@ -12,9 +12,9 @@
  */
 package org.web3j.crypto;
 
-import org.web3j.utils.Numeric;
-
 import java.math.BigInteger;
+
+import org.web3j.utils.Numeric;
 
 /** Keys generated for unit testing purposes. */
 public class SampleR1Keys {

--- a/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
+++ b/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
@@ -29,7 +29,7 @@ public class SampleR1Keys {
     static final BigInteger PUBLIC_KEY = Numeric.toBigInt(PUBLIC_KEY_STRING);
 
     static final ECKeyPair KEY_PAIR =
-            new ECKeyPair(PRIVATE_KEY, PUBLIC_KEY, NistECDSASignature.R1_CURVE.getCurve());
+            new ECKeyPair(PRIVATE_KEY, PUBLIC_KEY, Sign.NIST_CURVE.getCurve());
 
     private SampleR1Keys() {}
 }

--- a/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
+++ b/crypto/src/test/java/org/web3j/crypto/SampleR1Keys.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+
+/** Keys generated for unit testing purposes. */
+public class SampleR1Keys {
+
+    public static final String PRIVATE_KEY_STRING =
+            "841751f2469044902cd0190724aff81233447d5da96dd4b86eb4e632a5c7f32d";
+    static final String PUBLIC_KEY_STRING =
+            "0x59320b8c6a805b6feb8295b8663bbe696f30d65115138b8a35c320215f3f0ba3e4525befe27caaee7818b7ee66485503031d74a6150b70b079dfbd7171eaf57";
+    public static final String ADDRESS = "0x7eb4e4c200d9f2bd45dc1701680974948ac07717";
+
+    static final BigInteger PRIVATE_KEY = Numeric.toBigInt(PRIVATE_KEY_STRING);
+    static final BigInteger PUBLIC_KEY = Numeric.toBigInt(PUBLIC_KEY_STRING);
+
+    static final ECKeyPair KEY_PAIR =
+            new ECKeyPair(PRIVATE_KEY, PUBLIC_KEY, NistECDSASignature.R1_CURVE.getCurve());
+
+    private SampleR1Keys() {}
+}

--- a/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import org.bouncycastle.math.ec.ECPoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.web3j.crypto.Sign.CHAIN_ID_INC;
+import static org.web3j.crypto.Sign.LOWER_REAL_V;
+import static org.web3j.crypto.Sign.REPLAY_PROTECTED_V_MIN;
+
+public class SignR1Test {
+
+    private static final byte[] TEST_MESSAGE = "A test message".getBytes();
+
+    @Test
+    public void testSignMessage() {
+        Sign.SignatureData signatureData =
+                Sign.signPrefixedMessage(TEST_MESSAGE, SampleR1Keys.KEY_PAIR);
+
+        Sign.SignatureData expected =
+                new Sign.SignatureData(
+                        (byte) 27,
+                        Numeric.hexStringToByteArray(
+                                "0x5384eea41f6a9fe7a45740b276fc827dc5c3824c9e86c46b539a6e96eb7ea9ba"),
+                        Numeric.hexStringToByteArray(
+                                "0x7ffc6e1691190524865d97ca45cf528ee8fe6840ba282e9941cc8c39b759704e"));
+
+        assertEquals(signatureData, (expected));
+    }
+
+    @Test
+    public void testSignedMessageToKey() throws SignatureException {
+        Sign.SignatureData signatureData =
+                Sign.signPrefixedMessage(TEST_MESSAGE, SampleR1Keys.KEY_PAIR);
+        BigInteger key = Sign.signedPrefixedMessageToR1Key(TEST_MESSAGE, signatureData);
+        assertEquals(key, (SampleR1Keys.PUBLIC_KEY));
+    }
+
+    @Test
+    public void testPublicKeyFromPrivateKey() {
+        assertEquals(
+                Sign.publicKeyFromPrivate(SampleR1Keys.PRIVATE_KEY, NistECDSASignature.R1_CURVE),
+                (SampleR1Keys.PUBLIC_KEY));
+    }
+
+    @Test
+    public void testInvalidSignature() {
+
+        assertThrows(
+                RuntimeException.class,
+                () ->
+                        Sign.signedMessageToKey(
+                                TEST_MESSAGE,
+                                new Sign.SignatureData((byte) 27, new byte[] {1}, new byte[] {0})));
+    }
+
+    @Test
+    public void testPublicKeyFromPrivatePoint() {
+        ECPoint point =
+                Sign.publicPointFromPrivate(SampleR1Keys.PRIVATE_KEY, NistECDSASignature.R1_CURVE);
+        assertEquals(Sign.publicFromPoint(point.getEncoded(false)), (SampleR1Keys.PUBLIC_KEY));
+    }
+
+    @ParameterizedTest(name = "testGetRecId(chainId={0}, recId={1}, isEip155={2})")
+    @MethodSource("recIdArguments")
+    public void testGetRecId(final long chainId, final long recId, final boolean isEip155) {
+        final long testV = isEip155 ? CHAIN_ID_INC + chainId * 2 + recId : LOWER_REAL_V + recId;
+        final Sign.SignatureData signedMsg =
+                new Sign.SignatureData((byte) testV, new byte[] {}, new byte[] {});
+
+        int recoveredRecId = Sign.getRecId(signedMsg, chainId);
+        assertEquals(recId, recoveredRecId);
+    }
+
+    @ParameterizedTest(name = "testGetRecIdWithInvalidVParam(v = {0})")
+    @MethodSource("invalidVSigningParams")
+    public void testGetRecIdWithInvalidVParam(final long invalidV) {
+        final Sign.SignatureData signedMsg =
+                new Sign.SignatureData((byte) invalidV, new byte[] {}, new byte[] {});
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> Sign.getRecId(signedMsg, 1),
+                "Unsupported v parameter: " + invalidV);
+    }
+
+    public static List<Arguments> recIdArguments() {
+        final List<Long> chainIds = Arrays.asList(1L, 2L, 100L);
+        final List<Long> recIds = Arrays.asList(0L, 1L);
+        final List<Boolean> isEip155Options = Arrays.asList(true, false);
+
+        final List<Arguments> args = new ArrayList<>();
+        for (Long chainId : chainIds) {
+            for (Long recId : recIds) {
+                for (Boolean isEip155Option : isEip155Options) {
+                    args.add(Arguments.of(chainId, recId, isEip155Option));
+                }
+            }
+        }
+
+        return args;
+    }
+
+    public static List<Arguments> invalidVSigningParams() {
+        final List<Arguments> args = new ArrayList<>();
+        for (int i = 0; i < LOWER_REAL_V; i++) {
+            args.add(Arguments.of(i));
+        }
+        for (int i = LOWER_REAL_V + 2; i < REPLAY_PROTECTED_V_MIN; i++) {
+            args.add(Arguments.of(i));
+        }
+
+        return args;
+    }
+}

--- a/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
@@ -63,7 +63,7 @@ public class SignR1Test {
     @Test
     public void testPublicKeyFromPrivateKey() {
         assertEquals(
-                Sign.publicKeyFromPrivate(SampleR1Keys.PRIVATE_KEY, NistECDSASignature.R1_CURVE),
+                Sign.publicKeyFromPrivate(SampleR1Keys.PRIVATE_KEY, Sign.NIST_CURVE),
                 (SampleR1Keys.PUBLIC_KEY));
     }
 
@@ -80,8 +80,7 @@ public class SignR1Test {
 
     @Test
     public void testPublicKeyFromPrivatePoint() {
-        ECPoint point =
-                Sign.publicPointFromPrivate(SampleR1Keys.PRIVATE_KEY, NistECDSASignature.R1_CURVE);
+        ECPoint point = Sign.publicPointFromPrivate(SampleR1Keys.PRIVATE_KEY, Sign.NIST_CURVE);
         assertEquals(Sign.publicFromPoint(point.getEncoded(false)), (SampleR1Keys.PUBLIC_KEY));
     }
 

--- a/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignR1Test.java
@@ -12,18 +12,19 @@
  */
 package org.web3j.crypto;
 
-import org.bouncycastle.math.ec.ECPoint;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.web3j.utils.Numeric;
-
 import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.bouncycastle.math.ec.ECPoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.web3j.utils.Numeric;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
### What does this PR do?
With this feature, we can use **secp256r1** curve. It adds the support to create secp256r1 keys and signing of the transactions. 

### Where should the reviewer start?
Crypto submodule: 
1. Keys.java
2. ECKeyPair.java
3. Sign.java

### Why is it needed?
Currently the web3j only support k1 curve. Using r1 keys and signing of the transactions (using Nist curve) is **not** supported. This is to extend the functionality where both curves can be supported. This will help sign and recover from signature for secp256r1 curve. Instead of writing Nist support in other components using the web3j, we can now use web3j to create keys, sign and recover from signature using r1 curve. 

