### PR TITLE
update jackson vesion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 ext {
     bouncycastleVersion = '1.68'
-    jacksonVersion = '2.13.1'
+    jacksonVersion = '2.13.3'
     javaPoetVersion = '1.7.0'
     kotlinVersion = '1.3.72'
     kotlinPoetVersion = '1.5.0'


### PR DESCRIPTION
### What does this PR do?
Updates jackson from version 2.13.1 (which is knew to have vulnerabilities)  to 2.13.3

### Where should the reviewer start?
*required*

### Why is it needed?
*required*

