### PR TITLE
fixed FunctionEncoder for Array in Struct

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
@@ -51,7 +51,7 @@ public class DynamicStruct extends DynamicArray<Type> implements StructType {
         final StringBuilder type = new StringBuilder("(");
         for (int i = 0; i < itemTypes.size(); ++i) {
             final Class<Type> cls = itemTypes.get(i);
-            if (StructType.class.isAssignableFrom(cls)) {
+            if (StructType.class.isAssignableFrom(cls) || Array.class.isAssignableFrom(cls)) {
                 type.append(getValue().get(i).getTypeAsString());
             } else {
                 type.append(AbiTypes.getTypeAString(cls));

--- a/abi/src/main/java/org/web3j/abi/datatypes/StaticStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/StaticStruct.java
@@ -38,7 +38,7 @@ public class StaticStruct extends StaticArray<Type> implements StructType {
         final StringBuilder type = new StringBuilder("(");
         for (int i = 0; i < itemTypes.size(); ++i) {
             final Class<Type> cls = itemTypes.get(i);
-            if (StructType.class.isAssignableFrom(cls)) {
+            if (StructType.class.isAssignableFrom(cls) || Array.class.isAssignableFrom(cls)) {
                 type.append(getValue().get(i).getTypeAsString());
             } else {
                 type.append(AbiTypes.getTypeAString(cls));

--- a/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
+++ b/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
@@ -12,10 +12,6 @@
  */
 package org.web3j.abi;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
 import org.web3j.abi.datatypes.DynamicStruct;
@@ -23,11 +19,18 @@ import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.StaticStruct;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.generated.Bytes32;
 import org.web3j.abi.datatypes.generated.StaticArray1;
 import org.web3j.abi.datatypes.generated.StaticArray2;
 import org.web3j.abi.datatypes.generated.StaticArray3;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint32;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class AbiV2TestFixture {
 
@@ -108,6 +111,8 @@ public class AbiV2TestFixture {
     public static final String FUNC_SETWIZ = "setWiz";
 
     public static final String FUNC_addDynamicBytesArray = "addDynamicBytesArray";
+
+    public static final String FUNC_setArrayInStruct = "setArrayInStruct";
 
     public static class Foo extends DynamicStruct {
         public String id;
@@ -769,4 +774,47 @@ public class AbiV2TestFixture {
                             new BytesStruct(
                                     "dynamic".getBytes(), BigInteger.ZERO, "Bytes".getBytes())),
                     Collections.<TypeReference<?>>emptyList());
+
+
+    public static class FooArrayInStruct extends DynamicStruct {
+        public List<BigInteger> fooIntArray;
+        public List<String> fooStringArray;
+        public List<byte[]> fooBytesArray;
+
+        public FooArrayInStruct(List<BigInteger> fooIntArray, List<String> fooStringArray, List<byte[]> fooBytesArray) {
+            super(
+                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint256>(
+                            org.web3j.abi.datatypes.generated.Uint256.class,
+                            org.web3j.abi.Utils.typeMap(fooIntArray, org.web3j.abi.datatypes.generated.Uint256.class)),
+                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Utf8String>(
+                            org.web3j.abi.datatypes.Utf8String.class,
+                            org.web3j.abi.Utils.typeMap(fooStringArray, org.web3j.abi.datatypes.Utf8String.class)),
+                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Bytes32>(
+                            org.web3j.abi.datatypes.generated.Bytes32.class,
+                            org.web3j.abi.Utils.typeMap(fooBytesArray, org.web3j.abi.datatypes.generated.Bytes32.class)));
+
+            this.fooIntArray = fooIntArray;
+            this.fooStringArray = fooStringArray;
+            this.fooBytesArray = fooBytesArray;
+        }
+
+        public FooArrayInStruct(DynamicArray<Uint256> fooIntArray, DynamicArray<Utf8String> fooStringArray, DynamicArray<Bytes32> fooBytesArray) {
+            super(fooIntArray, fooStringArray, fooBytesArray);
+            this.fooIntArray = fooIntArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
+            this.fooStringArray = fooStringArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
+            this.fooBytesArray = fooBytesArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
+        }
+    }
+
+    public static final Function setArrayInStructFunction =
+            new Function(
+                    FUNC_setArrayInStruct,
+                    Arrays.<Type>asList(
+                            new FooArrayInStruct(
+                                    Arrays.asList(BigInteger.valueOf(123), BigInteger.valueOf(567)),
+                                    Arrays.asList("foo", "bar"),
+                                    Arrays.asList("0x123456789012345678901234567890".getBytes(), "0x123456789012345678901234567891".getBytes())
+                            )),
+                    Collections.<TypeReference<?>>emptyList());
+
 }

--- a/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
+++ b/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
@@ -12,6 +12,12 @@
  */
 package org.web3j.abi;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
 import org.web3j.abi.datatypes.DynamicStruct;
@@ -25,12 +31,6 @@ import org.web3j.abi.datatypes.generated.StaticArray2;
 import org.web3j.abi.datatypes.generated.StaticArray3;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint32;
-
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class AbiV2TestFixture {
 
@@ -775,34 +775,54 @@ public class AbiV2TestFixture {
                                     "dynamic".getBytes(), BigInteger.ZERO, "Bytes".getBytes())),
                     Collections.<TypeReference<?>>emptyList());
 
-
     public static class FooArrayInStruct extends DynamicStruct {
         public List<BigInteger> fooIntArray;
         public List<String> fooStringArray;
         public List<byte[]> fooBytesArray;
 
-        public FooArrayInStruct(List<BigInteger> fooIntArray, List<String> fooStringArray, List<byte[]> fooBytesArray) {
+        public FooArrayInStruct(
+                List<BigInteger> fooIntArray,
+                List<String> fooStringArray,
+                List<byte[]> fooBytesArray) {
             super(
-                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Uint256>(
+                    new org.web3j.abi.datatypes.DynamicArray<
+                            org.web3j.abi.datatypes.generated.Uint256>(
                             org.web3j.abi.datatypes.generated.Uint256.class,
-                            org.web3j.abi.Utils.typeMap(fooIntArray, org.web3j.abi.datatypes.generated.Uint256.class)),
+                            org.web3j.abi.Utils.typeMap(
+                                    fooIntArray, org.web3j.abi.datatypes.generated.Uint256.class)),
                     new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Utf8String>(
                             org.web3j.abi.datatypes.Utf8String.class,
-                            org.web3j.abi.Utils.typeMap(fooStringArray, org.web3j.abi.datatypes.Utf8String.class)),
-                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.generated.Bytes32>(
+                            org.web3j.abi.Utils.typeMap(
+                                    fooStringArray, org.web3j.abi.datatypes.Utf8String.class)),
+                    new org.web3j.abi.datatypes.DynamicArray<
+                            org.web3j.abi.datatypes.generated.Bytes32>(
                             org.web3j.abi.datatypes.generated.Bytes32.class,
-                            org.web3j.abi.Utils.typeMap(fooBytesArray, org.web3j.abi.datatypes.generated.Bytes32.class)));
+                            org.web3j.abi.Utils.typeMap(
+                                    fooBytesArray,
+                                    org.web3j.abi.datatypes.generated.Bytes32.class)));
 
             this.fooIntArray = fooIntArray;
             this.fooStringArray = fooStringArray;
             this.fooBytesArray = fooBytesArray;
         }
 
-        public FooArrayInStruct(DynamicArray<Uint256> fooIntArray, DynamicArray<Utf8String> fooStringArray, DynamicArray<Bytes32> fooBytesArray) {
+        public FooArrayInStruct(
+                DynamicArray<Uint256> fooIntArray,
+                DynamicArray<Utf8String> fooStringArray,
+                DynamicArray<Bytes32> fooBytesArray) {
             super(fooIntArray, fooStringArray, fooBytesArray);
-            this.fooIntArray = fooIntArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
-            this.fooStringArray = fooStringArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
-            this.fooBytesArray = fooBytesArray.getValue().stream().map(v -> v.getValue()).collect(Collectors.toList());
+            this.fooIntArray =
+                    fooIntArray.getValue().stream()
+                            .map(v -> v.getValue())
+                            .collect(Collectors.toList());
+            this.fooStringArray =
+                    fooStringArray.getValue().stream()
+                            .map(v -> v.getValue())
+                            .collect(Collectors.toList());
+            this.fooBytesArray =
+                    fooBytesArray.getValue().stream()
+                            .map(v -> v.getValue())
+                            .collect(Collectors.toList());
         }
     }
 
@@ -813,8 +833,8 @@ public class AbiV2TestFixture {
                             new FooArrayInStruct(
                                     Arrays.asList(BigInteger.valueOf(123), BigInteger.valueOf(567)),
                                     Arrays.asList("foo", "bar"),
-                                    Arrays.asList("0x123456789012345678901234567890".getBytes(), "0x123456789012345678901234567891".getBytes())
-                            )),
+                                    Arrays.asList(
+                                            "0x123456789012345678901234567890".getBytes(),
+                                            "0x123456789012345678901234567891".getBytes()))),
                     Collections.<TypeReference<?>>emptyList());
-
 }

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -12,12 +12,7 @@
  */
 package org.web3j.abi;
 
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
-import java.util.*;
-
 import org.junit.jupiter.api.Test;
-
 import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Bool;
 import org.web3j.abi.datatypes.DynamicArray;
@@ -31,6 +26,12 @@ import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Bytes10;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint32;
+
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -795,5 +796,29 @@ public class DefaultFunctionEncoderTest {
                         + "0000000000000000000000000000000000000000000000000000000000000000";
 
         assertEquals(expected, FunctionEncoder.encode(AbiV2TestFixture.setBarDynamicArrayFunction));
+    }
+
+    @Test
+    void testArrayInStruct() {
+        String expected =
+                "0x9ca411e8"
+                        + "0000000000000000000000000000000000000000000000000000000000000020"
+                        + "0000000000000000000000000000000000000000000000000000000000000060"
+                        + "00000000000000000000000000000000000000000000000000000000000000c0"
+                        + "00000000000000000000000000000000000000000000000000000000000001a0"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "000000000000000000000000000000000000000000000000000000000000007b"
+                        + "0000000000000000000000000000000000000000000000000000000000000237"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "0000000000000000000000000000000000000000000000000000000000000040"
+                        + "0000000000000000000000000000000000000000000000000000000000000080"
+                        + "0000000000000000000000000000000000000000000000000000000000000003"
+                        + "666f6f0000000000000000000000000000000000000000000000000000000000"
+                        + "0000000000000000000000000000000000000000000000000000000000000003"
+                        + "6261720000000000000000000000000000000000000000000000000000000000"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "3078313233343536373839303132333435363738393031323334353637383930"
+                        + "3078313233343536373839303132333435363738393031323334353637383931";
+        assertEquals(expected, FunctionEncoder.encode(AbiV2TestFixture.setArrayInStructFunction));
     }
 }

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -12,7 +12,14 @@
  */
 package org.web3j.abi;
 
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
 import org.junit.jupiter.api.Test;
+
 import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.Bool;
 import org.web3j.abi.datatypes.DynamicArray;
@@ -26,12 +33,6 @@ import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.abi.datatypes.generated.Bytes10;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint32;
-
-import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
### What does this PR do?
**Pre-condition** : array in Struct
```solidity
struct FooArrayInStruct {
  uint256[] fooIntArray;
  string[] fooStringArray;
  bytes[] fooBytesArray;
}
```

**Action** : `FunctionEncoder.buildMethodSignature(Function(FooArrayInStruct))`

✅ **Expected**
```
{method-name}((uint256[],string[],bytes[]))
```
🟥 **Actual**
```
{method-name}((dynamicarray,dynamicarray,dynamicarray))
```

If array is wrapped in struct, the signature of parameter isn't converted proper type's array but dynamicarray or staticarray.

### Where should the reviewer start?
1. Check `FooArrayInStruct` in `AbiV2TestFixture.java`
2. Check `DynamicStruct.java` & `StaticStruct.java`
3. Check or run `DefaultFunctionEncoderTest.testArrayInStruct()`

### Why is it needed?
Oct 2021 (https://github.com/web3j/web3j/issues/1526) Dec 2021 (https://github.com/web3j/web3j/issues/1588), there was various reports but not fixed yet. I also faced same issue and found how to fix.

Please kindly consider and review. Hopefully merge into next release.

