### PR TITLE
Fix NPE in try-catch

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -401,7 +401,15 @@ public abstract class Contract extends ManagedTransaction {
                                 constructor);
             }
         } catch (JsonRpcError error) {
-            throw new TransactionException(error.getData().toString());
+
+            if (error.getData() != null) {
+                throw new TransactionException(error.getData().toString());
+            } else {
+                throw new TransactionException(
+                        String.format(
+                                "JsonRpcError thrown with code %d. Message: %s",
+                                error.getCode(), error.getMessage()));
+            }
         }
 
         if (!(receipt instanceof EmptyTransactionReceipt)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.web3j
-version=4.9.2-SNAPSHOT
+version=4.9.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.web3j
-version=4.9.2
+version=4.9.2-SNAPSHOT


### PR DESCRIPTION
### What does this PR do?
Patches NPE when a JsonRpcError is thrown on transaction execution

### Where should the reviewer start?
Contract.java line 403 (old branch) will create a NPE, I proposed a change to check if the getData() from the RPC error is null before calling toString() on it.

### Why is it needed?
If getData() is null in the RpcError, the user will not receive any information as to what the RPC error code or message is and rather gets a NullPointerException making it impossible to figure out what the root cause / error is.

