### PR TITLE
Allow TransactionHash objects to be serialised

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -538,6 +538,10 @@ public class EthBlock extends Response<EthBlock.Block> {
         public String get() {
             return value;
         }
+        
+        public String getValue() {
+            return value;
+        }
 
         public void setValue(String value) {
             this.value = value;


### PR DESCRIPTION
### What does this PR do?
- The public get() function is never called by a serialiser to get the hash string as it doesnt confirm to the public getter standard of get + field name. ie. getValue()
- Adds a public getter getValue() to return the transaction hash as a string. This allows serialisers to correctly serialise the transactionhash object.

### Where should the reviewer start?
Create an instance of TransactionHash and attempt to serialise it and confirm that it serializes to a json string in the format of:

```
                {
                    "value": "0x2a9e6ea167..........."
                }
```

### Why is it needed?
- When a TransactionHash object is serialised to json it results in an empty object eg. "{}"

