### PR TITLE
updated the isValidHexQuantity Method in Numeric.java and added supporting Unit tests

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -339,6 +339,7 @@ public class Transaction {
     }
 
     public BigInteger getMaxFeePerGas() {
+        if (maxFeePerGas == null) return null;
         return Numeric.decodeQuantity(maxFeePerGas);
     }
 

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -63,7 +63,7 @@ public final class Numeric {
         }
     }
 
-    private static boolean isValidHexQuantity(String value) {
+    protected static boolean isValidHexQuantity(String value) {
         if (value == null) {
             return false;
         }
@@ -80,7 +80,7 @@ public final class Numeric {
             return false;
         }
 
-        return true;
+        return value.matches("0[xX][0-9a-fA-F]+");
     }
 
     public static String cleanHexPrefix(String input) {

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -279,4 +279,21 @@ public class NumericTest {
         assertEquals(" ", Numeric.removeDoubleQuotes(" "));
         assertEquals(text, Numeric.removeDoubleQuotes(text));
     }
+    @Test
+    void testIsValidHexQuantity() {
+
+        assertEquals(true, Numeric.isValidHexQuantity("0x0"));
+        assertEquals(true, Numeric.isValidHexQuantity("0x9"));
+        assertEquals(true, Numeric.isValidHexQuantity("0x123f"));
+        assertEquals(true, Numeric.isValidHexQuantity("0x419E"));
+        assertEquals(true, Numeric.isValidHexQuantity("0x975d"));
+        assertEquals(true, Numeric.isValidHexQuantity("0xDC449C1C16BA0"));
+        assertEquals(true, Numeric.isValidHexQuantity("0x419E"));
+
+        assertEquals(false, Numeric.isValidHexQuantity("419E"));
+        assertEquals(false, Numeric.isValidHexQuantity("0419E"));
+        assertEquals(false, Numeric.isValidHexQuantity("0x419Erf"));
+        assertEquals(false, Numeric.isValidHexQuantity("0x419fg"));
+    }
+
 }


### PR DESCRIPTION

### What does this PR do?
Bug Fix for the Issue #1759 
In case of null values of the maxFeePerGas parameter in the Transaction.java Object(https://github.com/web3j/web3j/blob/b3f9e4e3f5bab87940ee47cd1ed12838d1d6ac1f/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java#L69). Instead of directly converting the hexValue to BigInteger, added a check case to directly return null values of maxFeePerGas.

Also added the Regex expression check for isValidHexQuantity method in the Numeric.java. Better validation of hex values.

Also added Unit tests for the method isValidHexQuantity, which is missing in the earlier implementations. 

### Where should the reviewer start?
Test the Unit test from the file https://github.com/web3j/web3j/blob/master/utils/src/test/java/org/web3j/utils/NumericTest.java 

### Why is it needed?
The implementation will avoid the error case of MessageEncodingException which is thrown when the value to be decoded is null or not a validHexQuantity. So when the Ethereum getBlock API will fetch a null value of maxFeePerGas the web3j will not break and thow MessageEncodingException on using the getMaxFeePerGas() getter.

