### PR TITLE
Fix signature for methods with struct with array.

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
@@ -53,6 +53,8 @@ public class DynamicStruct extends DynamicArray<Type> implements StructType {
             final Class<Type> cls = itemTypes.get(i);
             if (StructType.class.isAssignableFrom(cls)) {
                 type.append(getValue().get(i).getTypeAsString());
+            } else if (Array.class.isAssignableFrom(cls)) {
+                type.append(getValue().get(i).getTypeAsString());
             } else {
                 type.append(AbiTypes.getTypeAString(cls));
             }

--- a/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
+++ b/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
@@ -15,7 +15,10 @@ package org.web3j.abi;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.web3j.abi.datatypes.Address;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
 import org.web3j.abi.datatypes.DynamicStruct;
@@ -108,6 +111,9 @@ public class AbiV2TestFixture {
     public static final String FUNC_SETWIZ = "setWiz";
 
     public static final String FUNC_addDynamicBytesArray = "addDynamicBytesArray";
+
+    public static final String FUNC_setArrayOfStructWithArraysFunction =
+            "setArrayOfStructWithArraysFunction";
 
     public static class Foo extends DynamicStruct {
         public String id;
@@ -768,5 +774,50 @@ public class AbiV2TestFixture {
                     Arrays.<Type>asList(
                             new BytesStruct(
                                     "dynamic".getBytes(), BigInteger.ZERO, "Bytes".getBytes())),
+                    Collections.<TypeReference<?>>emptyList());
+
+    public static class ArrayStruct extends DynamicStruct {
+        public BigInteger id;
+
+        public List<String> addresses;
+
+        public ArrayStruct(BigInteger id, List<String> addresses) {
+            super(
+                    new org.web3j.abi.datatypes.generated.Uint256(id),
+                    new org.web3j.abi.datatypes.DynamicArray<org.web3j.abi.datatypes.Address>(
+                            org.web3j.abi.datatypes.Address.class,
+                            org.web3j.abi.Utils.typeMap(
+                                    addresses, org.web3j.abi.datatypes.Address.class)));
+            this.id = id;
+            this.addresses = addresses;
+        }
+
+        public ArrayStruct(Uint256 id, DynamicArray<Address> addresses) {
+            super(id, addresses);
+            this.id = id.getValue();
+            this.addresses =
+                    addresses.getValue().stream()
+                            .map(v -> v.getValue())
+                            .collect(Collectors.toList());
+        }
+    }
+
+    public static final Function setArrayOfStructWithArraysFunction =
+            new Function(
+                    FUNC_setArrayOfStructWithArraysFunction,
+                    Arrays.<Type>asList(
+                            new org.web3j.abi.datatypes.DynamicArray<ArrayStruct>(
+                                    ArrayStruct.class,
+                                    Arrays.asList(
+                                            new ArrayStruct(
+                                                    BigInteger.ONE,
+                                                    Arrays.asList(
+                                                            "0x0000000000000000000000000000000000000000",
+                                                            "0x1111111111111111111111111111111111111111")),
+                                            new ArrayStruct(
+                                                    BigInteger.TEN,
+                                                    Arrays.asList(
+                                                            "0x2222222222222222222222222222222222222222",
+                                                            "0x3333333333333333333333333333333333333333"))))),
                     Collections.<TypeReference<?>>emptyList());
 }

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -57,6 +57,17 @@ public class DefaultFunctionEncoderTest {
     }
 
     @Test
+    public void testBuildMethodSignatureWithStructWithArray() {
+        assertEquals(
+                "structWithArray((uint256,address[]))",
+                DefaultFunctionEncoder.buildMethodSignature(
+                        "structWithArray",
+                        Arrays.asList(
+                                new AbiV2TestFixture.ArrayStruct(
+                                        BigInteger.ONE, Collections.emptyList()))));
+    }
+
+    @Test
     public void testEncodeConstructorEmpty() {
         assertEquals("", FunctionEncoder.encodeConstructor(Collections.emptyList()));
     }
@@ -795,5 +806,29 @@ public class DefaultFunctionEncoderTest {
                         + "0000000000000000000000000000000000000000000000000000000000000000";
 
         assertEquals(expected, FunctionEncoder.encode(AbiV2TestFixture.setBarDynamicArrayFunction));
+    }
+
+    @Test
+    public void testEncodeArrayOfStructWithArrays() {
+        String expected =
+                "0xfc3fdffb"
+                        + "0000000000000000000000000000000000000000000000000000000000000020"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "0000000000000000000000000000000000000000000000000000000000000040"
+                        + "00000000000000000000000000000000000000000000000000000000000000e0"
+                        + "0000000000000000000000000000000000000000000000000000000000000001"
+                        + "0000000000000000000000000000000000000000000000000000000000000040"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "0000000000000000000000000000000000000000000000000000000000000000"
+                        + "0000000000000000000000001111111111111111111111111111111111111111"
+                        + "000000000000000000000000000000000000000000000000000000000000000a"
+                        + "0000000000000000000000000000000000000000000000000000000000000040"
+                        + "0000000000000000000000000000000000000000000000000000000000000002"
+                        + "0000000000000000000000002222222222222222222222222222222222222222"
+                        + "0000000000000000000000003333333333333333333333333333333333333333";
+
+        assertEquals(
+                expected,
+                FunctionEncoder.encode(AbiV2TestFixture.setArrayOfStructWithArraysFunction));
     }
 }


### PR DESCRIPTION
### What does this PR do?
It fixes the generation of the method signature when there is a struct containing an array.

### Why is it needed?
Without this patch a (address) array inside a struct is converted into `dynamicarray` instead of `address[]` when constructing the signature, generating a wrong 4-byte function selector.
