### PR TITLE
add finalized and safe block

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/DefaultBlockParameterName.java
+++ b/core/src/main/java/org/web3j/protocol/core/DefaultBlockParameterName.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum DefaultBlockParameterName implements DefaultBlockParameter {
     EARLIEST("earliest"),
     LATEST("latest"),
-    PENDING("pending");
+    PENDING("pending"),
+    FINALIZED("finalized"),
+    SAFE("safe");
 
     private String name;
 


### PR DESCRIPTION
### What does this PR do?
To support new rpc block number types after the merge of ethereum
https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L64

to resolve #1772 


### Where should the reviewer start?
https://github.com/ethereum/go-ethereum/blob/master/rpc/types.go#L64

### Why is it needed?
web3j client can query the new type of block supported by ethereum after the merge

