### PR TITLE
Fix the detection of a reverted call.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthCall.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthCall.java
@@ -21,6 +21,7 @@ import org.web3j.abi.datatypes.AbiTypes;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Utf8String;
 import org.web3j.protocol.core.Response;
+import org.web3j.utils.EnsUtils;
 
 /** eth_call. */
 public class EthCall extends Response<String> {
@@ -39,7 +40,7 @@ public class EthCall extends Response<String> {
 
     public boolean isReverted() {
         if (hasError() && getError().getCode() == 3 && getError().getData() != null) {
-            return false;
+            return !EnsUtils.isEIP3668(getError().getData());
         }
 
         return hasError() || isErrorInResult();


### PR DESCRIPTION
### What does this PR do?
It fixes a bug introduced by PR #1617 that started ignoring the revert reasons generated by `eth_call`.
The patch fix the broken behavior by ignoring *only* the revert reasons associated to the `OffchainLookup` error.

### Where should the reviewer start?
Sample of a reverted transaction for which the revert reason is ignored:

```
{
  "jsonrpc":"2.0",
  "id":1,
  "error":
  {
    "code":3,
    "message":"execution reverted: TransferHelper: TRANSFER_FROM_FAILED",
    "data":"0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000245472616e7366657248656c7065723a205452414e534645525f46524f4d5f4641494c454400000000000000000000000000000000000000000000000000000000"
  }
}
```

Sample of a OffchainLookup reverted transaction:
```
{
  "jsonrpc":"2.0",
  "id":1,
  "error":
  {
    "code": 3,
    "message": "execution reverted",
    "data": "0x556f18300000000000000000000000005230e500fe09da1834dc6e508b1894d9b034e2d900000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000c02de737d800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010100000000000000000000000000000000000000000000000000000000000000"
  }
}
```

### Why is it needed?
Because now calling a method that reverts fails on the output decoding (that is missing) instead of throwing the correct revert reason.

