### PR TITLE
Update Sign.java

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -58,7 +58,9 @@ public class Sign {
     static final String MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
 
     static byte[] getEthereumMessagePrefix(int messageLength) {
-        return MESSAGE_PREFIX.concat(String.valueOf(messageLength)).getBytes(StandardCharsets.UTF_8);
+        return MESSAGE_PREFIX
+                .concat(String.valueOf(messageLength))
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     public static byte[] getEthereumMessageHash(byte[] message) {

--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -12,8 +12,8 @@
  */
 package org.web3j.crypto;
 
-import java.nio.charset.StandardCharsets;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.SignatureException;
 import java.util.Arrays;
 

--- a/crypto/src/main/java/org/web3j/crypto/Sign.java
+++ b/crypto/src/main/java/org/web3j/crypto/Sign.java
@@ -12,6 +12,7 @@
  */
 package org.web3j.crypto;
 
+import java.nio.charset.StandardCharsets;
 import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.Arrays;
@@ -57,7 +58,7 @@ public class Sign {
     static final String MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
 
     static byte[] getEthereumMessagePrefix(int messageLength) {
-        return MESSAGE_PREFIX.concat(String.valueOf(messageLength)).getBytes();
+        return MESSAGE_PREFIX.concat(String.valueOf(messageLength)).getBytes(StandardCharsets.UTF_8);
     }
 
     public static byte[] getEthereumMessageHash(byte[] message) {


### PR DESCRIPTION
### What does this PR do?

This pull request fixes issue #1799 by setting UTF-8 charset on "personal sign" message prefix computation. 

### Where should the reviewer start?

In the **getEthereumMessagePrefix(int messageLength)** method of **Sign.java**

### Why is it needed?

It is needed to correctly generate hash for personal_sign on platform where UTF-8 is not the default encoding



