### PR TITLE
Add "accepted" block name

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/DefaultBlockParameterName.java
+++ b/core/src/main/java/org/web3j/protocol/core/DefaultBlockParameterName.java
@@ -20,7 +20,8 @@ public enum DefaultBlockParameterName implements DefaultBlockParameter {
     LATEST("latest"),
     PENDING("pending"),
     FINALIZED("finalized"),
-    SAFE("safe");
+    SAFE("safe"),
+    ACCEPTED("accepted");
 
     private String name;
 


### PR DESCRIPTION
As used by Avalanche: https://github.com/ava-labs/coreth/blob/master/rpc/types.go#L74