### PR TITLE
Add eip-2930 transaction decoding

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/AccessListObject.java
+++ b/crypto/src/main/java/org/web3j/crypto/AccessListObject.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import java.util.List;
+import java.util.Objects;
+
+public class AccessListObject {
+    private String address;
+    private List<String> storageKeys;
+
+    public AccessListObject() {}
+
+    public AccessListObject(String address, List<String> storageKeys) {
+        this.address = address;
+        this.storageKeys = storageKeys;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public List<String> getStorageKeys() {
+        return storageKeys;
+    }
+
+    public void setStorageKeys(List<String> storageKeys) {
+        this.storageKeys = storageKeys;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AccessListObject that = (AccessListObject) o;
+        return Objects.equals(getAddress(), that.getAddress())
+                && Objects.equals(getStorageKeys(), that.getStorageKeys());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAddress(), getStorageKeys());
+    }
+}

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -13,10 +13,12 @@
 package org.web3j.crypto;
 
 import java.math.BigInteger;
+import java.util.List;
 
 import org.web3j.crypto.transaction.type.ITransaction;
 import org.web3j.crypto.transaction.type.LegacyTransaction;
 import org.web3j.crypto.transaction.type.Transaction1559;
+import org.web3j.crypto.transaction.type.Transaction2930;
 import org.web3j.crypto.transaction.type.TransactionType;
 
 /**
@@ -114,6 +116,20 @@ public class RawTransaction {
                         data,
                         maxPriorityFeePerGas,
                         maxFeePerGas));
+    }
+
+    public static RawTransaction createTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList) {
+        return new RawTransaction(
+                Transaction2930.createTransaction(
+                        chainId, nonce, gasPrice, gasLimit, to, value, data, accessList));
     }
 
     public BigInteger getNonce() {

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -13,21 +13,27 @@
 package org.web3j.crypto;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.web3j.crypto.transaction.type.TransactionType;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;
+import org.web3j.rlp.RlpType;
 import org.web3j.utils.Numeric;
 
 public class TransactionDecoder {
     private static final int UNSIGNED_EIP1559TX_RLP_LIST_SIZE = 9;
+    private static final int UNSIGNED_EIP2930TX_RLP_LIST_SIZE = 8;
 
     public static RawTransaction decode(final String hexTransaction) {
         final byte[] transaction = Numeric.hexStringToByteArray(hexTransaction);
         if (getTransactionType(transaction) == TransactionType.EIP1559) {
             return decodeEIP1559Transaction(transaction);
+        } else if (getTransactionType(transaction) == TransactionType.EIP2930) {
+            return decodeEIP2930Transaction(transaction);
         }
         return decodeLegacyTransaction(transaction);
     }
@@ -36,7 +42,8 @@ public class TransactionDecoder {
         // The first byte indicates a transaction type.
         byte firstByte = transaction[0];
         if (firstByte == TransactionType.EIP1559.getRlpType()) return TransactionType.EIP1559;
-        return TransactionType.LEGACY;
+        else if (firstByte == TransactionType.EIP2930.getRlpType()) return TransactionType.EIP2930;
+        else return TransactionType.LEGACY;
     }
 
     private static RawTransaction decodeEIP1559Transaction(final byte[] transaction) {
@@ -119,5 +126,66 @@ public class TransactionDecoder {
             return new SignedRawTransaction(
                     nonce, gasPrice, gasLimit, to, value, data, signatureData);
         }
+    }
+
+    private static RawTransaction decodeEIP2930Transaction(final byte[] transaction) {
+        final byte[] encodedTx = Arrays.copyOfRange(transaction, 1, transaction.length);
+        final RlpList rlpList = RlpDecoder.decode(encodedTx);
+        final RlpList values = (RlpList) rlpList.getValues().get(0);
+
+        final long chainId =
+                ((RlpString) values.getValues().get(0)).asPositiveBigInteger().longValue();
+        final BigInteger nonce = ((RlpString) values.getValues().get(1)).asPositiveBigInteger();
+        final BigInteger gasPrice = ((RlpString) values.getValues().get(2)).asPositiveBigInteger();
+        final BigInteger gasLimit = ((RlpString) values.getValues().get(3)).asPositiveBigInteger();
+        final String to = ((RlpString) values.getValues().get(4)).asString();
+        final BigInteger value = ((RlpString) values.getValues().get(5)).asPositiveBigInteger();
+        final String data = ((RlpString) values.getValues().get(6)).asString();
+        List<AccessListObject> accessList =
+                decodeAccessList(((RlpList) values.getValues().get(7)).getValues());
+
+        final RawTransaction rawTransaction =
+                RawTransaction.createTransaction(
+                        chainId, nonce, gasPrice, gasLimit, to, value, data, accessList);
+
+        if (values.getValues().size() == UNSIGNED_EIP2930TX_RLP_LIST_SIZE) {
+            return rawTransaction;
+        } else {
+            final byte[] v =
+                    Sign.getVFromRecId(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(8)).getBytes())
+                                    .intValue());
+            final byte[] r =
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(9)).getBytes()),
+                            32);
+            final byte[] s =
+                    Numeric.toBytesPadded(
+                            Numeric.toBigInt(((RlpString) values.getValues().get(10)).getBytes()),
+                            32);
+            final Sign.SignatureData signatureData = new Sign.SignatureData(v, r, s);
+            return new SignedRawTransaction(rawTransaction.getTransaction(), signatureData);
+        }
+    }
+
+    private static List<AccessListObject> decodeAccessList(List<RlpType> rlp) {
+        final List<AccessListObject> res = new ArrayList<AccessListObject>();
+        rlp.forEach(
+                rawEntry -> {
+                    AccessListObject entry = new AccessListObject();
+                    List<RlpType> values = ((RlpList) rawEntry).getValues();
+
+                    entry.setAddress(((RlpString) values.get(0)).asString());
+                    List<RlpType> keyList = ((RlpList) values.get(1)).getValues();
+
+                    List<String> keys = new ArrayList<>();
+                    keyList.forEach(
+                            rawKey -> {
+                                keys.add(((RlpString) rawKey).asString());
+                            });
+                    entry.setStorageKeys(keys);
+                    res.add(entry);
+                });
+        return res;
     }
 }

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -117,7 +117,7 @@ public class TransactionEncoder {
         RlpList rlpList = new RlpList(values);
         byte[] encoded = RlpEncoder.encode(rlpList);
 
-        if (rawTransaction.getType().isEip1559()) {
+        if (rawTransaction.getType().isEip1559() || rawTransaction.getType().isEip2930()) {
             return ByteBuffer.allocate(encoded.length + 1)
                     .put(rawTransaction.getType().getRlpType())
                     .put(encoded)

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
@@ -14,6 +14,7 @@ package org.web3j.crypto.transaction.type;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.web3j.crypto.AccessListObject;
@@ -106,7 +107,8 @@ public class Transaction2930 extends LegacyTransaction {
             BigInteger gasLimit,
             String to,
             BigInteger value) {
-        return new Transaction2930(chainId, nonce, gasPrice, gasLimit, to, value, "", List.of());
+        return new Transaction2930(
+                chainId, nonce, gasPrice, gasLimit, to, value, "", Collections.emptyList());
     }
 
     public static Transaction2930 createTransaction(

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto.transaction.type;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.web3j.crypto.AccessListObject;
+import org.web3j.crypto.Sign;
+import org.web3j.rlp.RlpList;
+import org.web3j.rlp.RlpString;
+import org.web3j.rlp.RlpType;
+import org.web3j.utils.Bytes;
+import org.web3j.utils.Numeric;
+
+import static org.web3j.crypto.transaction.type.TransactionType.EIP2930;
+
+public class Transaction2930 extends LegacyTransaction {
+    private long chainId;
+    private List<AccessListObject> accessList;
+
+    public Transaction2930(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList) {
+        super(EIP2930, nonce, gasPrice, gasLimit, to, value, data);
+        this.chainId = chainId;
+        this.accessList = accessList;
+    }
+
+    @Override
+    public List<RlpType> asRlpValues(Sign.SignatureData signatureData) {
+        List<RlpType> result = new ArrayList<>();
+
+        result.add(RlpString.create(getChainId()));
+        result.add(RlpString.create(getNonce()));
+        result.add(RlpString.create(getGasPrice()));
+        result.add(RlpString.create(getGasLimit()));
+
+        // an empty to address (contract creation) should not be encoded as a numeric 0 value
+        String to = getTo();
+        if (to != null && to.length() > 0) {
+            // addresses that start with zeros should be encoded with the zeros included, not
+            // as numeric values
+            result.add(RlpString.create(Numeric.hexStringToByteArray(to)));
+        } else {
+            result.add(RlpString.create(""));
+        }
+
+        result.add(RlpString.create(getValue()));
+
+        // value field will already be hex encoded, so we need to convert into binary first
+        byte[] data = Numeric.hexStringToByteArray(getData());
+        result.add(RlpString.create(data));
+
+        // access list
+        List<AccessListObject> accessList = getAccessList();
+        List<RlpType> rlpAccessList = new ArrayList<>();
+        accessList.forEach(
+                entry -> {
+                    List<RlpType> rlpAccessListObject = new ArrayList<>();
+                    rlpAccessListObject.add(
+                            RlpString.create(Numeric.hexStringToByteArray(entry.getAddress())));
+                    List<RlpType> keyList = new ArrayList<>();
+                    entry.getStorageKeys()
+                            .forEach(
+                                    key -> {
+                                        keyList.add(
+                                                RlpString.create(
+                                                        Numeric.hexStringToByteArray(key)));
+                                    });
+                    rlpAccessListObject.add(new RlpList(keyList));
+                    rlpAccessList.add(new RlpList(rlpAccessListObject));
+                });
+        result.add(new RlpList(rlpAccessList));
+
+        if (signatureData != null) {
+            result.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
+            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getR())));
+            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getS())));
+        }
+
+        return result;
+    }
+
+    public static Transaction2930 createEtherTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value) {
+        return new Transaction2930(chainId, nonce, gasPrice, gasLimit, to, value, "", List.of());
+    }
+
+    public static Transaction2930 createTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasPrice,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            List<AccessListObject> accessList) {
+        return new Transaction2930(chainId, nonce, gasPrice, gasLimit, to, value, data, accessList);
+    }
+
+    public long getChainId() {
+        return chainId;
+    }
+
+    public List<AccessListObject> getAccessList() {
+        return accessList;
+    }
+}

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/TransactionType.java
@@ -14,6 +14,7 @@ package org.web3j.crypto.transaction.type;
 
 public enum TransactionType {
     LEGACY(null),
+    EIP2930(((byte) 0x01)),
     EIP1559(((byte) 0x02));
 
     Byte type;
@@ -32,5 +33,9 @@ public enum TransactionType {
 
     public boolean isEip1559() {
         return this.equals(TransactionType.EIP1559);
+    }
+
+    public boolean isEip2930() {
+        return this.equals(TransactionType.EIP2930);
     }
 }

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -264,7 +264,7 @@ public class TransactionDecoderTest {
     }
 
     private static RawTransaction createEip2930RawTransaction() {
-// Test example from https://eips.ethereum.org/EIPS/eip-2930
+        // Test example from https://eips.ethereum.org/EIPS/eip-2930
         List<AccessListObject> accessList =
                 Stream.of(
                                 new AccessListObject(

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -264,6 +264,7 @@ public class TransactionDecoderTest {
     }
 
     private static RawTransaction createEip2930RawTransaction() {
+// Test example from https://eips.ethereum.org/EIPS/eip-2930
         List<AccessListObject> accessList =
                 Stream.of(
                                 new AccessListObject(

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -16,7 +16,6 @@ import java.math.BigInteger;
 import java.security.SignatureException;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +24,7 @@ import org.web3j.crypto.transaction.type.Transaction1559;
 import org.web3j.crypto.transaction.type.Transaction2930;
 import org.web3j.utils.Numeric;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -271,11 +271,11 @@ public class TransactionDecoderTest {
                                         Stream.of(
                                                         "0x0000000000000000000000000000000000000000000000000000000000000003",
                                                         "0x0000000000000000000000000000000000000000000000000000000000000007")
-                                                .collect(Collectors.toList())),
+                                                .collect(toList())),
                                 new AccessListObject(
                                         "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
                                         Collections.emptyList()))
-                        .collect(Collectors.toList());
+                        .collect(toList());
 
         return RawTransaction.createTransaction(
                 3L,

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -14,7 +14,10 @@ package org.web3j.crypto;
 
 import java.math.BigInteger;
 import java.security.SignatureException;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -262,14 +265,17 @@ public class TransactionDecoderTest {
 
     private static RawTransaction createEip2930RawTransaction() {
         List<AccessListObject> accessList =
-                List.of(
-                        new AccessListObject(
-                                "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
-                                List.of(
-                                        "0x0000000000000000000000000000000000000000000000000000000000000003",
-                                        "0x0000000000000000000000000000000000000000000000000000000000000007")),
-                        new AccessListObject(
-                                "0xbb9bc244d798123fde783fcc1c72d3bb8c189413", List.of()));
+                Stream.of(
+                                new AccessListObject(
+                                        "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                                        Stream.of(
+                                                        "0x0000000000000000000000000000000000000000000000000000000000000003",
+                                                        "0x0000000000000000000000000000000000000000000000000000000000000007")
+                                                .collect(Collectors.toList())),
+                                new AccessListObject(
+                                        "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
+                                        Collections.emptyList()))
+                        .collect(Collectors.toList());
 
         return RawTransaction.createTransaction(
                 3L,

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -14,13 +14,16 @@ package org.web3j.crypto;
 
 import java.math.BigInteger;
 import java.security.SignatureException;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import org.web3j.crypto.transaction.type.Transaction1559;
+import org.web3j.crypto.transaction.type.Transaction2930;
 import org.web3j.utils.Numeric;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,5 +197,88 @@ public class TransactionDecoderTest {
                 BigInteger.valueOf(123),
                 BigInteger.valueOf(5678),
                 BigInteger.valueOf(1100000));
+    }
+
+    @Test
+    public void testDecoding2930() {
+        final RawTransaction rawTransaction = createEip2930RawTransaction();
+        final Transaction2930 transaction2930 = (Transaction2930) rawTransaction.getTransaction();
+
+        final byte[] encodedMessage = TransactionEncoder.encode(rawTransaction);
+        final String hexMessage = Numeric.toHexString(encodedMessage);
+
+        final RawTransaction result = TransactionDecoder.decode(hexMessage);
+        assertTrue(result.getTransaction() instanceof Transaction2930);
+        final Transaction2930 resultTransaction2930 = (Transaction2930) result.getTransaction();
+
+        assertNotNull(result);
+        assertEquals(transaction2930.getChainId(), resultTransaction2930.getChainId());
+        assertEquals(transaction2930.getNonce(), resultTransaction2930.getNonce());
+        assertEquals(transaction2930.getGasPrice(), resultTransaction2930.getGasPrice());
+        assertEquals(transaction2930.getGasLimit(), resultTransaction2930.getGasLimit());
+        assertEquals(transaction2930.getTo(), resultTransaction2930.getTo());
+        assertEquals(transaction2930.getValue(), resultTransaction2930.getValue());
+        assertEquals(transaction2930.getData(), resultTransaction2930.getData());
+        assertIterableEquals(
+                transaction2930.getAccessList(), resultTransaction2930.getAccessList());
+    }
+
+    @Test
+    public void testDecodingSigned2930() throws SignatureException {
+        final RawTransaction rawTransaction = createEip2930RawTransaction();
+        final Transaction2930 transaction2930 = (Transaction2930) rawTransaction.getTransaction();
+
+        final byte[] signedMessage =
+                TransactionEncoder.signMessage(rawTransaction, SampleKeys.CREDENTIALS);
+        final String signedHexMessage = Numeric.toHexString(signedMessage);
+
+        final RawTransaction result = TransactionDecoder.decode(signedHexMessage);
+        assertTrue(result.getTransaction() instanceof Transaction2930);
+        final Transaction2930 resultTransaction2930 = (Transaction2930) result.getTransaction();
+
+        assertNotNull(result);
+        assertEquals(transaction2930.getChainId(), resultTransaction2930.getChainId());
+        assertEquals(transaction2930.getNonce(), resultTransaction2930.getNonce());
+        assertEquals(transaction2930.getGasPrice(), resultTransaction2930.getGasPrice());
+        assertEquals(transaction2930.getGasLimit(), resultTransaction2930.getGasLimit());
+        assertEquals(transaction2930.getTo(), resultTransaction2930.getTo());
+        assertEquals(transaction2930.getValue(), resultTransaction2930.getValue());
+        assertEquals(transaction2930.getData(), resultTransaction2930.getData());
+        assertIterableEquals(
+                transaction2930.getAccessList(), resultTransaction2930.getAccessList());
+
+        assertTrue(result instanceof SignedRawTransaction);
+        final SignedRawTransaction signedResult = (SignedRawTransaction) result;
+        assertNotNull(signedResult.getSignatureData());
+
+        final Sign.SignatureData signatureData = signedResult.getSignatureData();
+        final byte[] encodedTransaction = TransactionEncoder.encode(rawTransaction);
+        final BigInteger key = Sign.signedMessageToKey(encodedTransaction, signatureData);
+        assertEquals(key, SampleKeys.PUBLIC_KEY);
+        assertEquals(SampleKeys.ADDRESS, signedResult.getFrom());
+        signedResult.verify(SampleKeys.ADDRESS);
+        assertNull(signedResult.getChainId());
+    }
+
+    private static RawTransaction createEip2930RawTransaction() {
+        List<AccessListObject> accessList =
+                List.of(
+                        new AccessListObject(
+                                "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                                List.of(
+                                        "0x0000000000000000000000000000000000000000000000000000000000000003",
+                                        "0x0000000000000000000000000000000000000000000000000000000000000007")),
+                        new AccessListObject(
+                                "0xbb9bc244d798123fde783fcc1c72d3bb8c189413", List.of()));
+
+        return RawTransaction.createTransaction(
+                3L,
+                BigInteger.valueOf(0),
+                BigInteger.valueOf(30000),
+                BigInteger.valueOf(500000),
+                "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+                BigInteger.valueOf(1000000),
+                "0x1000001111100000",
+                accessList);
     }
 }


### PR DESCRIPTION
### What does this PR do?
Adds support for [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) (type 1) transaction encoding/decoding.

### Where should the reviewer start?
All code is additive and should be reviewed. There may be some areas where DRY patterns can be used better. Also would love suggestions on where to put the `AccessListObject` as its currently just copied from its original location.

### Why is it needed?
Support is missing for this transaction type. This PR allows the `TransactionDecoder` to handle all transaction types.

