### PR TITLE
Handle generated `StaticArrayNN` in `Utils#getParameterizedTypeName`

### DIFF
--- a/abi/src/main/java/org/web3j/abi/Utils.java
+++ b/abi/src/main/java/org/web3j/abi/Utils.java
@@ -148,13 +148,18 @@ public class Utils {
                 Class<U> parameterizedType = getParameterizedTypeFromArray(typeReference);
                 String parameterizedTypeName = simpleNameOrStruct(parameterizedType);
                 return parameterizedTypeName + "[]";
-            } else if (type.equals(StaticArray.class)) {
+            } else if (StaticArray.class.isAssignableFrom(type)) {
                 Class<U> parameterizedType = getParameterizedTypeFromArray(typeReference);
                 String parameterizedTypeName = simpleNameOrStruct(parameterizedType);
-                return parameterizedTypeName
-                        + "["
-                        + ((TypeReference.StaticArrayTypeReference) typeReference).getSize()
-                        + "]";
+                final int length;
+                if (TypeReference.StaticArrayTypeReference.class.isAssignableFrom(
+                        typeReference.getClass())) {
+                    length = ((TypeReference.StaticArrayTypeReference) typeReference).getSize();
+                } else {
+                    length = Integer.parseInt(type.getSimpleName().substring(11));
+                }
+
+                return parameterizedTypeName + "[" + length + "]";
             } else {
                 throw new UnsupportedOperationException("Invalid type provided " + type.getName());
             }

--- a/abi/src/test/java/org/web3j/abi/UtilsTest.java
+++ b/abi/src/test/java/org/web3j/abi/UtilsTest.java
@@ -28,10 +28,7 @@ import org.web3j.abi.datatypes.StaticArray;
 import org.web3j.abi.datatypes.Ufixed;
 import org.web3j.abi.datatypes.Uint;
 import org.web3j.abi.datatypes.Utf8String;
-import org.web3j.abi.datatypes.generated.Int64;
-import org.web3j.abi.datatypes.generated.StaticArray2;
-import org.web3j.abi.datatypes.generated.Uint256;
-import org.web3j.abi.datatypes.generated.Uint64;
+import org.web3j.abi.datatypes.generated.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.web3j.abi.Utils.typeMap;
@@ -50,6 +47,8 @@ public class UtilsTest {
         assertEquals(Utils.getTypeName(new TypeReference<Bool>() {}), ("bool"));
         assertEquals(Utils.getTypeName(new TypeReference<Utf8String>() {}), ("string"));
         assertEquals(Utils.getTypeName(new TypeReference<DynamicBytes>() {}), ("bytes"));
+        assertEquals(
+                Utils.getTypeName(new TypeReference<StaticArray3<Uint256>>() {}), ("uint256[3]"));
 
         assertEquals(
                 Utils.getTypeName(


### PR DESCRIPTION
### What does this PR do?
Handle `StaticArrayNN` instances in `Utils#getParameterizedTypeName`.

### Where should the reviewer start?
/

### Why is it needed?
It seems that fixed-sized event parameters are generated using a normal `TypeReference` instead of `StaticArrayTypeReference`. This is handles such cases in `getParameterizedTypeName` method.

