### PR TITLE
Fixed leading zeroes Hex quantity not accepted

### DIFF
--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -47,11 +47,23 @@ public final class Numeric {
         if (!isValidHexQuantity(value)) {
             throw new MessageDecodingException("Value must be in format 0x[1-9]+[0-9]* or 0x0");
         }
+
         try {
-            return new BigInteger(value.substring(2), 16);
+            return new BigInteger(parsePaddedHexQuantity(value), 16);
         } catch (NumberFormatException e) {
             throw new MessageDecodingException("Negative ", e);
         }
+    }
+
+    private static String parsePaddedHexQuantity(String value) {
+        if (value.length() > 3 && value.charAt(2) == '0') {
+            for (int i = 2; i < value.length(); i++) {
+                if (value.charAt(i) != '0') {
+                    return value.substring(i);
+                }
+            }
+        }
+        return value;
     }
 
     private static boolean isLongValue(String value) {
@@ -73,10 +85,6 @@ public final class Numeric {
         }
 
         if (!value.startsWith(HEX_PREFIX)) {
-            return false;
-        }
-
-        if (value.length() > 3 && value.charAt(2) == '0') {
             return false;
         }
 

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -49,21 +49,15 @@ public final class Numeric {
         }
 
         try {
-            return new BigInteger(parsePaddedHexQuantity(value), 16);
+            return parsePaddedNumberHex(value);
         } catch (NumberFormatException e) {
             throw new MessageDecodingException("Negative ", e);
         }
     }
 
-    private static String parsePaddedHexQuantity(String value) {
-        if (value.length() > 3 && value.charAt(2) == '0') {
-            for (int i = 2; i < value.length(); i++) {
-                if (value.charAt(i) != '0') {
-                    return value.substring(i);
-                }
-            }
-        }
-        return value.substring(2);
+    public static BigInteger parsePaddedNumberHex(String value) {
+        String numWithoutLeadingZeros = cleanHexPrefix(value).replaceFirst("^0+(?!$)", "");
+        return new BigInteger(numWithoutLeadingZeros, 16);
     }
 
     private static boolean isLongValue(String value) {

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -63,7 +63,7 @@ public final class Numeric {
                 }
             }
         }
-        return value;
+        return value.substring(2);
     }
 
     private static boolean isLongValue(String value) {

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -74,6 +74,8 @@ public class NumericTest {
     public void testQuantityDecodeLeadingZero() {
         assertEquals(Numeric.decodeQuantity("0x0400"), (BigInteger.valueOf(1024L)));
         assertEquals(Numeric.decodeQuantity("0x001"), (BigInteger.valueOf(1L)));
+        assertEquals(Numeric.decodeQuantity("0x000"), (BigInteger.ZERO));
+        assertEquals(Numeric.decodeQuantity("0x00f"), (BigInteger.valueOf(15L)));
     }
 
     @Test

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -72,8 +72,8 @@ public class NumericTest {
 
     @Test
     public void testQuantityDecodeLeadingZero() {
-        assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("0x0400"));
-        assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("0x001"));
+        assertEquals(Numeric.decodeQuantity("0x0400"), (BigInteger.valueOf(1024L)));
+        assertEquals(Numeric.decodeQuantity("0x001"), (BigInteger.valueOf(1L)));
     }
 
     @Test

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -77,12 +77,6 @@ public class NumericTest {
     }
 
     @Test
-    public void testQuantityDecodeLeadingZeroException() {
-
-        assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("0x0400"));
-    }
-
-    @Test
     public void testQuantityDecodeMissingPrefix() {
 
         assertThrows(MessageDecodingException.class, () -> Numeric.decodeQuantity("ff"));


### PR DESCRIPTION
### What does this PR do?
Allow parsing of padded numerical strings with leading zeroes

### Where should the reviewer start?
from decodeQuantity() function in "utils/src/main/java/org/web3j/utils/Numeric.java"

### Why is it needed?
Fixes issues - https://github.com/web3j/web3j/issues/1752

