### PR TITLE
Upgrade bouncycastle to 1.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 
 ext {
-    bouncycastleVersion = '1.68'
+    bouncycastleVersion = '1.70'
     jacksonVersion = '2.13.3'
     javaPoetVersion = '1.7.0'
     kotlinVersion = '1.3.72'


### PR DESCRIPTION
### What does this PR do?
Upgrades bouncy castle from v1.68 to v1.70. All checks go through. Also, tested by integrating with our app.

### Where should the reviewer start?
The change is just one line in top level build.gradle.

### Why is it needed?
To keep up with the latest library version.

