### PR TITLE
Fix Bug: When length < input.length, the output is wrong, because the…

### DIFF
--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -239,7 +239,8 @@ public final class Numeric {
 
     private static char[] toHexCharArray(byte[] input, int offset, int length, boolean withPrefix) {
         final char[] output = new char[length << 1];
-        for (int i = offset, j = 0; i < length; i++, j++) {
+        int end = length + offset;
+        for (int i = offset, j = 0; i < end; i++, j++) {
             final int v = input[i] & 0xFF;
             output[j++] = HEX_CHAR_MAP[v >>> 4];
             output[j] = HEX_CHAR_MAP[v & 0x0F];

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -233,14 +233,13 @@ public final class Numeric {
     }
 
     public static String toHexString(byte[] input, int offset, int length, boolean withPrefix) {
-        final String output = new String(toHexCharArray(input, offset, length, withPrefix));
+        final String output = new String(toHexCharArray(input, offset, length));
         return withPrefix ? new StringBuilder(HEX_PREFIX).append(output).toString() : output;
     }
 
-    private static char[] toHexCharArray(byte[] input, int offset, int length, boolean withPrefix) {
+    private static char[] toHexCharArray(byte[] input, int offset, int length) {
         final char[] output = new char[length << 1];
-        int end = length + offset;
-        for (int i = offset, j = 0; i < end; i++, j++) {
+        for (int i = offset, j = 0; i < length + offset; i++, j++) {
             final int v = input[i] & 0xFF;
             output[j++] = HEX_CHAR_MAP[v >>> 4];
             output[j] = HEX_CHAR_MAP[v & 0x0F];

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.web3j.utils.Numeric.asByte;
-import static org.web3j.utils.Numeric.toHexString;
 
 public class NumericTest {
 
@@ -177,13 +176,13 @@ public class NumericTest {
 
     @Test
     public void testToHexString() {
-        assertEquals(toHexString(new byte[] {}), ("0x"));
-        assertEquals(toHexString(new byte[] {0x1}), ("0x01"));
-        assertEquals(toHexString(HEX_RANGE_ARRAY), (HEX_RANGE_STRING));
+        assertEquals(Numeric.toHexString(new byte[] {}), ("0x"));
+        assertEquals(Numeric.toHexString(new byte[] {0x1}), ("0x01"));
+        assertEquals(Numeric.toHexString(HEX_RANGE_ARRAY), (HEX_RANGE_STRING));
         byte[] input = {(byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78};
-        assertEquals(toHexString(input, 0, input.length, false), ("12345678"));
-        assertEquals(toHexString(input, 0, 2, false), ("1234"));
-        assertEquals(toHexString(input, 2, 2, false), ("5678"));
+        assertEquals(Numeric.toHexString(input, 0, input.length, false), ("12345678"));
+        assertEquals(Numeric.toHexString(input, 0, 2, false), ("1234"));
+        assertEquals(Numeric.toHexString(input, 2, 2, false), ("5678"));
     }
 
     @Test

--- a/utils/src/test/java/org/web3j/utils/NumericTest.java
+++ b/utils/src/test/java/org/web3j/utils/NumericTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.web3j.utils.Numeric.asByte;
+import static org.web3j.utils.Numeric.toHexString;
 
 public class NumericTest {
 
@@ -176,9 +177,13 @@ public class NumericTest {
 
     @Test
     public void testToHexString() {
-        assertEquals(Numeric.toHexString(new byte[] {}), ("0x"));
-        assertEquals(Numeric.toHexString(new byte[] {0x1}), ("0x01"));
-        assertEquals(Numeric.toHexString(HEX_RANGE_ARRAY), (HEX_RANGE_STRING));
+        assertEquals(toHexString(new byte[] {}), ("0x"));
+        assertEquals(toHexString(new byte[] {0x1}), ("0x01"));
+        assertEquals(toHexString(HEX_RANGE_ARRAY), (HEX_RANGE_STRING));
+        byte[] input = {(byte) 0x12, (byte) 0x34, (byte) 0x56, (byte) 0x78};
+        assertEquals(toHexString(input, 0, input.length, false), ("12345678"));
+        assertEquals(toHexString(input, 0, 2, false), ("1234"));
+        assertEquals(toHexString(input, 2, 2, false), ("5678"));
     }
 
     @Test


### PR DESCRIPTION
… number of times in the for loop is length - offset, and the correct one should be length.

### What does this PR do?
Fix Bug

### Where should the reviewer start?
Numeric.java file line 242

### Why is it needed?
Fix Bug
When length < input.length, the output is wrong, because the number of times in the for loop is length - offset, and the correct one should be length.
