### PR TITLE
Fix offset miscalculation in nested struct

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -490,7 +490,7 @@ public class TypeDecoder {
                                         0,
                                         TypeReference.create(declaredField));
                         staticOffset +=
-                                staticStructNestedPublicFieldsFlatList((Class<Type>) classType)
+                                staticStructNestedPublicFieldsFlatList((Class<Type>) declaredField)
                                                 .size()
                                         * MAX_BYTE_LENGTH_FOR_HEX_STRING;
                     } else {

--- a/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
+++ b/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
@@ -827,6 +827,7 @@ public class AbiV2TestFixture {
             this.data = data.getValue();
         }
     }
+
     public static final org.web3j.abi.datatypes.Function setQuxFunction =
             new org.web3j.abi.datatypes.Function(
                     FUNC_SETQUX,
@@ -835,9 +836,7 @@ public class AbiV2TestFixture {
 
     public static final org.web3j.abi.datatypes.Function getQuxFunction =
             new org.web3j.abi.datatypes.Function(
-                    FUNC_GETQUX,
-                    Arrays.<Type>asList(),
-                    Arrays.asList(new TypeReference<Qux>() {}));
+                    FUNC_GETQUX, Arrays.<Type>asList(), Arrays.asList(new TypeReference<Qux>() {}));
 
     public static class BytesStruct extends DynamicStruct {
         public byte[] pubkey;

--- a/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
+++ b/abi/src/test/java/org/web3j/abi/AbiV2TestFixture.java
@@ -112,6 +112,10 @@ public class AbiV2TestFixture {
 
     public static final String FUNC_SETWIZ = "setWiz";
 
+    public static final String FUNC_SETQUX = "setQux";
+
+    public static final String FUNC_GETQUX = "getQux";
+
     public static final String FUNC_addDynamicBytesArray = "addDynamicBytesArray";
 
     public static final String FUNC_setArrayOfStructWithArraysFunction =
@@ -805,6 +809,35 @@ public class AbiV2TestFixture {
                     FUNC_SETWIZ,
                     Arrays.<Type>asList(new Wiz(new Foo("id", "name"), "data")),
                     Collections.emptyList());
+
+    public static class Qux extends DynamicStruct {
+        public Bar bar;
+
+        public String data;
+
+        public Qux(Bar bar, String data) {
+            super(bar, new org.web3j.abi.datatypes.Utf8String(data));
+            this.bar = bar;
+            this.data = data;
+        }
+
+        public Qux(Bar bar, Utf8String data) {
+            super(bar, data);
+            this.bar = bar;
+            this.data = data.getValue();
+        }
+    }
+    public static final org.web3j.abi.datatypes.Function setQuxFunction =
+            new org.web3j.abi.datatypes.Function(
+                    FUNC_SETQUX,
+                    Arrays.<Type>asList(new Qux(new Bar(BigInteger.ONE, BigInteger.TEN), "data")),
+                    Collections.emptyList());
+
+    public static final org.web3j.abi.datatypes.Function getQuxFunction =
+            new org.web3j.abi.datatypes.Function(
+                    FUNC_GETQUX,
+                    Arrays.<Type>asList(),
+                    Arrays.asList(new TypeReference<Qux>() {}));
 
     public static class BytesStruct extends DynamicStruct {
         public byte[] pubkey;

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -869,4 +869,21 @@ public class DefaultFunctionEncoderTest {
                 expected,
                 FunctionEncoder.encode(AbiV2TestFixture.setArrayOfStructWithArraysFunction));
     }
+
+    @Test
+    public void testDynamicStructWithStaticStruct() {
+        String expected =
+                "0x3db2b680"
+                        + "0000000000000000000000000000000000000000000000000000000000000020"
+                        + "0000000000000000000000000000000000000000000000000000000000000001"
+                        + "000000000000000000000000000000000000000000000000000000000000000a"
+                        + "0000000000000000000000000000000000000000000000000000000000000060"
+                        + "0000000000000000000000000000000000000000000000000000000000000004"
+                        + "6461746100000000000000000000000000000000000000000000000000000000";
+
+        assertEquals(
+                expected,
+                FunctionEncoder.encode(AbiV2TestFixture.setQuxFunction));
+
+    }
 }

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -881,9 +881,6 @@ public class DefaultFunctionEncoderTest {
                         + "0000000000000000000000000000000000000000000000000000000000000004"
                         + "6461746100000000000000000000000000000000000000000000000000000000";
 
-        assertEquals(
-                expected,
-                FunctionEncoder.encode(AbiV2TestFixture.setQuxFunction));
-
+        assertEquals(expected, FunctionEncoder.encode(AbiV2TestFixture.setQuxFunction));
     }
 }

--- a/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -1311,12 +1311,9 @@ public class FunctionReturnDecoderTest {
                         + "6461746100000000000000000000000000000000000000000000000000000000";
         assertEquals(
                 FunctionReturnDecoder.decode(
-                        rawInput,
-                        AbiV2TestFixture.getQuxFunction.getOutputParameters()),
+                        rawInput, AbiV2TestFixture.getQuxFunction.getOutputParameters()),
                 Arrays.asList(
                         new AbiV2TestFixture.Qux(
-                                new AbiV2TestFixture.Bar(BigInteger.ONE, BigInteger.TEN),
-                                "data")));
+                                new AbiV2TestFixture.Bar(BigInteger.ONE, BigInteger.TEN), "data")));
     }
-
 }

--- a/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -1298,4 +1298,25 @@ public class FunctionReturnDecoderTest {
                                 new Uint256(0),
                                 new Uint256(0))));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDecodeDynamicStructWithStaticStruct() {
+        String rawInput =
+                "0x0000000000000000000000000000000000000000000000000000000000000020"
+                        + "0000000000000000000000000000000000000000000000000000000000000001"
+                        + "000000000000000000000000000000000000000000000000000000000000000a"
+                        + "0000000000000000000000000000000000000000000000000000000000000060"
+                        + "0000000000000000000000000000000000000000000000000000000000000004"
+                        + "6461746100000000000000000000000000000000000000000000000000000000";
+        assertEquals(
+                FunctionReturnDecoder.decode(
+                        rawInput,
+                        AbiV2TestFixture.getQuxFunction.getOutputParameters()),
+                Arrays.asList(
+                        new AbiV2TestFixture.Qux(
+                                new AbiV2TestFixture.Bar(BigInteger.ONE, BigInteger.TEN),
+                                "data")));
+    }
+
 }


### PR DESCRIPTION
### What does this PR do?
Fix a bug that existed in decoding dynamic struct:
- correct offset miscalculation in nested struct 

### Where should the reviewer start?
In the **decodeDynamicStructElements(final String input, final int offset, final TypeReference<T> typeReference, final BiFunction<List<T>, String, T> consumer)** method of **TypeDecoder.java**

### Why is it needed?
More and more users start to use nested struct in Solidity. It turns out inputdata/returndata decoder is becoming a common method.

