### PR TITLE
Fix ETH feeHistory 

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -112,7 +112,7 @@ public interface Ethereum {
     Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas();
 
     Request<?, EthFeeHistory> ethFeeHistory(
-            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
+            String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
 
     Request<?, EthAccounts> ethAccounts();
 

--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -111,6 +111,19 @@ public interface Ethereum {
 
     Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas();
 
+    @Deprecated
+    /**
+     * Method receives wrong type parameter int for blockCount, according to documentation the type
+     * should be String which is the encoded hex of the blocks number. This is kept for backward
+     * compatibility
+     *
+     * @param blockCount Requested range of blocks
+     * @param newestBlock Highest block of the requested range.
+     * @param rewardPercentiles A monotonically increasing list of percentile values.
+     */
+    Request<?, EthFeeHistory> ethFeeHistory(
+            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
+
     Request<?, EthFeeHistory> ethFeeHistory(
             String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
 

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -234,7 +234,7 @@ public class JsonRpc2_0Web3j implements Web3j {
 
     @Override
     public Request<?, EthFeeHistory> ethFeeHistory(
-            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
+            String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
         return new Request<>(
                 "eth_feeHistory",
                 Arrays.asList(blockCount, newestBlock.getValue(), rewardPercentiles),

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -233,6 +233,17 @@ public class JsonRpc2_0Web3j implements Web3j {
     }
 
     @Override
+    @Deprecated
+    public Request<?, EthFeeHistory> ethFeeHistory(
+            int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
+        return new Request<>(
+                "eth_feeHistory",
+                Arrays.asList(blockCount, newestBlock.getValue(), rewardPercentiles),
+                web3jService,
+                EthFeeHistory.class);
+    }
+
+    @Override
     public Request<?, EthFeeHistory> ethFeeHistory(
             String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
         return new Request<>(

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -156,10 +156,14 @@ public class RequestTest extends RequestTester {
 
     @Test
     public void testEthFeeHistory() throws Exception {
-        web3j.ethFeeHistory(1, DefaultBlockParameterName.LATEST, null).send();
+        web3j.ethFeeHistory(
+                        Numeric.toHexStringWithPrefixZeroPadded(BigInteger.valueOf(1), 1),
+                        DefaultBlockParameterName.LATEST,
+                        null)
+                .send();
 
         verifyResult(
-                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_feeHistory\",\"params\":[1,\"latest\",null],\"id\":1}");
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_feeHistory\",\"params\":[\"0x1\",\"latest\",null],\"id\":1}");
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Fix argument type for feeHistory

### Where should the reviewer start?
Changed files

### Why is it needed?
One discord users mentioned that the argument type is wrong and fails on Hardhat. I tested and it seems as int it was working on Ganache, Geth, but on Hardhat is failing. Now should be fine for all as it is accordingly too documentation.
https://ethereum.github.io/execution-apis/api-documentation/

