### PR TITLE
fix: incorrect error thrown by EnsResolver

### DIFF
--- a/core/src/main/java/org/web3j/ens/EnsResolver.java
+++ b/core/src/main/java/org/web3j/ens/EnsResolver.java
@@ -128,14 +128,22 @@ public class EnsResolver {
      */
     protected OffchainResolverContract obtainOffchainResolver(String ensName) {
         if (isValidEnsName(ensName, addressLength)) {
+            boolean isSynced;
+
             try {
-                if (!isSynced()) {
-                    throw new EnsResolutionException("Node is not currently synced");
-                } else {
-                    return lookupOffchainResolver(ensName);
-                }
+                isSynced = isSynced();
             } catch (Exception e) {
                 throw new EnsResolutionException("Unable to determine sync status of node", e);
+            }
+
+            if (!isSynced) {
+                throw new EnsResolutionException("Node is not currently synced");
+            }
+
+            try {
+                return lookupOffchainResolver(ensName);
+            } catch (Exception e) {
+                throw new EnsResolutionException("Unable to get resolver", e);
             }
         } else {
             throw new EnsResolutionException("EnsName is invalid: " + ensName);


### PR DESCRIPTION
### What does this PR do?
Rearrange try/catch to handle errors thrown by `lookupOffchainResolver` separately.

### Where should the reviewer start?
See the diff. To reproduce the issue, call `reverseResolve` for any address that doesn't have an ENS name registered.

### Why is it needed?
The whole method is wrapped in a single try/catch that throws `Unable to determine sync status of node`. When the node is synced but an error is thrown for another reason, the caller will still see this message which won't make sense in that case.

