### PR TITLE
Fix for compareJavaFile test fail - platform independent

### DIFF
--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -219,8 +219,8 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
                                         inputFileName + ".java"),
                                 File.separator));
         assertEquals(
-                new String(Files.readAllBytes(fileExpected.toPath())),
-                new String(Files.readAllBytes(fileActual.toPath())));
+                new String(Files.readAllBytes(fileExpected.toPath())).replaceAll("(\r\n|\n)", ""),
+                new String(Files.readAllBytes(fileActual.toPath())).replaceAll("(\r\n|\n)", ""));
     }
 
     private void testCodeGenerationJvmTypes(String contractName, String inputFileName)


### PR DESCRIPTION
### What does this PR do?
In compareJavaFile() it replaces all "\n" "\r\n" in compared strings to make it platform independent 

### Where should the reviewer start?
check compareJavaFile() function in codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java

### Why is it needed?
Fixes compareJavaFile test 

