### PR TITLE
Add dynamic gas provider implementations.

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -48,6 +48,7 @@ import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.tx.gas.ContractEIP1559GasProvider;
 import org.web3j.tx.gas.ContractGasProvider;
+import org.web3j.tx.gas.EIP1559GasFeeData;
 import org.web3j.tx.gas.StaticGasProvider;
 import org.web3j.tx.response.EmptyTransactionReceipt;
 import org.web3j.utils.Numeric;
@@ -377,15 +378,27 @@ public abstract class Contract extends ManagedTransaction {
                 ContractEIP1559GasProvider eip1559GasProvider =
                         (ContractEIP1559GasProvider) gasProvider;
                 if (eip1559GasProvider.isEIP1559Enabled()) {
+                    EIP1559GasFeeData feeData =
+                            eip1559GasProvider.getGasFeeData(
+                                    transactionManager.getFromAddress(),
+                                    contractAddress,
+                                    data,
+                                    weiValue,
+                                    funcName);
                     receipt =
                             sendEIP1559(
                                     eip1559GasProvider.getChainId(),
                                     contractAddress,
                                     data,
                                     weiValue,
-                                    eip1559GasProvider.getGasLimit(funcName),
-                                    eip1559GasProvider.getMaxPriorityFeePerGas(funcName),
-                                    eip1559GasProvider.getMaxFeePerGas(funcName),
+                                    eip1559GasProvider.getGasLimit(
+                                            transactionManager.getFromAddress(),
+                                            contractAddress,
+                                            data,
+                                            weiValue,
+                                            funcName),
+                                    feeData.getMaxPriorityFeePerGas(),
+                                    feeData.getMaxFeePerGas(),
                                     constructor);
                 }
             }
@@ -396,8 +409,18 @@ public abstract class Contract extends ManagedTransaction {
                                 contractAddress,
                                 data,
                                 weiValue,
-                                gasProvider.getGasPrice(funcName),
-                                gasProvider.getGasLimit(funcName),
+                                gasProvider.getGasPrice(
+                                        transactionManager.getFromAddress(),
+                                        contractAddress,
+                                        data,
+                                        weiValue,
+                                        funcName),
+                                gasProvider.getGasLimit(
+                                        transactionManager.getFromAddress(),
+                                        contractAddress,
+                                        data,
+                                        weiValue,
+                                        funcName),
                                 constructor);
             }
         } catch (JsonRpcError error) {

--- a/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/ContractGasProvider.java
@@ -15,11 +15,28 @@ package org.web3j.tx.gas;
 import java.math.BigInteger;
 
 public interface ContractGasProvider {
+
+    BigInteger getGasPrice(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc);
+
+    @Deprecated
     BigInteger getGasPrice(String contractFunc);
 
     @Deprecated
     BigInteger getGasPrice();
 
+    BigInteger getGasLimit(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc);
+
+    @Deprecated
     BigInteger getGasLimit(String contractFunc);
 
     @Deprecated

--- a/core/src/main/java/org/web3j/tx/gas/DynamicEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/DynamicEIP1559GasProvider.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthEstimateGas;
+import org.web3j.tx.exceptions.ContractCallException;
+
+public class DynamicEIP1559GasProvider extends StaticEIP1559GasProvider {
+
+    private BigInteger extraGas;
+    private BigInteger maxFeePerGasCap;
+    private BigInteger gasLimitCap;
+    private Web3j web3j;
+
+    public DynamicEIP1559GasProvider(
+            long chainId,
+            BigInteger fallbackMaxFeePerGas,
+            BigInteger fallbackMaxPriorityFeePerGas,
+            BigInteger fallbackGasLimit,
+            BigInteger extraGas,
+            BigInteger maxFeePerGasCap,
+            BigInteger gasLimitCap,
+            Web3j web3j) {
+        super(chainId, fallbackMaxFeePerGas, fallbackMaxPriorityFeePerGas, fallbackGasLimit);
+        this.extraGas = extraGas;
+        this.maxFeePerGasCap = maxFeePerGasCap;
+        this.gasLimitCap = gasLimitCap;
+        this.web3j = web3j;
+    }
+
+    public DynamicEIP1559GasProvider(
+            long chainId,
+            BigInteger fallbackMaxFeePerGas,
+            BigInteger fallbackMaxPriorityFeePerGas,
+            BigInteger fallbackGasLimit,
+            Web3j web3j) {
+        this(
+                chainId,
+                fallbackMaxFeePerGas,
+                fallbackMaxPriorityFeePerGas,
+                fallbackGasLimit,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                web3j);
+    }
+
+    @Override
+    public BigInteger getGasLimit(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        Transaction tx =
+                Transaction.createEthCallTransaction(fromAddress, contractAddress, data, weiValue);
+        try {
+            EthEstimateGas estimateGasResponse = web3j.ethEstimateGas(tx).send();
+            if (estimateGasResponse.hasError()) {
+                throw new ContractCallException(estimateGasResponse.getError().getMessage());
+            } else {
+                BigInteger gasUsed = estimateGasResponse.getAmountUsed().add(extraGas);
+                return gasLimitCap.compareTo(BigInteger.ZERO) > 0
+                        ? gasUsed.min(gasLimitCap)
+                        : gasUsed;
+            }
+        } catch (IOException e) {
+            return getGasLimit(contractFunc);
+        }
+    }
+
+    @Override
+    public EIP1559GasFeeData getGasFeeData(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        BigInteger baseFee = null;
+        try {
+            baseFee =
+                    web3j.ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false)
+                            .send()
+                            .getBlock()
+                            .getBaseFeePerGas();
+        } catch (Exception e) {
+        }
+        BigInteger maxPriorityFeePerGas = null;
+        try {
+            maxPriorityFeePerGas = web3j.ethMaxPriorityFeePerGas().send().getMaxPriorityFeePerGas();
+        } catch (Exception e) {
+        }
+        if (maxPriorityFeePerGas == null)
+            maxPriorityFeePerGas = getMaxPriorityFeePerGas(contractFunc);
+        BigInteger maxFeePerGas;
+        if (baseFee != null) {
+            maxFeePerGas = baseFee.multiply(BigInteger.valueOf(2)).add(maxPriorityFeePerGas);
+            if (maxFeePerGasCap.compareTo(BigInteger.ZERO) > 0)
+                maxFeePerGas = maxFeePerGas.min(maxFeePerGasCap);
+        } else {
+            maxFeePerGas = getMaxFeePerGas(contractFunc);
+        }
+        return new EIP1559GasFeeData(maxFeePerGas, maxPriorityFeePerGas);
+    }
+}

--- a/core/src/main/java/org/web3j/tx/gas/DynamicGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/DynamicGasProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.tx.gas;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.request.Transaction;
+import org.web3j.protocol.core.methods.response.EthEstimateGas;
+import org.web3j.tx.exceptions.ContractCallException;
+
+public class DynamicGasProvider extends StaticGasProvider {
+
+    private BigInteger extraGas;
+    private BigInteger gasLimitCap;
+    private Web3j web3j;
+
+    public DynamicGasProvider(
+            BigInteger fallbackGasPrice,
+            BigInteger fallbackGasLimit,
+            BigInteger extraGas,
+            BigInteger gasLimitCap,
+            Web3j web3j) {
+        super(fallbackGasPrice, fallbackGasLimit);
+        this.extraGas = extraGas;
+        this.gasLimitCap = gasLimitCap;
+        this.web3j = web3j;
+    }
+
+    public DynamicGasProvider(
+            BigInteger fallbackGasPrice, BigInteger fallbackGasLimit, Web3j web3j) {
+        this(fallbackGasPrice, fallbackGasLimit, BigInteger.ZERO, BigInteger.ZERO, web3j);
+    }
+
+    @Override
+    public BigInteger getGasLimit(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        Transaction tx =
+                Transaction.createEthCallTransaction(fromAddress, contractAddress, data, weiValue);
+        try {
+            EthEstimateGas estimateGasResponse = web3j.ethEstimateGas(tx).send();
+            if (estimateGasResponse.hasError()) {
+                throw new ContractCallException(estimateGasResponse.getError().getMessage());
+            } else {
+                BigInteger gasUsed = estimateGasResponse.getAmountUsed().add(extraGas);
+                return gasLimitCap.compareTo(BigInteger.ZERO) > 0
+                        ? gasUsed.min(gasLimitCap)
+                        : gasUsed;
+            }
+        } catch (IOException e) {
+            return getGasLimit(contractFunc);
+        }
+    }
+
+    @Override
+    public BigInteger getGasPrice(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        try {
+            return web3j.ethGasPrice().send().getGasPrice();
+        } catch (Exception e) {
+            return getGasPrice(contractFunc);
+        }
+    }
+}

--- a/core/src/main/java/org/web3j/tx/gas/EIP1559GasFeeData.java
+++ b/core/src/main/java/org/web3j/tx/gas/EIP1559GasFeeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Web3 Labs Ltd.
+ * Copyright 2023 Web3 Labs Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,21 +14,21 @@ package org.web3j.tx.gas;
 
 import java.math.BigInteger;
 
-public interface ContractEIP1559GasProvider extends ContractGasProvider {
-    boolean isEIP1559Enabled();
+public class EIP1559GasFeeData {
 
-    long getChainId();
+    private BigInteger maxFeePerGas;
+    private BigInteger maxPriorityFeePerGas;
 
-    EIP1559GasFeeData getGasFeeData(
-            String fromAddress,
-            String contractAddress,
-            String data,
-            BigInteger weiValue,
-            String contractFunc);
+    public EIP1559GasFeeData(BigInteger maxFeePerGas, BigInteger maxPriorityFeePerGas) {
+        this.maxFeePerGas = maxFeePerGas;
+        this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    }
 
-    @Deprecated
-    BigInteger getMaxFeePerGas(String contractFunc);
+    public BigInteger getMaxFeePerGas() {
+        return maxFeePerGas;
+    }
 
-    @Deprecated
-    BigInteger getMaxPriorityFeePerGas(String contractFunc);
+    public BigInteger getMaxPriorityFeePerGas() {
+        return maxPriorityFeePerGas;
+    }
 }

--- a/core/src/main/java/org/web3j/tx/gas/StaticEIP1559GasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticEIP1559GasProvider.java
@@ -32,6 +32,16 @@ public class StaticEIP1559GasProvider implements ContractEIP1559GasProvider {
     }
 
     @Override
+    public BigInteger getGasPrice(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        return maxFeePerGas;
+    }
+
+    @Override
     public BigInteger getGasPrice(String contractFunc) {
         return maxFeePerGas;
     }
@@ -39,6 +49,16 @@ public class StaticEIP1559GasProvider implements ContractEIP1559GasProvider {
     @Override
     public BigInteger getGasPrice() {
         return maxFeePerGas;
+    }
+
+    @Override
+    public BigInteger getGasLimit(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        return gasLimit;
     }
 
     @Override
@@ -59,6 +79,16 @@ public class StaticEIP1559GasProvider implements ContractEIP1559GasProvider {
     @Override
     public long getChainId() {
         return chainId;
+    }
+
+    @Override
+    public EIP1559GasFeeData getGasFeeData(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        return new EIP1559GasFeeData(maxFeePerGas, maxPriorityFeePerGas);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
+++ b/core/src/main/java/org/web3j/tx/gas/StaticGasProvider.java
@@ -25,6 +25,16 @@ public class StaticGasProvider implements ContractGasProvider {
     }
 
     @Override
+    public BigInteger getGasPrice(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        return gasPrice;
+    }
+
+    @Override
     public BigInteger getGasPrice(String contractFunc) {
         return gasPrice;
     }
@@ -32,6 +42,16 @@ public class StaticGasProvider implements ContractGasProvider {
     @Override
     public BigInteger getGasPrice() {
         return gasPrice;
+    }
+
+    @Override
+    public BigInteger getGasLimit(
+            String fromAddress,
+            String contractAddress,
+            String data,
+            BigInteger weiValue,
+            String contractFunc) {
+        return gasLimit;
     }
 
     @Override


### PR DESCRIPTION
For EIP-1559 transactions:
- gasLimit is calculated from gas estimation (+ extraGas), transactions detected to fail are not submitted
- maxPriorityFeePerGas is obtained from node
- maxFeePerGas is calculated as baseFee * 2 + maxPriorityFeePerGas

For Legacy transactions:
- gasLimit is calculated from gas estimation (+ extraGas), transactions detected to fail are not submitted
- gasPrice is obtained from node

Both implementations allow to set fallback values and price/limit caps.

### What does this PR do?
It adds two new ContractGasProvider implementations that allow to dynamically set gasLimit, gasPrice, maxPriorityFeePerGas and maxBaseFeePerGas, as almost any web3 library does by default.

### Why is it needed?
To pay less fees and to increase the probability for a transaction to be included in a block.
