### PR TITLE
Better fix for #1834, use the correct block count encoding.

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -111,21 +111,8 @@ public interface Ethereum {
 
     Request<?, EthMaxPriorityFeePerGas> ethMaxPriorityFeePerGas();
 
-    @Deprecated
-    /**
-     * Method receives wrong type parameter int for blockCount, according to documentation the type
-     * should be String which is the encoded hex of the blocks number. This is kept for backward
-     * compatibility
-     *
-     * @param blockCount Requested range of blocks
-     * @param newestBlock Highest block of the requested range.
-     * @param rewardPercentiles A monotonically increasing list of percentile values.
-     */
     Request<?, EthFeeHistory> ethFeeHistory(
             int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
-
-    Request<?, EthFeeHistory> ethFeeHistory(
-            String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles);
 
     Request<?, EthAccounts> ethAccounts();
 

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -233,22 +233,14 @@ public class JsonRpc2_0Web3j implements Web3j {
     }
 
     @Override
-    @Deprecated
     public Request<?, EthFeeHistory> ethFeeHistory(
             int blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
         return new Request<>(
                 "eth_feeHistory",
-                Arrays.asList(blockCount, newestBlock.getValue(), rewardPercentiles),
-                web3jService,
-                EthFeeHistory.class);
-    }
-
-    @Override
-    public Request<?, EthFeeHistory> ethFeeHistory(
-            String blockCount, DefaultBlockParameter newestBlock, List<Double> rewardPercentiles) {
-        return new Request<>(
-                "eth_feeHistory",
-                Arrays.asList(blockCount, newestBlock.getValue(), rewardPercentiles),
+                Arrays.asList(
+                        Numeric.encodeQuantity(BigInteger.valueOf(blockCount)),
+                        newestBlock.getValue(),
+                        rewardPercentiles),
                 web3jService,
                 EthFeeHistory.class);
     }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -156,11 +156,7 @@ public class RequestTest extends RequestTester {
 
     @Test
     public void testEthFeeHistory() throws Exception {
-        web3j.ethFeeHistory(
-                        Numeric.toHexStringWithPrefixZeroPadded(BigInteger.valueOf(1), 1),
-                        DefaultBlockParameterName.LATEST,
-                        null)
-                .send();
+        web3j.ethFeeHistory(1, DefaultBlockParameterName.LATEST, null).send();
 
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"eth_feeHistory\",\"params\":[\"0x1\",\"latest\",null],\"id\":1}");


### PR DESCRIPTION
PR #1834 duplicated the `ethFeeHistory` function and deprecated the old one. The correct thing to do would have been to just fix the block count encoding format of the existing one.