### PR TITLE
Update gradle version to meet with modern (but not the latest) JDK

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### What does this PR do?
Update ```gradle``` version to gradle-6.3

### Where should the reviewer start?
gradle-wrapper.properties

### Why is it needed?
Required by this PR https://github.com/web3j/web3j/pull/1860

It is possible to find a workaround, but it would be better to update it. There is a compatibility issue between ```gradle``` and ```java``` versions, without resolving it I am not able even to compile a project. I don't use the latest ```JDK```, just one which is comfortable to work with on the rest of my projects. I believe it is a time to migrate to more recent ```gradle``` version.

