### PR TITLE
StaticStruct Method Signature Is Wrong

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/StaticStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/StaticStruct.java
@@ -38,7 +38,7 @@ public class StaticStruct extends StaticArray<Type> implements StructType {
         final StringBuilder type = new StringBuilder("(");
         for (int i = 0; i < itemTypes.size(); ++i) {
             final Class<Type> cls = itemTypes.get(i);
-            if (StructType.class.isAssignableFrom(cls)) {
+            if (StructType.class.isAssignableFrom(cls) || Array.class.isAssignableFrom(cls)) {
                 type.append(getValue().get(i).getTypeAsString());
             } else {
                 type.append(AbiTypes.getTypeAString(cls));

--- a/abi/src/test/java/org/web3j/abi/datatypes/StaticStructTest.java
+++ b/abi/src/test/java/org/web3j/abi/datatypes/StaticStructTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.abi.datatypes;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.abi.datatypes.generated.StaticArray4;
+import org.web3j.abi.datatypes.generated.Uint256;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StaticStructTest {
+    @Test
+    public void testStaticStruct() {
+        Address address1 = Address.DEFAULT;
+        Address address2 = Address.DEFAULT;
+        StaticArray4<Uint256> array4 =
+                new StaticArray4<>(
+                        Uint256.class,
+                        Uint256.DEFAULT,
+                        Uint256.DEFAULT,
+                        Uint256.DEFAULT,
+                        Uint256.DEFAULT);
+        StaticStruct struct = new StaticStruct(address1, address2, array4);
+
+        // (address,address,uint256[4])
+        String expected =
+                "("
+                        + address1.getTypeAsString()
+                        + ","
+                        + address2.getTypeAsString()
+                        + ","
+                        + array4.getTypeAsString()
+                        + ")";
+        assertEquals(expected, struct.getTypeAsString());
+    }
+}


### PR DESCRIPTION
### What does this PR do?
*required*
if a function's parameter  like this, the function signature will be wrong,
solidity
```
function createAccount(
        address owner,
        Config memory config,
        uint256 salt
    ) public returns (address)

struct Config {
    address entryPoint;
    address aggregator;
    uint256[4] publicKey;
}
```
java
```
public class Config extends StaticStruct {

    public final Address entryPoint;

    public final Address aggregator;

    public final StaticArray4<Uint256> publicKey;

    public Config(Address entryPoint, Address aggregator, StaticArray4<Uint256> publicKey) {
        super(entryPoint, aggregator, publicKey);
        this.entryPoint = entryPoint;
        this.aggregator = aggregator;
        this.publicKey = publicKey;
    }
}
```

real method signature is **createAccount(address,(address,address,uint256[4]),uint256)**
but the **FunctionEncoder** return **createAccount(address,(address,address,StaticArray4),uint256)**
### Where should the reviewer start?
org/web3j/abi/datatypes/StaticStruct.java:41
### Why is it needed?
*required*
it's a bug
