### PR TITLE
`Numeric.decodeQuantity(String)` `MessageDecodingException` message

### DIFF
--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -45,7 +45,7 @@ public final class Numeric {
         }
 
         if (!isValidHexQuantity(value)) {
-            throw new MessageDecodingException("Value must be in format 0x[1-9]+[0-9]* or 0x0");
+            throw new MessageDecodingException("Value must be in format 0x[0-9a-fA-F]+");
         }
 
         try {


### PR DESCRIPTION
### What does this PR do?
Fix `MessageDecodingException` message in `Numeric.decodeQuantity(String)`. Character set was limited to decimal digits, and suggesting zero-padded inputs are not supported, which they are now.

### Where should the reviewer start?
Self-contained change.

### Why is it needed?
Informative.
