### PR TITLE
feat(#): add new eth method of eth_getBlockReceipts

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -12,6 +12,9 @@
  */
 package org.web3j.protocol.core;
 
+import java.math.BigInteger;
+import java.util.List;
+
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.response.BooleanResponse;
 import org.web3j.protocol.core.methods.response.DbGetHex;
@@ -70,9 +73,6 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
-
-import java.math.BigInteger;
-import java.util.List;
 
 /** Core Ethereum JSON-RPC API. */
 public interface Ethereum {
@@ -183,7 +183,9 @@ public interface Ethereum {
             DefaultBlockParameter defaultBlockParameter, BigInteger transactionIndex);
 
     Request<?, EthGetTransactionReceipt> ethGetTransactionReceipt(String transactionHash);
-    Request<?, EthGetBlockReceipts> ethGetBlockReceipts(DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, EthGetBlockReceipts> ethGetBlockReceipts(
+            DefaultBlockParameter defaultBlockParameter);
 
     Request<?, EthBlock> ethGetUncleByBlockHashAndIndex(
             String blockHash, BigInteger transactionIndex);

--- a/core/src/main/java/org/web3j/protocol/core/Ethereum.java
+++ b/core/src/main/java/org/web3j/protocol/core/Ethereum.java
@@ -12,9 +12,6 @@
  */
 package org.web3j.protocol.core;
 
-import java.math.BigInteger;
-import java.util.List;
-
 import org.web3j.protocol.core.methods.request.ShhFilter;
 import org.web3j.protocol.core.methods.response.BooleanResponse;
 import org.web3j.protocol.core.methods.response.DbGetHex;
@@ -34,6 +31,7 @@ import org.web3j.protocol.core.methods.response.EthFeeHistory;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
+import org.web3j.protocol.core.methods.response.EthGetBlockReceipts;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByHash;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByNumber;
 import org.web3j.protocol.core.methods.response.EthGetCode;
@@ -72,6 +70,9 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 import org.web3j.protocol.core.methods.response.admin.AdminPeers;
+
+import java.math.BigInteger;
+import java.util.List;
 
 /** Core Ethereum JSON-RPC API. */
 public interface Ethereum {
@@ -182,6 +183,7 @@ public interface Ethereum {
             DefaultBlockParameter defaultBlockParameter, BigInteger transactionIndex);
 
     Request<?, EthGetTransactionReceipt> ethGetTransactionReceipt(String transactionHash);
+    Request<?, EthGetBlockReceipts> ethGetBlockReceipts(DefaultBlockParameter defaultBlockParameter);
 
     Request<?, EthBlock> ethGetUncleByBlockHashAndIndex(
             String blockHash, BigInteger transactionIndex);

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -12,17 +12,7 @@
  */
 package org.web3j.protocol.core;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
-
 import io.reactivex.Flowable;
-
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.methods.request.ShhFilter;
@@ -46,6 +36,7 @@ import org.web3j.protocol.core.methods.response.EthFeeHistory;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
+import org.web3j.protocol.core.methods.response.EthGetBlockReceipts;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByHash;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByNumber;
 import org.web3j.protocol.core.methods.response.EthGetCode;
@@ -91,6 +82,15 @@ import org.web3j.protocol.websocket.events.LogNotification;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** JSON-RPC 2.0 factory implementation. */
 public class JsonRpc2_0Web3j implements Web3j {
@@ -452,6 +452,15 @@ public class JsonRpc2_0Web3j implements Web3j {
                 Arrays.asList(transactionHash),
                 web3jService,
                 EthGetTransactionReceipt.class);
+    }
+
+    @Override
+    public Request<?, EthGetBlockReceipts> ethGetBlockReceipts(DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "eth_getBlockReceipts",
+                Arrays.asList(defaultBlockParameter.getValue()),
+                web3jService,
+                EthGetBlockReceipts.class);
     }
 
     @Override

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -12,7 +12,17 @@
  */
 package org.web3j.protocol.core;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+
 import io.reactivex.Flowable;
+
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.methods.request.ShhFilter;
@@ -82,15 +92,6 @@ import org.web3j.protocol.websocket.events.LogNotification;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
 import org.web3j.utils.Async;
 import org.web3j.utils.Numeric;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 
 /** JSON-RPC 2.0 factory implementation. */
 public class JsonRpc2_0Web3j implements Web3j {
@@ -455,7 +456,8 @@ public class JsonRpc2_0Web3j implements Web3j {
     }
 
     @Override
-    public Request<?, EthGetBlockReceipts> ethGetBlockReceipts(DefaultBlockParameter defaultBlockParameter) {
+    public Request<?, EthGetBlockReceipts> ethGetBlockReceipts(
+            DefaultBlockParameter defaultBlockParameter) {
         return new Request<>(
                 "eth_getBlockReceipts",
                 Arrays.asList(defaultBlockParameter.getValue()),

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetBlockReceipts.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetBlockReceipts.java
@@ -1,0 +1,20 @@
+package org.web3j.protocol.core.methods.response;
+
+import org.web3j.protocol.core.Response;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author Edison
+ * @version 1.0
+ * <p></p>
+ * @date 2023/2/8
+ * @since 17
+ */
+public class EthGetBlockReceipts extends Response<List<TransactionReceipt>> {
+    public Optional<List<TransactionReceipt>> getBlockReceipts() {
+        return Optional.ofNullable(getResult());
+    }
+
+}

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetBlockReceipts.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthGetBlockReceipts.java
@@ -1,20 +1,24 @@
+/*
+ * Copyright 2023 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.web3j.protocol.core.methods.response;
-
-import org.web3j.protocol.core.Response;
 
 import java.util.List;
 import java.util.Optional;
 
-/**
- * @author Edison
- * @version 1.0
- * <p></p>
- * @date 2023/2/8
- * @since 17
- */
+import org.web3j.protocol.core.Response;
+
 public class EthGetBlockReceipts extends Response<List<TransactionReceipt>> {
     public Optional<List<TransactionReceipt>> getBlockReceipts() {
         return Optional.ofNullable(getResult());
     }
-
 }

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -12,7 +12,11 @@
  */
 package org.web3j.protocol.core;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
+
 import org.web3j.protocol.RequestTester;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.methods.request.EthFilter;
@@ -21,9 +25,6 @@ import org.web3j.protocol.core.methods.request.ShhPost;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Numeric;
-
-import java.math.BigInteger;
-import java.util.Arrays;
 
 public class RequestTest extends RequestTester {
 

--- a/core/src/test/java/org/web3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/RequestTest.java
@@ -12,11 +12,7 @@
  */
 package org.web3j.protocol.core;
 
-import java.math.BigInteger;
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
-
 import org.web3j.protocol.RequestTester;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.methods.request.EthFilter;
@@ -25,6 +21,9 @@ import org.web3j.protocol.core.methods.request.ShhPost;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+import java.util.Arrays;
 
 public class RequestTest extends RequestTester {
 
@@ -430,6 +429,17 @@ public class RequestTest extends RequestTester {
         verifyResult(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionReceipt\",\"params\":["
                         + "\"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238\"],"
+                        + "\"id\":1}");
+    }
+
+    @Test
+    public void testEthGetBlockReceipts() throws Exception {
+        web3j.ethGetBlockReceipts(DefaultBlockParameter.valueOf(BigInteger.valueOf(15455945)))
+                .send();
+
+        verifyResult(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockReceipts\",\"params\":["
+                        + "\"0xebd6c9\"],"
                         + "\"id\":1}");
     }
 

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -12,7 +12,17 @@
  */
 package org.web3j.protocol.core;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
+
 import org.web3j.protocol.ResponseTester;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 import org.web3j.protocol.core.methods.response.AccessListObject;
@@ -76,20 +86,9 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Core Protocol Response tests.
- */
+/** Core Protocol Response tests. */
 public class ResponseTest extends ResponseTester {
 
     @Test
@@ -1112,106 +1111,107 @@ public class ResponseTest extends ResponseTester {
 
     @Test
     public void testEthGetBlockReceipts() {
-        buildResponse("{\n" +
-                "    \"jsonrpc\": \"2.0\",\n" +
-                "    \"id\": 1,\n" +
-                "    \"result\": [\n" +
-                "        {\n" +
-                "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
-                "            \"blockNumber\": \"0xf4240\",\n" +
-                "            \"contractAddress\": null,\n" +
-                "            \"cumulativeGasUsed\": \"0x723c\",\n" +
-                "            \"effectiveGasPrice\": \"0x12bfb19e60\",\n" +
-                "            \"from\": \"0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3\",\n" +
-                "            \"gasUsed\": \"0x723c\",\n" +
-                "            \"logs\": [\n" +
-                "                {\n" +
-                "                    \"address\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n" +
-                "                    \"topics\": [\n" +
-                "                        \"0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c\"\n" +
-                "                    ],\n" +
-                "                    \"data\": \"0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000\",\n" +
-                "                    \"blockNumber\": \"0xf4240\",\n" +
-                "                    \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n" +
-                "                    \"transactionIndex\": \"0x0\",\n" +
-                "                    \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
-                "                    \"logIndex\": \"0x0\",\n" +
-                "                    \"removed\": false\n" +
-                "                }\n" +
-                "            ],\n" +
-                "            \"logsBloom\": \"0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000\",\n" +
-                "            \"status\": \"0x1\",\n" +
-                "            \"to\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n" +
-                "            \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n" +
-                "            \"transactionIndex\": \"0x0\",\n" +
-                "            \"type\": \"0x0\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
-                "            \"blockNumber\": \"0xf4240\",\n" +
-                "            \"contractAddress\": null,\n" +
-                "            \"cumulativeGasUsed\": \"0xc444\",\n" +
-                "            \"effectiveGasPrice\": \"0xdf8475800\",\n" +
-                "            \"from\": \"0x32be343b94f860124dc4fee278fdcbd38c102d88\",\n" +
-                "            \"gasUsed\": \"0x5208\",\n" +
-                "            \"logs\": [],\n" +
-                "            \"logsBloom\": \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\n" +
-                "            \"status\": \"0x1\",\n" +
-                "            \"to\": \"0xdf190dc7190dfba737d7777a163445b7fff16133\",\n" +
-                "            \"transactionHash\": \"0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e\",\n" +
-                "            \"transactionIndex\": \"0x1\",\n" +
-                "            \"type\": \"0x0\"\n" +
-                "        }\n" +
-                "    ]\n" +
-                "}");
-        List<TransactionReceipt> transactionReceipts = Arrays.asList(
-                new TransactionReceipt(
-                        "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
-                        "0x0",
-                        "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
-                        "0xf4240",
-                        "0x723c",
-                        "0x723c",
-                        null,
-                        null,
-                        "0x1",
-                        "0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3",
-                        "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
-                        Arrays.asList(new Log(
-                                false,
-                                "0x0",
-                                "0x0",
+        buildResponse(
+                "{\n"
+                        + "    \"jsonrpc\": \"2.0\",\n"
+                        + "    \"id\": 1,\n"
+                        + "    \"result\": [\n"
+                        + "        {\n"
+                        + "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n"
+                        + "            \"blockNumber\": \"0xf4240\",\n"
+                        + "            \"contractAddress\": null,\n"
+                        + "            \"cumulativeGasUsed\": \"0x723c\",\n"
+                        + "            \"effectiveGasPrice\": \"0x12bfb19e60\",\n"
+                        + "            \"from\": \"0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3\",\n"
+                        + "            \"gasUsed\": \"0x723c\",\n"
+                        + "            \"logs\": [\n"
+                        + "                {\n"
+                        + "                    \"address\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n"
+                        + "                    \"topics\": [\n"
+                        + "                        \"0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c\"\n"
+                        + "                    ],\n"
+                        + "                    \"data\": \"0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000\",\n"
+                        + "                    \"blockNumber\": \"0xf4240\",\n"
+                        + "                    \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n"
+                        + "                    \"transactionIndex\": \"0x0\",\n"
+                        + "                    \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n"
+                        + "                    \"logIndex\": \"0x0\",\n"
+                        + "                    \"removed\": false\n"
+                        + "                }\n"
+                        + "            ],\n"
+                        + "            \"logsBloom\": \"0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000\",\n"
+                        + "            \"status\": \"0x1\",\n"
+                        + "            \"to\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n"
+                        + "            \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n"
+                        + "            \"transactionIndex\": \"0x0\",\n"
+                        + "            \"type\": \"0x0\"\n"
+                        + "        },\n"
+                        + "        {\n"
+                        + "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n"
+                        + "            \"blockNumber\": \"0xf4240\",\n"
+                        + "            \"contractAddress\": null,\n"
+                        + "            \"cumulativeGasUsed\": \"0xc444\",\n"
+                        + "            \"effectiveGasPrice\": \"0xdf8475800\",\n"
+                        + "            \"from\": \"0x32be343b94f860124dc4fee278fdcbd38c102d88\",\n"
+                        + "            \"gasUsed\": \"0x5208\",\n"
+                        + "            \"logs\": [],\n"
+                        + "            \"logsBloom\": \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\n"
+                        + "            \"status\": \"0x1\",\n"
+                        + "            \"to\": \"0xdf190dc7190dfba737d7777a163445b7fff16133\",\n"
+                        + "            \"transactionHash\": \"0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e\",\n"
+                        + "            \"transactionIndex\": \"0x1\",\n"
+                        + "            \"type\": \"0x0\"\n"
+                        + "        }\n"
+                        + "    ]\n"
+                        + "}");
+        List<TransactionReceipt> transactionReceipts =
+                Arrays.asList(
+                        new TransactionReceipt(
                                 "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+                                "0x0",
                                 "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
                                 "0xf4240",
-                                "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
-                                "0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000",
+                                "0x723c",
+                                "0x723c",
                                 null,
-                                Arrays.asList("0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c")
-                        )),
-                        "0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000",
-                        null,
-                        "0x0",
-                        "0x12bfb19e60"
-                ),
-                new TransactionReceipt(
-                        "0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e",
-                        "0x1",
-                        "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
-                        "0xf4240",
-                        "0xc444",
-                        "0x5208",
-                        null,
-                        null,
-                        "0x1",
-                        "0x32be343b94f860124dc4fee278fdcbd38c102d88",
-                        "0xdf190dc7190dfba737d7777a163445b7fff16133",
-                        Arrays.asList(),
-                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                        null,
-                        "0x0",
-                        "0xdf8475800"
-                ));
+                                null,
+                                "0x1",
+                                "0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3",
+                                "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+                                Arrays.asList(
+                                        new Log(
+                                                false,
+                                                "0x0",
+                                                "0x0",
+                                                "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+                                                "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                                                "0xf4240",
+                                                "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+                                                "0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000",
+                                                null,
+                                                Arrays.asList(
+                                                        "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c"))),
+                                "0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000",
+                                null,
+                                "0x0",
+                                "0x12bfb19e60"),
+                        new TransactionReceipt(
+                                "0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e",
+                                "0x1",
+                                "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                                "0xf4240",
+                                "0xc444",
+                                "0x5208",
+                                null,
+                                null,
+                                "0x1",
+                                "0x32be343b94f860124dc4fee278fdcbd38c102d88",
+                                "0xdf190dc7190dfba737d7777a163445b7fff16133",
+                                Arrays.asList(),
+                                "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                null,
+                                "0x0",
+                                "0xdf8475800"));
         EthGetBlockReceipts ethGetBlockReceipts = deserialiseResponse(EthGetBlockReceipts.class);
 
         assertEquals(ethGetBlockReceipts.getBlockReceipts().get(), (transactionReceipts));

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -12,17 +12,7 @@
  */
 package org.web3j.protocol.core;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
-
 import org.web3j.protocol.ResponseTester;
 import org.web3j.protocol.core.methods.response.AbiDefinition;
 import org.web3j.protocol.core.methods.response.AccessListObject;
@@ -42,6 +32,7 @@ import org.web3j.protocol.core.methods.response.EthEstimateGas;
 import org.web3j.protocol.core.methods.response.EthFilter;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
+import org.web3j.protocol.core.methods.response.EthGetBlockReceipts;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByHash;
 import org.web3j.protocol.core.methods.response.EthGetBlockTransactionCountByNumber;
 import org.web3j.protocol.core.methods.response.EthGetCode;
@@ -85,12 +76,20 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-/** Core Protocol Response tests. */
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Core Protocol Response tests.
+ */
 public class ResponseTest extends ResponseTester {
 
     @Test
@@ -945,6 +944,7 @@ public class ResponseTest extends ResponseTester {
         EthBlock ethBlock = deserialiseResponse(EthBlock.class);
         assertNull(ethBlock.getBlock());
     }
+
     //
     @Test
     public void testEthTransaction() {
@@ -1108,6 +1108,113 @@ public class ResponseTest extends ResponseTester {
         EthGetTransactionReceipt ethGetTransactionReceipt =
                 deserialiseResponse(EthGetTransactionReceipt.class);
         assertEquals(ethGetTransactionReceipt.getTransactionReceipt().get(), (transactionReceipt));
+    }
+
+    @Test
+    public void testEthGetBlockReceipts() {
+        buildResponse("{\n" +
+                "    \"jsonrpc\": \"2.0\",\n" +
+                "    \"id\": 1,\n" +
+                "    \"result\": [\n" +
+                "        {\n" +
+                "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
+                "            \"blockNumber\": \"0xf4240\",\n" +
+                "            \"contractAddress\": null,\n" +
+                "            \"cumulativeGasUsed\": \"0x723c\",\n" +
+                "            \"effectiveGasPrice\": \"0x12bfb19e60\",\n" +
+                "            \"from\": \"0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3\",\n" +
+                "            \"gasUsed\": \"0x723c\",\n" +
+                "            \"logs\": [\n" +
+                "                {\n" +
+                "                    \"address\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n" +
+                "                    \"topics\": [\n" +
+                "                        \"0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c\"\n" +
+                "                    ],\n" +
+                "                    \"data\": \"0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000\",\n" +
+                "                    \"blockNumber\": \"0xf4240\",\n" +
+                "                    \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n" +
+                "                    \"transactionIndex\": \"0x0\",\n" +
+                "                    \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
+                "                    \"logIndex\": \"0x0\",\n" +
+                "                    \"removed\": false\n" +
+                "                }\n" +
+                "            ],\n" +
+                "            \"logsBloom\": \"0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000\",\n" +
+                "            \"status\": \"0x1\",\n" +
+                "            \"to\": \"0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47\",\n" +
+                "            \"transactionHash\": \"0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f\",\n" +
+                "            \"transactionIndex\": \"0x0\",\n" +
+                "            \"type\": \"0x0\"\n" +
+                "        },\n" +
+                "        {\n" +
+                "            \"blockHash\": \"0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e\",\n" +
+                "            \"blockNumber\": \"0xf4240\",\n" +
+                "            \"contractAddress\": null,\n" +
+                "            \"cumulativeGasUsed\": \"0xc444\",\n" +
+                "            \"effectiveGasPrice\": \"0xdf8475800\",\n" +
+                "            \"from\": \"0x32be343b94f860124dc4fee278fdcbd38c102d88\",\n" +
+                "            \"gasUsed\": \"0x5208\",\n" +
+                "            \"logs\": [],\n" +
+                "            \"logsBloom\": \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\n" +
+                "            \"status\": \"0x1\",\n" +
+                "            \"to\": \"0xdf190dc7190dfba737d7777a163445b7fff16133\",\n" +
+                "            \"transactionHash\": \"0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e\",\n" +
+                "            \"transactionIndex\": \"0x1\",\n" +
+                "            \"type\": \"0x0\"\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}");
+        List<TransactionReceipt> transactionReceipts = Arrays.asList(
+                new TransactionReceipt(
+                        "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+                        "0x0",
+                        "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                        "0xf4240",
+                        "0x723c",
+                        "0x723c",
+                        null,
+                        null,
+                        "0x1",
+                        "0x39fa8c5f2793459d6622857e7d9fbb4bd91766d3",
+                        "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+                        Arrays.asList(new Log(
+                                false,
+                                "0x0",
+                                "0x0",
+                                "0xea1093d492a1dcb1bef708f771a99a96ff05dcab81ca76c31940300177fcf49f",
+                                "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                                "0xf4240",
+                                "0xc083e9947cf02b8ffc7d3090ae9aea72df98fd47",
+                                "0x00000000000000000000000039fa8c5f2793459d6622857e7d9fbb4bd91766d30000000000000000000000000000000000000000000000056bc75e2d63100000",
+                                null,
+                                Arrays.asList("0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c")
+                        )),
+                        "0x00000000000000000000000000000000000800000000000000000000000800000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000",
+                        null,
+                        "0x0",
+                        "0x12bfb19e60"
+                ),
+                new TransactionReceipt(
+                        "0xe9e91f1ee4b56c0df2e9f06c2b8c27c6076195a88a7b8537ba8313d80e6f124e",
+                        "0x1",
+                        "0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e",
+                        "0xf4240",
+                        "0xc444",
+                        "0x5208",
+                        null,
+                        null,
+                        "0x1",
+                        "0x32be343b94f860124dc4fee278fdcbd38c102d88",
+                        "0xdf190dc7190dfba737d7777a163445b7fff16133",
+                        Arrays.asList(),
+                        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        null,
+                        "0x0",
+                        "0xdf8475800"
+                ));
+        EthGetBlockReceipts ethGetBlockReceipts = deserialiseResponse(EthGetBlockReceipts.class);
+
+        assertEquals(ethGetBlockReceipts.getBlockReceipts().get(), (transactionReceipts));
     }
 
     @Test

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -86,7 +86,10 @@ import org.web3j.protocol.core.methods.response.Web3Sha3;
 import org.web3j.protocol.core.methods.response.admin.AdminDataDir;
 import org.web3j.protocol.core.methods.response.admin.AdminNodeInfo;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Core Protocol Response tests. */
 public class ResponseTest extends ResponseTester {


### PR DESCRIPTION
### What does this PR do?
*required*
eth_getReceiptByTransactionHash need to batchRequest that's so bad so eth support a new eth method of eth_getBlockReipts, the method can't sub batchRequest
### Where should the reviewer start?
*required*
There is just a one file.
### Why is it needed?
*required*

convenient