### PR TITLE
"Filter not found" detection improved

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -143,9 +143,8 @@ public abstract class Filter<T> {
                     reinstallFilter();
                     break;
                 default:
-                    if (Pattern.compile("(?i)\\bfilter\\s+not\\s+found\\b").matcher(message).find())
-                        reinstallFilter();
-                    else throwException(error);
+                    Pattern.compile("FILTER_NOT_FOUND_PATTERN").matcher(message).find())? 
+                    reinstallFilter():throwException(error);
                     break;
             }
         } else {

--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -50,6 +50,8 @@ public abstract class Filter<T> {
 
     private long blockTime;
 
+    private static final String FILTER_NOT_FOUND_PATTERN = "(?i)\\bfilter\\s+not\\s+found\\b";
+
     public Filter(Web3j web3j, Callback<T> callback) {
         this.web3j = web3j;
         this.callback = callback;
@@ -143,8 +145,9 @@ public abstract class Filter<T> {
                     reinstallFilter();
                     break;
                 default:
-                    Pattern.compile("FILTER_NOT_FOUND_PATTERN").matcher(message).find())? 
-                    reinstallFilter():throwException(error);
+                    if (Pattern.compile(FILTER_NOT_FOUND_PATTERN).matcher(message).find())
+                        reinstallFilter();
+                    else throwException(error);
                     break;
             }
         } else {

--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,12 +137,15 @@ public abstract class Filter<T> {
         }
         if (ethLog.hasError()) {
             Error error = ethLog.getError();
+            String message = error.getMessage();
             switch (error.getCode()) {
                 case RpcErrors.FILTER_NOT_FOUND:
                     reinstallFilter();
                     break;
                 default:
-                    throwException(error);
+                    if (Pattern.compile("(?i)\\bfilter\\s+not\\s+found\\b").matcher(message).find())
+                        reinstallFilter();
+                    else throwException(error);
                     break;
             }
         } else {


### PR DESCRIPTION
### What does this PR do?
*Add a condition on the EthFilter polling.*

### Where should the reviewer start?
*There is just a one file.*

### Why is it needed?
*As pointed out in Issue #1839, every client returns a different error code to notify the loss of a filter. Thus, we can check firstly the error code, and if that is not matched, we can check the error message and see if it matches the string "filter not found". I used regex to create a case insensitve and multi-space pattern in order to incude as many cases as possible.*

