### PR TITLE
upgraded Contract.IsValid to support all kinds of existing encryptions

### DIFF
--- a/core/src/main/java/org/web3j/tx/Contract.java
+++ b/core/src/main/java/org/web3j/tx/Contract.java
@@ -76,6 +76,13 @@ public abstract class Contract extends ManagedTransaction {
     protected TransactionReceipt transactionReceipt;
     protected Map<String, String> deployedAddresses;
     protected DefaultBlockParameter defaultBlockParameter = DefaultBlockParameterName.LATEST;
+    protected String[] MetadataHashStringIndicators =
+            new String[] {
+                "a165627a7a72305820" /*Swarm legacy (bzzr0)*/,
+                "a265627a7a72315820" /*Swarm (bzzr1)*/,
+                "a2646970667358221220" /*IPFS*/,
+                "a164736f6c634300080a000a" /*solc (None)*/
+            };
 
     protected Contract(
             String contractBinary,
@@ -254,7 +261,14 @@ public abstract class Contract extends ManagedTransaction {
         }
 
         String code = Numeric.cleanHexPrefix(ethGetCode.getCode());
-        int metadataIndex = code.indexOf("a165627a7a72305820");
+
+        int metadataIndex = -1;
+        for (String metadataIndicator : MetadataHashStringIndicators) {
+            metadataIndex = code.indexOf(metadataIndicator);
+
+            if (metadataIndex != -1) break;
+        }
+
         if (metadataIndex != -1) {
             code = code.substring(0, metadataIndex);
         }


### PR DESCRIPTION
### What does this PR do?
The `Contract.IsValid` has several checks to verify that the contract used is similar to the one deployed, in order to do so it reads the bytecode and correlates it to the bytecode it has for the contract.

However the indicator it uses to localize the end of code bytecode (a165627a7a72305820) and start of Metadata is and old version.

as of Solidity 0.6.0 (https://docs.soliditylang.org/en/v0.8.17/060-breaking-changes.html) under **Metadata Hash Options** the default hash has been upgraded from bzzr0 to ipfs with an option to use bzzr1 or none.

This PR changes the metadata hash indicator to be an array that iterates over all these possibilities so that it can validate the bytecode regardless of the metadata hash used. 


### Where should the reviewer start?
Anywhere the changes are small and the hashes can be validated with [HexDecoder](https://www.convertstring.com/en/EncodeDecode/HexDecode)

### Why is it needed?
The default for solidity has changed, this mean the IsValid call will fail for all contracts that uses solidity 0.6 or higher.

The code is backwards compatible.
