### PR TITLE
Added withdrawals and withdrawalsRoot to EthBlock

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -540,6 +540,7 @@ public class EthBlock extends Response<EthBlock.Block> {
                     31 * result
                             + (getWithdrawalsRoot() != null ? getWithdrawalsRoot().hashCode() : 0);
             result = 31 * result + (getWithdrawals() != null ? getWithdrawals().hashCode() : 0);
+            
             return result;
         }
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -17,6 +17,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -81,6 +82,8 @@ public class EthBlock extends Response<EthBlock.Block> {
         private List<String> uncles;
         private List<String> sealFields;
         private String baseFeePerGas;
+        private String withdrawalsRoot;
+        private List<Withdrawal> withdrawals;
 
         public Block() {}
 
@@ -107,7 +110,9 @@ public class EthBlock extends Response<EthBlock.Block> {
                 List<TransactionResult> transactions,
                 List<String> uncles,
                 List<String> sealFields,
-                String baseFeePerGas) {
+                String baseFeePerGas,
+                String withdrawalsRoot,
+                List<Withdrawal> withdrawals) {
             this.number = number;
             this.hash = hash;
             this.parentHash = parentHash;
@@ -131,6 +136,8 @@ public class EthBlock extends Response<EthBlock.Block> {
             this.uncles = uncles;
             this.sealFields = sealFields;
             this.baseFeePerGas = baseFeePerGas;
+            this.withdrawalsRoot = withdrawalsRoot;
+            this.withdrawals = withdrawals;
         }
 
         public BigInteger getNumber() {
@@ -475,9 +482,21 @@ public class EthBlock extends Response<EthBlock.Block> {
                 return false;
             }
 
-            return getSealFields() != null
-                    ? getSealFields().equals(block.getSealFields())
-                    : block.getSealFields() == null;
+            if (getSealFields() != null
+                    ? !getSealFields().equals(block.getSealFields())
+                    : block.getSealFields() != null) {
+                return false;
+            }
+
+            if (getWithdrawalsRoot() != null
+                    ? !getWithdrawalsRoot().equals(block.getWithdrawalsRoot())
+                    : block.getWithdrawalsRoot() != null) {
+                return false;
+            }
+
+            return getWithdrawals() != null
+                    ? getWithdrawals().equals(block.getWithdrawals())
+                    : block.getWithdrawals() == null;
         }
 
         @Override
@@ -517,7 +536,27 @@ public class EthBlock extends Response<EthBlock.Block> {
                             + (getBaseFeePerGasRaw() != null
                                     ? getBaseFeePerGasRaw().hashCode()
                                     : 0);
+            result =
+                    31 * result
+                            + (getWithdrawalsRoot() != null ? getWithdrawalsRoot().hashCode() : 0);
+            result = 31 * result + (getWithdrawals() != null ? getWithdrawals().hashCode() : 0);
             return result;
+        }
+
+        public List<Withdrawal> getWithdrawals() {
+            return withdrawals;
+        }
+
+        public void setWithdrawals(List<Withdrawal> withdrawals) {
+            this.withdrawals = withdrawals;
+        }
+
+        public String getWithdrawalsRoot() {
+            return withdrawalsRoot;
+        }
+
+        public void setWithdrawalsRoot(String withdrawalsRoot) {
+            this.withdrawalsRoot = withdrawalsRoot;
         }
     }
 
@@ -699,6 +738,70 @@ public class EthBlock extends Response<EthBlock.Block> {
             }
 
             return transactionResults;
+        }
+    }
+
+    public static class Withdrawal {
+        private String index;
+        private String validatorIndex;
+        private String address;
+        private String amount;
+
+        public Withdrawal() {}
+
+        public Withdrawal(String index, String validatorIndex, String address, String amount) {
+            this.index = index;
+            this.validatorIndex = validatorIndex;
+            this.address = address;
+            this.amount = amount;
+        }
+
+        public String getIndex() {
+            return index;
+        }
+
+        public void setIndex(String index) {
+            this.index = index;
+        }
+
+        public String getValidatorIndex() {
+            return validatorIndex;
+        }
+
+        public void setValidatorIndex(String validatorIndex) {
+            this.validatorIndex = validatorIndex;
+        }
+
+        public String getAddress() {
+            return address;
+        }
+
+        public void setAddress(String address) {
+            this.address = address;
+        }
+
+        public BigInteger getAmount() {
+            return Numeric.decodeQuantity(amount);
+        }
+
+        public void setAmount(String amount) {
+            this.amount = amount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Withdrawal that = (Withdrawal) o;
+            return Objects.equals(index, that.index)
+                    && Objects.equals(validatorIndex, that.validatorIndex)
+                    && Objects.equals(address, that.address)
+                    && Objects.equals(amount, that.amount);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(index, validatorIndex, address, amount);
         }
     }
 

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -638,7 +638,16 @@ public class ResponseTest extends ResponseTester {
                         + "       \"0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b\",\n"
                         + "       \"0x39a3eb432fbef1fc\"\n"
                         + "    ],\n"
-                        + "    \"baseFeePerGas\": \"0x7\"\n"
+                        + "    \"baseFeePerGas\": \"0x7\",\n"
+                        + "    \"withdrawalsRoot\": \"0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2\",\n"
+                        + "    \"withdrawals\": [\n"
+                        + "      {\n"
+                        + "        \"index\": \"0x68ba80\",\n"
+                        + "        \"validatorIndex\": \"0x65285\",\n"
+                        + "        \"address\": \"0x1e09b4199780a45792f4ff195ef68410a091b047\",\n"
+                        + "        \"amount\": \"0xd1f129\"\n"
+                        + "      }\n"
+                        + "    ]\n"
                         + "  }\n"
                         + "}");
 
@@ -676,7 +685,14 @@ public class ResponseTest extends ResponseTester {
                         Arrays.asList(
                                 "0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b",
                                 "0x39a3eb432fbef1fc"),
-                        "0x7");
+                        "0x7",
+                        "0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2",
+                        Arrays.asList(
+                                new EthBlock.Withdrawal(
+                                        "0x68ba80",
+                                        "0x65285",
+                                        "0x1e09b4199780a45792f4ff195ef68410a091b047",
+                                        "0xd1f129")));
         assertEquals(ethBlock.getBlock(), (block));
     }
 
@@ -744,7 +760,16 @@ public class ResponseTest extends ResponseTester {
                         + "       \"0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b\",\n"
                         + "       \"0x39a3eb432fbef1fc\"\n"
                         + "    ],\n"
-                        + "    \"baseFeePerGas\": \"0x7\"\n"
+                        + "    \"baseFeePerGas\": \"0x7\",\n"
+                        + "    \"withdrawalsRoot\": \"0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2\",\n"
+                        + "    \"withdrawals\": [\n"
+                        + "      {\n"
+                        + "        \"index\": \"0x68ba80\",\n"
+                        + "        \"validatorIndex\": \"0x65285\",\n"
+                        + "        \"address\": \"0x1e09b4199780a45792f4ff195ef68410a091b047\",\n"
+                        + "        \"amount\": \"0xd1f129\"\n"
+                        + "      }\n"
+                        + "    ]\n"
                         + "  }\n"
                         + "}");
 
@@ -804,7 +829,14 @@ public class ResponseTest extends ResponseTester {
                         Arrays.asList(
                                 "0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b",
                                 "0x39a3eb432fbef1fc"),
-                        "0x7");
+                        "0x7",
+                        "0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2",
+                        Arrays.asList(
+                                new EthBlock.Withdrawal(
+                                        "0x68ba80",
+                                        "0x65285",
+                                        "0x1e09b4199780a45792f4ff195ef68410a091b047",
+                                        "0xd1f129")));
 
         assertEquals(ethBlock.getBlock(), (block));
     }
@@ -874,7 +906,16 @@ public class ResponseTest extends ResponseTester {
                         + "       \"0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b\",\n"
                         + "       \"0x39a3eb432fbef1fc\"\n"
                         + "    ],\n"
-                        + "    \"baseFeePerGas\": \"0x7\"\n"
+                        + "    \"baseFeePerGas\": \"0x7\",\n"
+                        + "    \"withdrawalsRoot\": \"0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2\",\n"
+                        + "    \"withdrawals\": [\n"
+                        + "      {\n"
+                        + "        \"index\": \"0x68ba80\",\n"
+                        + "        \"validatorIndex\": \"0x65285\",\n"
+                        + "        \"address\": \"0x1e09b4199780a45792f4ff195ef68410a091b047\",\n"
+                        + "        \"amount\": \"0xd1f129\"\n"
+                        + "      }\n"
+                        + "    ]\n"
                         + "  }\n"
                         + "}");
 
@@ -934,7 +975,14 @@ public class ResponseTest extends ResponseTester {
                         Arrays.asList(
                                 "0x57919c4e72e79ad7705a26e7ecd5a08ff546ac4fa37882e9cc57be87a3dab26b",
                                 "0x39a3eb432fbef1fc"),
-                        "0x7");
+                        "0x7",
+                        "0x1b1f845cd61c375a89ef101fd1bd86355f372a6a3dfe1960f2355e70bd5cd8a2",
+                        Arrays.asList(
+                                new EthBlock.Withdrawal(
+                                        "0x68ba80",
+                                        "0x65285",
+                                        "0x1e09b4199780a45792f4ff195ef68410a091b047",
+                                        "0xd1f129")));
 
         assertEquals(ethBlock.getBlock(), (block));
     }

--- a/core/src/test/java/org/web3j/protocol/core/methods/response/EthBlockTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/methods/response/EthBlockTest.java
@@ -25,7 +25,8 @@ public class EthBlockTest {
         EthBlock.Block ethBlock =
                 new EthBlock.Block(
                         null, null, null, null, null, null, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, null, null);
+                        null, null, null, null, null, null, null, null, null, null, null, null,
+                        null);
 
         assertEquals(ethBlock.getSize(), BigInteger.ZERO);
     }
@@ -35,7 +36,8 @@ public class EthBlockTest {
         EthBlock.Block ethBlock =
                 new EthBlock.Block(
                         null, null, null, null, null, null, null, null, null, null, null, null,
-                        null, null, null, "0x3e8", null, null, null, null, null, null, null);
+                        null, null, null, "0x3e8", null, null, null, null, null, null, null, null,
+                        null);
 
         assertEquals(ethBlock.getSize(), BigInteger.valueOf(1000));
     }


### PR DESCRIPTION
### What does this PR do?
Adds `withdrawals` and `withdrawalsRoot` fields to `EthBlock`

### Where should the reviewer start?
`org.web3j.protocol.core.methods.response.EthBlock.java`

### Why is it needed?
Two new fields `withdrawals` and `withdrawalsRoot` were added to the block as part of [eip-4895](https://eips.ethereum.org/EIPS/eip-4895) 

