### PR TITLE
Fixing `EthFilter` serialisation issue

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
@@ -12,6 +12,8 @@
  */
 package org.web3j.protocol.core.methods.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -71,6 +73,7 @@ public class EthFilter extends Filter<EthFilter> {
     }
 
     @Override
+    @JsonIgnore
     EthFilter getThis() {
         return this;
     }

--- a/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/EthFilter.java
@@ -12,10 +12,10 @@
  */
 package org.web3j.protocol.core.methods.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.Collections;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.web3j.protocol.core.DefaultBlockParameter;
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/request/ShhFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/request/ShhFilter.java
@@ -12,6 +12,8 @@
  */
 package org.web3j.protocol.core.methods.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Filter implementation as per <a
  * href="https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter">docs</a>
@@ -29,6 +31,7 @@ public class ShhFilter extends Filter<ShhFilter> {
     }
 
     @Override
+    @JsonIgnore
     ShhFilter getThis() {
         return this;
     }


### PR DESCRIPTION
### What does this PR do?
Fixes the issue with `EthFilter` serialisation that is happening on Android that's using the latest Android Gradle Plugin and proguard for code minification.

### Where should the reviewer start?
`EthFilter.java`

### Why is it needed?
`getThis` is treated as `this` property that during serialisation fails with `direct self-reference leading to cycle`

The exact stacktrace:
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Direct self-reference leading to cycle (through reference chain: org.web3j.protocol.core.Request["params"]->java.util.Arrays$ArrayList[0]->org.web3j.protocol.core.methods.request.EthFilter["this"])
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter._handleSelfReference(BeanPropertyWriter.java:944)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:722)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:119)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:79)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:728)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
	at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4568)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3821)
	at org.web3j.protocol.Service.send(Service.java:46)
	at org.web3j.protocol.core.Request.send(Request.java:87)
	at org.web3j.protocol.core.Request$$ExternalSyntheticLambda0.call(R8$$SyntheticClass:0)
	at org.web3j.protocol.core.Remote<truncated: 6151 chars>
       at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1300)
       at com.fasterxml.jackson.databind.ser.BeanPropertyWriter._handleSelfReference(BeanPropertyWriter.java:944)
       at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:722)
       at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
       at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
       at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:119)
       at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:79)
       at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18)
       at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:728)
       at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
       at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
       at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
       at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
       at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4568)
       at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3821)
       at org.web3j.protocol.Service.send(Service.java:46)
       at org.web3j.protocol.core.Request.send(Request.java:87)
```


