### PR TITLE
Move CipherException from org.web3j.crypto to org.web3j.crypto.exception

### DIFF
--- a/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
@@ -14,6 +14,7 @@ package org.web3j.crypto;
 
 import java.io.File;
 import java.io.IOException;
+
 import org.web3j.crypto.exception.CipherException;
 
 import static org.web3j.crypto.Bip32ECKeyPair.HARDENED_BIT;

--- a/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/Bip44WalletUtils.java
@@ -14,6 +14,7 @@ package org.web3j.crypto;
 
 import java.io.File;
 import java.io.IOException;
+import org.web3j.crypto.exception.CipherException;
 
 import static org.web3j.crypto.Bip32ECKeyPair.HARDENED_BIT;
 

--- a/core/src/main/java/org/web3j/crypto/Wallet.java
+++ b/core/src/main/java/org/web3j/crypto/Wallet.java
@@ -29,6 +29,7 @@ import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
 import org.bouncycastle.crypto.generators.SCrypt;
 import org.bouncycastle.crypto.params.KeyParameter;
 
+import org.web3j.crypto.exception.CipherException;
 import org.web3j.utils.Numeric;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/core/src/main/java/org/web3j/crypto/WalletUtils.java
+++ b/core/src/main/java/org/web3j/crypto/WalletUtils.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.web3j.crypto.exception.CipherException;
 import org.web3j.utils.Numeric;
 
 import static org.web3j.crypto.Hash.sha256;

--- a/crypto/src/main/java/org/web3j/crypto/exception/CipherException.java
+++ b/crypto/src/main/java/org/web3j/crypto/exception/CipherException.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.web3j.crypto;
+package org.web3j.crypto.exception;
 
 /** Cipher exception wrapper. */
 public class CipherException extends Exception {


### PR DESCRIPTION
### What does this PR do?
Move `CipherException` from `org.web3j.crypto` to `org.web3j.crypto.exception`

### Where should the reviewer start?
`org.web3j.crypto.exception`

### Why is it needed?
There is `exception` package in `org.web3j.crypto` but `CipherException` is not in `exception` package.

