### PR TITLE
Correctly encode structs without members

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,14 +121,10 @@ public class StructuredDataEncoder {
     public String encodeStruct(String structName) {
         HashMap<String, List<StructuredData.Entry>> types = jsonMessageObject.getTypes();
 
-        StringBuilder structRepresentation = new StringBuilder(structName + "(");
+        StringJoiner structRepresentation = new StringJoiner(",", structName + "(", ")");
         for (StructuredData.Entry entry : types.get(structName)) {
-            structRepresentation.append(String.format("%s %s,", entry.getType(), entry.getName()));
+            structRepresentation.add(String.format("%s %s", entry.getType(), entry.getName()));
         }
-        structRepresentation =
-                new StringBuilder(
-                        structRepresentation.substring(0, structRepresentation.length() - 1));
-        structRepresentation.append(")");
 
         return structRepresentation.toString();
     }

--- a/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/StructuredDataTest.java
@@ -114,6 +114,20 @@ public class StructuredDataTest {
     }
 
     @Test
+    public void testMinimalEncodeType() throws IOException, RuntimeException {
+        String validMinimalStructuredDataJSONFilePath =
+                "build/resources/test/"
+                        + "structured_data_json_files/ValidMinimalStructuredData.json";
+        StructuredDataEncoder dataEncoder =
+                new StructuredDataEncoder(getResource(validMinimalStructuredDataJSONFilePath));
+        String expectedTypeEncoding = "EIP712Domain()";
+
+        assertEquals(
+                dataEncoder.encodeType(dataEncoder.jsonMessageObject.getPrimaryType()),
+                expectedTypeEncoding);
+    }
+
+    @Test
     public void testTypeHash() throws IOException, RuntimeException {
         StructuredDataEncoder dataEncoder = new StructuredDataEncoder(jsonMessageString);
         String expectedTypeHashHex =

--- a/crypto/src/test/resources/structured_data_json_files/ValidMinimalStructuredData.json
+++ b/crypto/src/test/resources/structured_data_json_files/ValidMinimalStructuredData.json
@@ -1,0 +1,8 @@
+{
+  "types": {
+    "EIP712Domain": []
+  },
+  "primaryType": "EIP712Domain",
+  "domain": {},
+  "message": {}
+}


### PR DESCRIPTION
The JSON RPC API specification for 'eth_signTypedData_v4' does not explicitly state that the required struct 'EIP712Domain' has to define any members [1]. The current implementation cannot correctly encode such a structure, as it assumes that at least one member has been parsed and added to the struct's string representation.

[1] https://eips.ethereum.org/EIPS/eip-712#specification-of-the-eth_signtypeddata-json-rpc

### What does this PR do?
This commit refactors the struct encoding function such that it now accepts structures that does not define any members. This PR aims to resolve issue #1967.

### Where should the reviewer start?
There's only one function changed. I've also gone ahead and added a new test.

### Why is it needed?
This is needed to fully support the EIP-712 specification. Without it, web3j fails to properly handle valid types of structured data.

