### PR TITLE
Expose direct byte[] decoding.

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -30,7 +30,10 @@ public class TransactionDecoder {
     private static final int UNSIGNED_EIP2930TX_RLP_LIST_SIZE = 8;
 
     public static RawTransaction decode(final String hexTransaction) {
-        final byte[] transaction = Numeric.hexStringToByteArray(hexTransaction);
+        return decode(Numeric.hexStringToByteArray(hexTransaction));
+    }
+
+    public static RawTransaction decode(final byte[] transaction) {
         if (getTransactionType(transaction) == TransactionType.EIP1559) {
             return decodeEIP1559Transaction(transaction);
         } else if (getTransactionType(transaction) == TransactionType.EIP2930) {


### PR DESCRIPTION
### What does this PR do?
It exposes decoding directly a byte[] (vs hex encoded string).

### Where should the reviewer start?
All the steps were already there, I've just extracted the hex decoding into a separate method which delegates to the new one taking the byte[].

### Why is it needed?
To avoid going byte[] -> hex string -> byte[] for cased when the tx is already available as a byte[].

