### PR TITLE
decodeDynamicStructElements NPE fix

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -517,6 +517,9 @@ public class TypeDecoder {
                     final Class<T> parameterFromAnnotation =
                             Utils.extractParameterFromAnnotation(
                                     constructor.getParameterAnnotations()[i]);
+                    if (parameterFromAnnotation == null) {
+                        throw new RuntimeException("Can not extract parameter from annotation, try to use annotation @Parameterized to specify the parameter type");
+                    }
                     parameters.put(
                             i,
                             decodeDynamicParameterFromStruct(


### PR DESCRIPTION
### What does this PR do?
*fix decodeDynamicStructElements NPE*
lower version codegen does not generate @Parameterized annotation when use DynamicArray<T> parameter, which will cause the error as below that confuse people
<img width="998" alt="image" src="https://github.com/web3j/web3j/assets/18752800/a010445c-abbe-4557-b55e-c241fa5175da">


### Where should the reviewer start?
*use the test case: org.web3j.abi.FunctionReturnDecoderTest#testDecodeDynamicStruct3*
remove the Annotation can see the case
<img width="683" alt="image" src="https://github.com/web3j/web3j/assets/18752800/3e4c784b-f83c-44c1-a3d1-5faaedda6c44">


### Why is it needed?
*(https://github.com/web3j/web3j/issues/1726#issuecomment-1605250651*

