### PR TITLE
Fix dynamic array decode null pointer

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -564,6 +564,9 @@ public class TypeDecoder {
         if (DynamicStruct.class.isAssignableFrom(declaredField)) {
             value = decodeDynamicStruct(dynamicElementData, 0, TypeReference.create(declaredField));
         } else if (DynamicArray.class.isAssignableFrom(declaredField)) {
+            if (parameter == null) {
+                throw new RuntimeException("parameter can not be null, try to use annotation @Parameterized to specify the parameter type");
+            }
             value =
                     (T)
                             decodeDynamicArray(


### PR DESCRIPTION
### What does this PR do?
fix decodeDynamicStructElements NPE
lower version codegen does not generate @parameterized annotation when use DynamicArray parameter, which will cause the error as below that confuse people
![image](https://github.com/web3j/web3j/assets/18752800/04c0881e-1312-4253-8873-f3d5a2227e6e)


### Where should the reviewer start?
use the test case: org.web3j.abi.FunctionReturnDecoderTest#testDecodeDynamicStruct3
remove the Annotation can see the case
![image](https://github.com/web3j/web3j/assets/18752800/5f91bbd3-23a8-49ca-9d04-501f0bf77bf8)

### Why is it needed?
https://github.com/web3j/web3j/issues/1726#issuecomment-1605250651

