### PR TITLE
Add AccessList to 1559 transaction rlp encoding

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -117,8 +117,31 @@ public class RawTransaction {
                         data,
                         maxPriorityFeePerGas,
                         maxFeePerGas,
-                        Collections.emptyList()
-                        ));
+                        Collections.emptyList()));
+    }
+
+    public static RawTransaction createTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            List<AccessListObject> accessList) {
+
+        return new RawTransaction(
+                Transaction1559.createTransaction(
+                        chainId,
+                        nonce,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        accessList));
     }
 
     public static RawTransaction createTransaction(

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -13,6 +13,7 @@
 package org.web3j.crypto;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
 
 import org.web3j.crypto.transaction.type.ITransaction;
@@ -115,7 +116,9 @@ public class RawTransaction {
                         value,
                         data,
                         maxPriorityFeePerGas,
-                        maxFeePerGas));
+                        maxFeePerGas,
+                        Collections.emptyList()
+                        ));
     }
 
     public static RawTransaction createTransaction(

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -64,6 +64,8 @@ public class TransactionDecoder {
 
         final BigInteger value = ((RlpString) values.getValues().get(6)).asPositiveBigInteger();
         final String data = ((RlpString) values.getValues().get(7)).asString();
+        List<AccessListObject> accessList =
+                decodeAccessList(((RlpList) values.getValues().get(8)).getValues());
 
         final RawTransaction rawTransaction =
                 RawTransaction.createTransaction(
@@ -74,7 +76,8 @@ public class TransactionDecoder {
                         value,
                         data,
                         maxPriorityFeePerGas,
-                        maxFeePerGas);
+                        maxFeePerGas,
+                        accessList);
 
         if (values.getValues().size() == UNSIGNED_EIP1559TX_RLP_LIST_SIZE) {
             return rawTransaction;

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
@@ -14,8 +14,10 @@ package org.web3j.crypto.transaction.type;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import org.web3j.crypto.AccessListObject;
 import org.web3j.crypto.Sign;
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;
@@ -44,7 +46,8 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
             BigInteger value,
             String data,
             BigInteger maxPriorityFeePerGas,
-            BigInteger maxFeePerGas) {
+            BigInteger maxFeePerGas,
+            List<AccessListObject> accessList) {
         super(EIP1559, nonce, null, gasLimit, to, value, data);
         this.chainId = chainId;
         this.maxPriorityFeePerGas = maxPriorityFeePerGas;
@@ -103,7 +106,7 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
             BigInteger maxPriorityFeePerGas,
             BigInteger maxFeePerGas) {
         return new Transaction1559(
-                chainId, nonce, gasLimit, to, value, "", maxPriorityFeePerGas, maxFeePerGas);
+                chainId, nonce, gasLimit, to, value, "", maxPriorityFeePerGas, maxFeePerGas, Collections.emptyList());
     }
 
     public static Transaction1559 createTransaction(
@@ -114,10 +117,11 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
             BigInteger value,
             String data,
             BigInteger maxPriorityFeePerGas,
-            BigInteger maxFeePerGas) {
+            BigInteger maxFeePerGas,
+            List<AccessListObject> accessList) {
 
         return new Transaction1559(
-                chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+                chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas, accessList);
     }
 
     @Override

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
@@ -32,9 +32,8 @@ import static org.web3j.crypto.transaction.type.TransactionType.EIP1559;
  * For the specification, refer to p4 of the <a href="http://gavwood.com/paper.pdf">yellow
  * paper</a>.
  */
-public class Transaction1559 extends LegacyTransaction implements ITransaction {
+public class Transaction1559 extends Transaction2930 implements ITransaction {
 
-    private long chainId;
     private BigInteger maxPriorityFeePerGas;
     private BigInteger maxFeePerGas;
 
@@ -48,8 +47,7 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
             BigInteger maxPriorityFeePerGas,
             BigInteger maxFeePerGas,
             List<AccessListObject> accessList) {
-        super(EIP1559, nonce, null, gasLimit, to, value, data);
-        this.chainId = chainId;
+        super(chainId, nonce, null, gasLimit, to, value, data,accessList);
         this.maxPriorityFeePerGas = maxPriorityFeePerGas;
         this.maxFeePerGas = maxFeePerGas;
     }
@@ -86,7 +84,7 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
         result.add(RlpString.create(data));
 
         // access list
-        result.add(new RlpList());
+        result.add(new RlpList(rlpAccessListRlp()));
 
         if (signatureData != null) {
             result.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
@@ -127,10 +125,6 @@ public class Transaction1559 extends LegacyTransaction implements ITransaction {
     @Override
     public BigInteger getGasPrice() {
         throw new UnsupportedOperationException("not available for 1559 transaction");
-    }
-
-    public long getChainId() {
-        return chainId;
     }
 
     public BigInteger getMaxPriorityFeePerGas() {

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction1559.java
@@ -25,8 +25,6 @@ import org.web3j.rlp.RlpType;
 import org.web3j.utils.Bytes;
 import org.web3j.utils.Numeric;
 
-import static org.web3j.crypto.transaction.type.TransactionType.EIP1559;
-
 /**
  * Transaction class used for signing 1559 transactions locally.<br>
  * For the specification, refer to p4 of the <a href="http://gavwood.com/paper.pdf">yellow
@@ -45,9 +43,23 @@ public class Transaction1559 extends Transaction2930 implements ITransaction {
             BigInteger value,
             String data,
             BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas) {
+        super(chainId, nonce, null, gasLimit, to, value, data, Collections.emptyList());
+        this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        this.maxFeePerGas = maxFeePerGas;
+    }
+
+    public Transaction1559(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxPriorityFeePerGas,
             BigInteger maxFeePerGas,
             List<AccessListObject> accessList) {
-        super(chainId, nonce, null, gasLimit, to, value, data,accessList);
+        super(chainId, nonce, null, gasLimit, to, value, data, accessList);
         this.maxPriorityFeePerGas = maxPriorityFeePerGas;
         this.maxFeePerGas = maxFeePerGas;
     }
@@ -104,7 +116,15 @@ public class Transaction1559 extends Transaction2930 implements ITransaction {
             BigInteger maxPriorityFeePerGas,
             BigInteger maxFeePerGas) {
         return new Transaction1559(
-                chainId, nonce, gasLimit, to, value, "", maxPriorityFeePerGas, maxFeePerGas, Collections.emptyList());
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                "",
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                Collections.emptyList());
     }
 
     public static Transaction1559 createTransaction(
@@ -119,7 +139,34 @@ public class Transaction1559 extends Transaction2930 implements ITransaction {
             List<AccessListObject> accessList) {
 
         return new Transaction1559(
-                chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas, accessList);
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                accessList);
+    }
+
+    public static Transaction1559 createTransaction(
+            long chainId,
+            BigInteger nonce,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas) {
+
+        return new Transaction1559(
+                chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+    }
+
+    @Override
+    public TransactionType getType() {
+        return TransactionType.EIP1559;
     }
 
     @Override

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
@@ -81,6 +81,7 @@ public class Transaction2930 extends LegacyTransaction {
 
         return result;
     }
+
     protected List<RlpType> rlpAccessListRlp() {
 
         List<AccessListObject> accessList = getAccessList();

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction2930.java
@@ -71,6 +71,18 @@ public class Transaction2930 extends LegacyTransaction {
         result.add(RlpString.create(data));
 
         // access list
+        result.add(new RlpList(rlpAccessListRlp()));
+
+        if (signatureData != null) {
+            result.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
+            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getR())));
+            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getS())));
+        }
+
+        return result;
+    }
+    protected List<RlpType> rlpAccessListRlp() {
+
         List<AccessListObject> accessList = getAccessList();
         List<RlpType> rlpAccessList = new ArrayList<>();
         accessList.forEach(
@@ -89,15 +101,7 @@ public class Transaction2930 extends LegacyTransaction {
                     rlpAccessListObject.add(new RlpList(keyList));
                     rlpAccessList.add(new RlpList(rlpAccessListObject));
                 });
-        result.add(new RlpList(rlpAccessList));
-
-        if (signatureData != null) {
-            result.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
-            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getR())));
-            result.add(RlpString.create(Bytes.trimLeadingZeroes(signatureData.getS())));
-        }
-
-        return result;
+        return rlpAccessList;
     }
 
     public static Transaction2930 createEtherTransaction(

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -154,6 +154,32 @@ public class TransactionDecoderTest {
     }
 
     @Test
+    public void testDecoding1559AccessList() {
+        final RawTransaction rawTransaction = createEip1559RawTransactionAccessList();
+        final Transaction1559 transaction1559 = (Transaction1559) rawTransaction.getTransaction();
+
+        final byte[] encodedMessage = TransactionEncoder.encode(rawTransaction);
+        final String hexMessage = Numeric.toHexString(encodedMessage);
+
+        final RawTransaction result = TransactionDecoder.decode(hexMessage);
+        assertTrue(result.getTransaction() instanceof Transaction1559);
+        final Transaction1559 resultTransaction1559 = (Transaction1559) result.getTransaction();
+
+        assertNotNull(result);
+        assertEquals(transaction1559.getChainId(), resultTransaction1559.getChainId());
+        assertEquals(transaction1559.getNonce(), resultTransaction1559.getNonce());
+        assertEquals(transaction1559.getMaxFeePerGas(), resultTransaction1559.getMaxFeePerGas());
+        assertEquals(
+                transaction1559.getMaxPriorityFeePerGas(),
+                resultTransaction1559.getMaxPriorityFeePerGas());
+        assertEquals(transaction1559.getGasLimit(), resultTransaction1559.getGasLimit());
+        assertEquals(transaction1559.getTo(), resultTransaction1559.getTo());
+        assertEquals(transaction1559.getValue(), resultTransaction1559.getValue());
+        assertEquals(transaction1559.getData(), resultTransaction1559.getData());
+        assertEquals(transaction1559.getAccessList(), resultTransaction1559.getAccessList());
+    }
+
+    @Test
     public void testDecodingSigned1559() throws SignatureException {
         final RawTransaction rawTransaction = createEip1559RawTransaction();
         final Transaction1559 transaction1559 = (Transaction1559) rawTransaction.getTransaction();
@@ -200,6 +226,31 @@ public class TransactionDecoderTest {
                 BigInteger.valueOf(123),
                 BigInteger.valueOf(5678),
                 BigInteger.valueOf(1100000));
+    }
+
+    private static RawTransaction createEip1559RawTransactionAccessList() {
+        List<AccessListObject> accessList =
+                Stream.of(
+                                new AccessListObject(
+                                        "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                                        Stream.of(
+                                                        "0x0000000000000000000000000000000000000000000000000000000000000003",
+                                                        "0x0000000000000000000000000000000000000000000000000000000000000007")
+                                                .collect(toList())),
+                                new AccessListObject(
+                                        "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
+                                        Collections.emptyList()))
+                        .collect(toList());
+        return RawTransaction.createTransaction(
+                3L,
+                BigInteger.valueOf(0),
+                BigInteger.valueOf(30000),
+                "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+                BigInteger.valueOf(123),
+                "0x1000001111100000",
+                BigInteger.valueOf(5678),
+                BigInteger.valueOf(1100000),
+                accessList);
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Add AccessList to 1559 transaction

### Where should the reviewer start?
`org.web3j.crypto.transaction.type.Transaction1559`

### Why is it needed?
#1991 
It's an omission in web3j

