### PR TITLE
add parentBeaconBlockRoot field

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthBlock.java
@@ -62,6 +62,7 @@ public class EthBlock extends Response<EthBlock.Block> {
         private String number;
         private String hash;
         private String parentHash;
+        private String parentBeaconBlockRoot;
         private String nonce;
         private String sha3Uncles;
         private String logsBloom;
@@ -93,6 +94,7 @@ public class EthBlock extends Response<EthBlock.Block> {
                 String number,
                 String hash,
                 String parentHash,
+                String parentBeaconBlockRoot,
                 String nonce,
                 String sha3Uncles,
                 String logsBloom,
@@ -120,6 +122,7 @@ public class EthBlock extends Response<EthBlock.Block> {
             this.number = number;
             this.hash = hash;
             this.parentHash = parentHash;
+            this.parentBeaconBlockRoot = parentBeaconBlockRoot;
             this.nonce = nonce;
             this.sha3Uncles = sha3Uncles;
             this.logsBloom = logsBloom;
@@ -225,6 +228,14 @@ public class EthBlock extends Response<EthBlock.Block> {
 
         public void setParentHash(String parentHash) {
             this.parentHash = parentHash;
+        }
+
+        public String getParentBeaconBlockRoot() {
+            return parentBeaconBlockRoot;
+        }
+
+        public void setParentBeaconBlockRoot(String parentBeaconBlockRoot) {
+            this.parentBeaconBlockRoot = parentBeaconBlockRoot;
         }
 
         public BigInteger getNonce() {
@@ -488,6 +499,11 @@ public class EthBlock extends Response<EthBlock.Block> {
                     : block.getParentHash() != null) {
                 return false;
             }
+            if (getParentBeaconBlockRoot() != null
+                    ? !getParentBeaconBlockRoot().equals(block.getParentBeaconBlockRoot())
+                    : block.getParentBeaconBlockRoot() != null) {
+                return false;
+            }
             if (getNonceRaw() != null
                     ? !getNonceRaw().equals(block.getNonceRaw())
                     : block.getNonceRaw() != null) {
@@ -619,6 +635,11 @@ public class EthBlock extends Response<EthBlock.Block> {
             int result = getNumberRaw() != null ? getNumberRaw().hashCode() : 0;
             result = 31 * result + (getHash() != null ? getHash().hashCode() : 0);
             result = 31 * result + (getParentHash() != null ? getParentHash().hashCode() : 0);
+            result =
+                    31 * result
+                            + (getParentBeaconBlockRoot() != null
+                                    ? getParentBeaconBlockRoot().hashCode()
+                                    : 0);
             result = 31 * result + (getNonceRaw() != null ? getNonceRaw().hashCode() : 0);
             result = 31 * result + (getSha3Uncles() != null ? getSha3Uncles().hashCode() : 0);
             result = 31 * result + (getLogsBloom() != null ? getLogsBloom().hashCode() : 0);

--- a/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/ResponseTest.java
@@ -626,6 +626,7 @@ public class ResponseTest extends ResponseTester {
                         + "    \"number\": \"0x1b4\",\n"
                         + "    \"hash\": \"0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331\",\n"
                         + "    \"parentHash\": \"0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5\",\n"
+                        + "    \"parentBeaconBlockRoot\": \"0x87996eeac031318cd38ee5de92b630676da7263b697a93ff55d0ad88c142e169\",\n"
                         + "    \"nonce\": \"0xe04d296d2460cfb8472af2c5fd05b5a214109c25688d3704aed5484f9a7792f2\",\n"
                         + "    \"sha3Uncles\": \"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\n"
                         + "    \"logsBloom\": \"0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331\",\n"
@@ -675,6 +676,7 @@ public class ResponseTest extends ResponseTester {
                         "0x1b4",
                         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
                         "0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5",
+                        "0x87996eeac031318cd38ee5de92b630676da7263b697a93ff55d0ad88c142e169",
                         "0xe04d296d2460cfb8472af2c5fd05b5a214109c25688d3704aed5484f9a7792f2",
                         "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
@@ -872,6 +874,7 @@ public class ResponseTest extends ResponseTester {
                         + "    \"number\": \"0x1b4\",\n"
                         + "    \"hash\": \"0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331\",\n"
                         + "    \"parentHash\": \"0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5\",\n"
+                        + "    \"parentBeaconBlockRoot\": \"0x87996eeac031318cd38ee5de92b630676da7263b697a93ff55d0ad88c142e169\",\n"
                         + "    \"nonce\": \"0xe04d296d2460cfb8472af2c5fd05b5a214109c25688d3704aed5484f9a7792f2\",\n"
                         + "    \"sha3Uncles\": \"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\n"
                         + "    \"logsBloom\": \"0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331\",\n"
@@ -950,6 +953,7 @@ public class ResponseTest extends ResponseTester {
                         "0x1b4",
                         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
                         "0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5",
+                        "0x87996eeac031318cd38ee5de92b630676da7263b697a93ff55d0ad88c142e169",
                         "0xe04d296d2460cfb8472af2c5fd05b5a214109c25688d3704aed5484f9a7792f2",
                         "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
                         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",

--- a/core/src/test/java/org/web3j/protocol/core/methods/response/EthBlockTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/methods/response/EthBlockTest.java
@@ -26,7 +26,7 @@ public class EthBlockTest {
                 new EthBlock.Block(
                         null, null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null, null, null, null,
-                        null, null, null);
+                        null, null, null, null);
 
         assertEquals(ethBlock.getSize(), BigInteger.ZERO);
     }
@@ -36,8 +36,8 @@ public class EthBlockTest {
         EthBlock.Block ethBlock =
                 new EthBlock.Block(
                         null, null, null, null, null, null, null, null, null, null, null, null,
-                        null, null, null, "0x3e8", null, null, null, null, null, null, null, null,
-                        null, null, null);
+                        null, null, null, null, "0x3e8", null, null, null, null, null, null, null,
+                        null, null, null, null);
 
         assertEquals(ethBlock.getSize(), BigInteger.valueOf(1000));
     }


### PR DESCRIPTION
### What does this PR do?
After Ethereum supports -4844, the response from eth_getBlockByNumber api will include parentBeaconBlockRoot.

### Where should the reviewer start?
PR is quite short

### Why is it needed?
This is the necessary update for EIP-4844.

