### PR TITLE
 Unify JDK distribution in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 21
       - name: Publish Javadocs (gh-pages)
         env:


### PR DESCRIPTION
### What does this PR do?

Align the release workflow with the rest of the CI by switching the JDK distribution for the javadocs-release job from Temurin to Zulu.