### PR TITLE
don't add '.abi' suffix - the name already has it

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapperGenerator.java
@@ -180,7 +180,7 @@ public class SolidityFunctionWrapperGenerator extends FunctionWrapperGenerator {
 
             System.out.println("File written to " + destinationDirLocation.toString() + "\n");
         } else {
-            System.out.println("Ignoring empty ABI file: " + abiFile.getName() + ".abi" + "\n");
+            System.out.println("Ignoring empty ABI file: " + abiFile.getName() + "\n");
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Removes an unnecessary file sufix in printed message.
Before the change:
`Ignoring empty ABI file: Math.abi.abi`
After:
`Ignoring empty ABI file: Math.abi`

### Where should the reviewer start?
It's a single-line change

### Why is it needed?
To not confuse users that a non-existing file has been taken for compilation.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.