### PR TITLE
Update Besu to 25.10.0 and Besu Native to 1.4.0

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -9,11 +9,8 @@ repositories {
     maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }
 }
 ext {
-    besuPluginVersion = '25.2.1'
-    besuInternalVersion = '25.2.1'
-    besuInternalCryptoVersion = '23.1.3'
-    besuCryptoDepVersion = '1.1.2'
-    besuBlsVersion = '1.0.0'
+    besuDepVersion = '25.10.0'
+    besuNativeDepVersion = '1.4.0'
 }
 
 def withoutAbi = { exclude group: 'org.web3j', module: 'abi' }
@@ -31,19 +28,19 @@ dependencies {
         // We dont want to pull the web3j version from unit
         exclude group: 'org.web3j'
     }
-    testImplementation "org.hyperledger.besu:plugin-api:$besuPluginVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:besu:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:api:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:config:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:core:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:crypto:$besuInternalCryptoVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:rlp:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:kvstore:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:metrics-core:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:trie:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu.internal:util:$besuInternalVersion",withoutAbi
-    testImplementation "org.hyperledger.besu:bls12-381:$besuBlsVersion",withoutAbi
-    testImplementation "org.hyperledger.besu:secp256k1:$besuCryptoDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu:besu-plugin-api:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-app:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-ethereum-api:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-config:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-ethereum-core:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-crypto-services:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-ethereum-rlp:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-services-kvstore:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-metrics-core:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-ethereum-trie:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu.internal:besu-util:$besuDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu:gnark:$besuNativeDepVersion",withoutAbi
+    testImplementation "org.hyperledger.besu:secp256k1:$besuNativeDepVersion",withoutAbi
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Update Besu and Besu Native dependencies to their latest version, also Maven coordinates have been updated accordingly. 
Maven coordinates changes for Besu introduced here https://github.com/hyperledger/besu/pull/8589 https://github.com/hyperledger/besu/pull/8746, and Besu Native BLS has been rename to Costantine.

### Where should the reviewer start?
Gradle script

### Why is it needed?
To use the newest Maven coordinates

## Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.