### PR TITLE
docs: align README badge links with current owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Web3j: Web3 Java Ethereum Dapp API
 ==================================
 
 [![Documentation Status](https://readthedocs.org/projects/web3j-docs/badge/?version=latest)](https://docs.web3j.io)
-[![build status](https://github.com/web3j/web3j/actions/workflows/build.yml/badge.svg)](https://github.com/web3j/web3j/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/LFDT-web3j/web3j/branch/main/graph/badge.svg?token=a4G9ITI6CU)](https://codecov.io/gh/web3j/web3j)
+[![build status](https://github.com/LFDT-web3j/web3j/actions/workflows/build.yml/badge.svg)](https://github.com/LFDT-web3j/web3j/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/LFDT-web3j/web3j/branch/main/graph/badge.svg?token=a4G9ITI6CU)](https://codecov.io/gh/LFDT-web3j/web3j)
 [![Discord](https://img.shields.io/discord/779382027614158919?label=discord)](https://discord.gg/A9UXfPF2tS)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Web3j%20Guru-006BFF)](https://gurubase.io/g/web3j)
 


### PR DESCRIPTION
## Summary
- update the README build-status badge link to use the current `LFDT-web3j/web3j` repository owner
- align the README Codecov link target with the same current repository owner

## Testing
- not run (README link-only change)

## Why
The repository now lives under `LFDT-web3j/web3j`, but the README still points the build badge link and Codecov target at the old `web3j/web3j` owner. These links currently redirect, but updating them to the current owner keeps the README self-consistent and avoids depending on old-owner redirects.