### PR TITLE
Replace stack trace print with structured logging in StructuredDataEncoder

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/StructuredDataEncoder.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.web3j.abi.TypeEncoder;
 import org.web3j.abi.datatypes.AbiTypes;
@@ -43,6 +45,8 @@ import static org.web3j.crypto.Hash.sha3;
 import static org.web3j.crypto.Hash.sha3String;
 
 public class StructuredDataEncoder {
+    private static final Logger log = LoggerFactory.getLogger(StructuredDataEncoder.class);
+
     public static ObjectMapper mapper =
             new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
     public final StructuredData.EIP712Message jsonMessageObject;
@@ -266,7 +270,7 @@ public class StructuredDataEncoder {
                 hashBytes = Numeric.toBytesPadded(bi, 32);
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.warn("Unable to convert structured data item for type '{}'", baseType, e);
             hashBytes = new byte[0];
         }
 


### PR DESCRIPTION

### What does this PR do?
*This PR replaces direct stack trace printing with structured SLF4J logging in StructuredDataEncoder.It adds a class logger and updates the exception path in convertToEncodedItem so errors are logged through the project logging system instead of printing to stderr.*

### Where should the reviewer start?
*Start in StructuredDataEncoder.java:48 to see the new logger declaration, then review the catch block change at StructuredDataEncoder.java:273.*

### Why is it needed?
*Direct stack trace printing from library code is noisy and bypasses application-level logging controls.Using structured logging makes the behavior consistent with the rest of the codebase while preserving existing fallback behavior.*

## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.