### PR TITLE
Fix raw EthLog.LogResult generic usages (#2252)

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java
@@ -35,8 +35,8 @@ public class BlockFilter extends Filter<String> {
     }
 
     @Override
-    protected void process(List<EthLog.LogResult> logResults) {
-        for (EthLog.LogResult logResult : logResults) {
+    protected void process(List<EthLog.LogResult<?>> logResults) {
+        for (EthLog.LogResult<?> logResult : logResults) {
             if (logResult instanceof EthLog.Hash) {
                 String blockHash = ((EthLog.Hash) logResult).get();
                 callback.onEvent(blockHash);

--- a/core/src/main/java/org/web3j/protocol/core/filters/BlocksFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/BlocksFilter.java
@@ -37,10 +37,10 @@ public class BlocksFilter extends Filter<List<String>> {
     }
 
     @Override
-    protected void process(List<LogResult> logResults) {
+    protected void process(List<LogResult<?>> logResults) {
         List<String> blockHashes = new ArrayList<>(logResults.size());
 
-        for (EthLog.LogResult logResult : logResults) {
+        for (LogResult<?> logResult : logResults) {
             if (!(logResult instanceof EthLog.Hash)) {
                 throw new FilterException(
                         "Unexpected result type: " + logResult.get() + ", required Hash");

--- a/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/Filter.java
@@ -157,7 +157,7 @@ public abstract class Filter<T> {
 
     protected abstract EthFilter sendRequest() throws IOException;
 
-    protected abstract void process(List<EthLog.LogResult> logResults);
+    protected abstract void process(List<EthLog.LogResult<?>> logResults);
 
     private void reinstallFilter() {
         log.warn(

--- a/core/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/LogFilter.java
@@ -42,8 +42,8 @@ public class LogFilter extends Filter<Log> {
     }
 
     @Override
-    protected void process(List<EthLog.LogResult> logResults) {
-        for (EthLog.LogResult logResult : logResults) {
+    protected void process(List<EthLog.LogResult<?>> logResults) {
+        for (EthLog.LogResult<?> logResult : logResults) {
             if (logResult instanceof EthLog.LogObject) {
                 Log log = ((EthLog.LogObject) logResult).get();
                 callback.onEvent(log);

--- a/core/src/main/java/org/web3j/protocol/core/filters/LogsFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/LogsFilter.java
@@ -44,10 +44,10 @@ public class LogsFilter extends Filter<List<Log>> {
     }
 
     @Override
-    protected void process(List<LogResult> logResults) {
+    protected void process(List<LogResult<?>> logResults) {
         List<Log> logs = new ArrayList<>(logResults.size());
 
-        for (EthLog.LogResult logResult : logResults) {
+        for (LogResult<?> logResult : logResults) {
             if (!(logResult instanceof EthLog.LogObject)) {
                 throw new FilterException(
                         "Unexpected result type: " + logResult.get() + " required LogObject");

--- a/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java
@@ -35,8 +35,8 @@ public class PendingTransactionFilter extends Filter<String> {
     }
 
     @Override
-    protected void process(List<EthLog.LogResult> logResults) {
-        for (EthLog.LogResult logResult : logResults) {
+    protected void process(List<EthLog.LogResult<?>> logResults) {
+        for (EthLog.LogResult<?> logResult : logResults) {
             if (logResult instanceof EthLog.Hash) {
                 String transactionHash = ((EthLog.Hash) logResult).get();
                 callback.onEvent(transactionHash);

--- a/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionsFilter.java
+++ b/core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionsFilter.java
@@ -36,10 +36,10 @@ public class PendingTransactionsFilter extends Filter<List<String>> {
     }
 
     @Override
-    protected void process(List<EthLog.LogResult> logResults) {
+    protected void process(List<EthLog.LogResult<?>> logResults) {
         List<String> logs = new ArrayList<>(logResults.size());
 
-        for (EthLog.LogResult logResult : logResults) {
+        for (EthLog.LogResult<?> logResult : logResults) {
             if (!(logResult instanceof EthLog.Hash)) {
                 throw new FilterException(
                         "Unexpected result type: " + logResult.get() + ", required Hash");

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/EthLog.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/EthLog.java
@@ -39,15 +39,15 @@ import org.web3j.protocol.core.Response;
  * <p>See <a href="https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges">docs</a> for
  * further details.
  */
-public class EthLog extends Response<List<EthLog.LogResult>> {
+public class EthLog extends Response<List<EthLog.LogResult<?>>> {
 
     @Override
     @JsonDeserialize(using = LogResultDeserialiser.class)
-    public void setResult(List<LogResult> result) {
+    public void setResult(List<LogResult<?>> result) {
         super.setResult(result);
     }
 
-    public List<LogResult> getLogs() {
+    public List<LogResult<?>> getLogs() {
         return getResult();
     }
 
@@ -127,16 +127,16 @@ public class EthLog extends Response<List<EthLog.LogResult>> {
         }
     }
 
-    public static class LogResultDeserialiser extends JsonDeserializer<List<LogResult>> {
+    public static class LogResultDeserialiser extends JsonDeserializer<List<LogResult<?>>> {
 
         private ObjectReader objectReader = ObjectMapperFactory.getObjectReader();
 
         @Override
-        public List<LogResult> deserialize(
+        public List<LogResult<?>> deserialize(
                 JsonParser jsonParser, DeserializationContext deserializationContext)
                 throws IOException {
 
-            List<LogResult> logResults = new ArrayList<>();
+            List<LogResult<?>> logResults = new ArrayList<>();
             JsonToken nextToken = jsonParser.nextToken();
 
             if (nextToken == JsonToken.START_OBJECT) {

--- a/core/src/test/java/org/web3j/protocol/core/filters/FilterTester.java
+++ b/core/src/test/java/org/web3j/protocol/core/filters/FilterTester.java
@@ -112,7 +112,7 @@ public abstract class FilterTester {
     }
 
     List createExpected(EthLog ethLog) {
-        List<EthLog.LogResult> logResults = ethLog.getLogs();
+                List<EthLog.LogResult<?>> logResults = ethLog.getLogs();
         if (logResults.isEmpty()) {
             fail("Results cannot be empty");
         }

--- a/integration-tests/src/test/java/org/web3j/protocol/core/CoreIT.java
+++ b/integration-tests/src/test/java/org/web3j/protocol/core/CoreIT.java
@@ -441,7 +441,7 @@ public class CoreIT {
 
         // eth_getFilterLogs
         EthLog ethFilterLogs = web3j.ethGetFilterLogs(filterId).send();
-        List<EthLog.LogResult> filterLogs = ethFilterLogs.getLogs();
+        List<EthLog.LogResult<?>> filterLogs = ethFilterLogs.getLogs();
         assertFalse(filterLogs.isEmpty());
 
         // eth_getFilterChanges - nothing will have changed in this interval
@@ -480,7 +480,7 @@ public class CoreIT {
         ethFilter.addSingleTopic(config.encodedEvent());
 
         EthLog ethLog = web3j.ethGetLogs(ethFilter).send();
-        List<EthLog.LogResult> logs = ethLog.getLogs();
+        List<EthLog.LogResult<?>> logs = ethLog.getLogs();
         assertFalse(logs.isEmpty());
     }
 

--- a/integration-tests/src/test/java/org/web3j/protocol/scenarios/EventFilterIT.java
+++ b/integration-tests/src/test/java/org/web3j/protocol/scenarios/EventFilterIT.java
@@ -81,11 +81,11 @@ public class EventFilterIT extends Scenario {
                         new Uint256(BigInteger.valueOf(1)), new Uint256(BigInteger.valueOf(1)))));
 
         // finally check it shows up in the event filter
-        List<EthLog.LogResult> filterLogs = createFilterForEvent(encodedEventSignature);
+                List<EthLog.LogResult<?>> filterLogs = createFilterForEvent(encodedEventSignature);
         assertFalse(filterLogs.isEmpty());
     }
 
-    private List<EthLog.LogResult> createFilterForEvent(String encodedEventSignature)
+        private List<EthLog.LogResult<?>> createFilterForEvent(String encodedEventSignature)
             throws Exception {
         EthFilter ethFilter =
                 new EthFilter(


### PR DESCRIPTION
### What does this PR do?
*Fixes issue #2252 by removing raw EthLog.LogResult generic usages and replacing them with wildcard-parameterized types across EthLog response handling, filter APIs/implementations, and affected tests.*

### Where should the reviewer start?
*Start with core/src/main/java/org/web3j/protocol/core/methods/response/EthLog.java, then review filter contract and implementations in:
core/src/main/java/org/web3j/protocol/core/filters/Filter.java,
core/src/main/java/org/web3j/protocol/core/filters/BlockFilter.java,
core/src/main/java/org/web3j/protocol/core/filters/BlocksFilter.java,
core/src/main/java/org/web3j/protocol/core/filters/LogFilter.java,
core/src/main/java/org/web3j/protocol/core/filters/LogsFilter.java,
core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionFilter.java,
core/src/main/java/org/web3j/protocol/core/filters/PendingTransactionsFilter.java.*

### Why is it needed?
*Raw generic usage of EthLog.LogResult produces IDE/compiler warnings and weakens type safety. Parameterizing these usages improves API clarity and developer experience without changing runtime behavior.*

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.