### PR TITLE
Add signTypedData address recovery test (#2019)

### DIFF
--- a/crypto/src/test/java/org/web3j/crypto/SignTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/SignTest.java
@@ -36,6 +36,8 @@ import static org.web3j.crypto.Sign.REPLAY_PROTECTED_V_MIN;
 public class SignTest {
 
     private static final byte[] TEST_MESSAGE = "A test message".getBytes();
+    private static final String TEST_JSON_TYPED_DATA =
+            "{\"types\": {    \"EIP712Domain\": [      {\"name\": \"name\", \"type\": \"string\"},      {\"name\": \"version\", \"type\": \"string\"},      {\"name\": \"chainId\", \"type\": \"uint256\"},      {\"name\": \"verifyingContract\", \"type\": \"address\"}    ],    \"Person\": [      {\"name\": \"name\", \"type\": \"string\"},      {\"name\": \"wallet\", \"type\": \"address\"}    ]  },  \"domain\": {    \"name\": \"My Dapp\",    \"version\": \"1.0\",    \"chainId\": 1,    \"verifyingContract\": \"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\"  },  \"primaryType\": \"Person\",  \"message\": {    \"name\": \"John Doe\",    \"wallet\": \"0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B\"  }}";
 
     @Test
     public void testSignMessage() {
@@ -85,8 +87,6 @@ public class SignTest {
 
     @Test
     public void testSignTypedData() throws IOException {
-        String TEST_JSON_TYPED_DATA =
-                "{\"types\": {    \"EIP712Domain\": [      {\"name\": \"name\", \"type\": \"string\"},      {\"name\": \"version\", \"type\": \"string\"},      {\"name\": \"chainId\", \"type\": \"uint256\"},      {\"name\": \"verifyingContract\", \"type\": \"address\"}    ],    \"Person\": [      {\"name\": \"name\", \"type\": \"string\"},      {\"name\": \"wallet\", \"type\": \"address\"}    ]  },  \"domain\": {    \"name\": \"My Dapp\",    \"version\": \"1.0\",    \"chainId\": 1,    \"verifyingContract\": \"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC\"  },  \"primaryType\": \"Person\",  \"message\": {    \"name\": \"John Doe\",    \"wallet\": \"0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B\"  }}";
         Sign.SignatureData signature =
                 Sign.signTypedData(TEST_JSON_TYPED_DATA, SampleKeys.KEY_PAIR);
         byte[] retval = new byte[65];
@@ -97,6 +97,19 @@ public class SignTest {
         assertEquals(
                 signedMessage,
                 "0x80361fd6c275c7492d00d976a48d0db4a663fb76da49a3c7d69c252f1c8cbea61438264a755d464e19bcd7c976b06640b40bd34de5f5c1456c0efe3b6626143a1c");
+    }
+
+    @Test
+    public void testRecoverAddressFromSignTypedData() throws IOException, SignatureException {
+        Sign.SignatureData signature =
+                Sign.signTypedData(TEST_JSON_TYPED_DATA, SampleKeys.KEY_PAIR);
+        StructuredDataEncoder dataEncoder = new StructuredDataEncoder(TEST_JSON_TYPED_DATA);
+        byte[] hashStructuredData = dataEncoder.hashStructuredData();
+
+        BigInteger recoveredPublicKey = Sign.signedMessageHashToKey(hashStructuredData, signature);
+        String recoveredAddress = "0x" + Keys.getAddress(recoveredPublicKey);
+
+        assertEquals(SampleKeys.ADDRESS, recoveredAddress);
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
*Adds a focused unit test to demonstrate and verify how to recover the signer address from a signTypedData signature.*

Specifically:

1. Reuses the existing typed-data JSON fixture in `SignTest`.
2. Signs the typed data with `Sign.signTypedData(...)`.
3. Recomputes the structured-data hash via `StructuredDataEncoder.hashStructuredData()`.
4. Recovers the public key using `Sign.signedMessageHashToKey(...)`.
5. Derives and asserts the recovered address matches `SampleKeys.ADDRESS`


### Where should the reviewer start?
*Start in `crypto/src/test/java/org/web3j/crypto/SignTest.java`, especially:*

*The new typed-data fixture constant near the top of the class.
`testRecoverAddressFromSignTypedData()` for the recovery flow.
`testSignTypedData()` which now reuses the shared fixture.*

### Why is it needed?
*Issue #2019 identifies a real gap: while signTypedData signing is tested, recovery/verification flow is not clearly demonstrated in tests.*

This PR closes that gap by adding an executable example that:

- Serves as documentation for users verifying typed-data signatures.
- Improves confidence in end-to-end signing + recovery behavior.
- Increases robustness of the crypto test suite without changing production behavior.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.