### PR TITLE
feat: introduce RateLimitException to handle HTTP 429 with Retry-After parsing

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,8 +23,9 @@ dependencies {
             "io.consensys.tuweni:tuweni-units:$tuweniVersion"
     implementation "software.amazon.awssdk:kms:$awsSdkVersion"
     testImplementation project(path: ':crypto', configuration: 'testArtifacts'),
-    "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion",
-    "ch.qos.logback:logback-classic:$logbackVersion"
+            "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion",
+            "ch.qos.logback:logback-classic:$logbackVersion",
+            "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
 }
 
 def timestampUTC = {

--- a/core/src/main/java/org/web3j/protocol/exceptions/RateLimitException.java
+++ b/core/src/main/java/org/web3j/protocol/exceptions/RateLimitException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.exceptions;
+
+/**
+ * Thrown when the RPC endpoint responds with HTTP 429 Too Many Requests.
+ *
+ * <p>Callers can inspect {@link #getRetryAfterSeconds()} to honour the server's
+ * back-off hint and {@link #getResponseBody()} for any machine-readable error payload.
+ */
+public class RateLimitException extends ClientConnectionException {
+
+    private final long retryAfterSeconds;
+    private final String responseBody;
+
+    /**
+     * @param message human-readable description (typically includes the status code and body)
+     * @param retryAfterSeconds parsed {@code Retry-After} delay, {@code 0} when absent
+     * @param responseBody raw HTTP response body, may be {@code null}
+     */
+    public RateLimitException(String message, long retryAfterSeconds, String responseBody) {
+        super(message);
+        this.retryAfterSeconds = retryAfterSeconds;
+        this.responseBody = responseBody;
+    }
+
+    /** Convenience constructor when the response body is not available separately. */
+    public RateLimitException(String message, long retryAfterSeconds) {
+        this(message, retryAfterSeconds, null);
+    }
+
+    /** Seconds the server asked the client to wait, or {@code 0} if the header was absent. */
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+
+    /** Raw HTTP response body returned with the 429 status, or {@code null} if unavailable. */
+    public String getResponseBody() {
+        return responseBody;
+    }
+}

--- a/core/src/main/java/org/web3j/protocol/http/HttpService.java
+++ b/core/src/main/java/org/web3j/protocol/http/HttpService.java
@@ -15,6 +15,11 @@ package org.web3j.protocol.http;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import org.web3j.protocol.Service;
 import org.web3j.protocol.exceptions.ClientConnectionException;
+import org.web3j.protocol.exceptions.RateLimitException;
 
 import static okhttp3.ConnectionSpec.CLEARTEXT;
 
@@ -85,6 +91,16 @@ public class HttpService extends Service {
             MediaType.parse("application/json; charset=utf-8");
 
     public static final String DEFAULT_URL = "http://localhost:8545/";
+
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+    private static final String RETRY_AFTER_HEADER = "Retry-After";
+
+    /**
+     * Upper bound applied to parsed {@code Retry-After} values to guard against
+     * buggy or adversarial servers stalling callers indefinitely.
+     */
+    static final long MAX_RETRY_AFTER_SECONDS = 86_400L;
 
     private static final Logger log = LoggerFactory.getLogger(HttpService.class);
 
@@ -169,6 +185,16 @@ public class HttpService extends Service {
                 int code = response.code();
                 String text = responseBody == null ? "N/A" : responseBody.string();
 
+                if (code == HTTP_TOO_MANY_REQUESTS) {
+                    long retryAfterSeconds =
+                            parseRetryAfterSeconds(
+                                    response.headers().get(RETRY_AFTER_HEADER));
+                    throw new RateLimitException(
+                            "Too many requests (429); " + text,
+                            retryAfterSeconds,
+                            text);
+                }
+
                 throw new ClientConnectionException(
                         "Invalid response received: " + code + "; " + text);
             }
@@ -177,6 +203,53 @@ public class HttpService extends Service {
 
     protected void processHeaders(Headers headers) {
         // Default implementation is empty
+    }
+
+    /**
+     * Parses the {@code Retry-After} header per
+     * <a href="https://www.rfc-editor.org/rfc/rfc7231#section-7.1.3">RFC 7231 Section 7.1.3</a>.
+     *
+     * <p>The header value is interpreted as either:
+     * <ul>
+     *   <li>a non-negative number of seconds ({@code delay-seconds}), or</li>
+     *   <li>an HTTP-date (RFC 1123 format), converted to a relative delta from now.</li>
+     * </ul>
+     *
+     * <p>Returns {@code 0} when the header is {@code null}, blank, negative, or unparseable.
+     * The result is capped at {@link #MAX_RETRY_AFTER_SECONDS} to prevent stalling on
+     * adversarial or misconfigured servers.
+     *
+     * @param retryAfterValue the raw header value, may be {@code null}
+     * @return seconds to wait before retrying, in the range {@code [0, MAX_RETRY_AFTER_SECONDS]}
+     */
+    static long parseRetryAfterSeconds(String retryAfterValue) {
+        if (retryAfterValue == null) {
+            return 0L;
+        }
+        String trimmed = retryAfterValue.trim();
+        if (trimmed.isEmpty()) {
+            return 0L;
+        }
+
+        try {
+            double seconds = Double.parseDouble(trimmed);
+            if (seconds >= 0 && !Double.isInfinite(seconds) && !Double.isNaN(seconds)) {
+                return Math.min(MAX_RETRY_AFTER_SECONDS, (long) Math.ceil(seconds));
+            }
+            return 0L;
+        } catch (NumberFormatException ignored) {
+            // Not numeric — fall through to HTTP-date parsing
+        }
+
+        try {
+            ZonedDateTime retryAt =
+                    ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME);
+            long seconds = ChronoUnit.SECONDS.between(Instant.now(), retryAt.toInstant());
+            return Math.min(MAX_RETRY_AFTER_SECONDS, Math.max(0L, seconds));
+        } catch (DateTimeParseException e) {
+            log.debug("Unparseable Retry-After header value: {}", trimmed);
+            return 0L;
+        }
     }
 
     private InputStream buildInputStream(ResponseBody responseBody) throws IOException {

--- a/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
+++ b/core/src/test/java/org/web3j/protocol/http/HttpServiceTest.java
@@ -13,11 +13,16 @@
 package org.web3j.protocol.http;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 
 import okhttp3.Call;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.Response;
@@ -29,9 +34,11 @@ import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
 import org.web3j.protocol.core.methods.response.EthSubscribe;
 import org.web3j.protocol.exceptions.ClientConnectionException;
+import org.web3j.protocol.exceptions.RateLimitException;
 import org.web3j.protocol.websocket.events.NewHeadsNotification;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -105,6 +112,216 @@ class HttpServiceTest {
         }
 
         fail("No exception");
+    }
+
+    @Test
+    void rateLimitIncludesRetryAfterSeconds() throws IOException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(
+                    new MockResponse()
+                            .setResponseCode(429)
+                            .setHeader("Retry-After", "30")
+                            .setBody("rate limited"));
+            server.start();
+            HttpService rateLimitedService = new HttpService(server.url("/").toString());
+
+            Request<String, EthBlockNumber> request =
+                    new Request<>(
+                            "eth_blockNumber",
+                            Collections.emptyList(),
+                            rateLimitedService,
+                            EthBlockNumber.class);
+
+            RateLimitException thrown =
+                    assertThrows(
+                            RateLimitException.class,
+                            () -> rateLimitedService.send(request, EthBlockNumber.class));
+            assertEquals(30L, thrown.getRetryAfterSeconds());
+            assertEquals("rate limited", thrown.getResponseBody());
+        }
+    }
+
+    @Test
+    void rateLimitWithMissingRetryAfterHeader() throws IOException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(
+                    new MockResponse()
+                            .setResponseCode(429)
+                            .setBody("rate limited"));
+            server.start();
+            HttpService rateLimitedService = new HttpService(server.url("/").toString());
+
+            Request<String, EthBlockNumber> request =
+                    new Request<>(
+                            "eth_blockNumber",
+                            Collections.emptyList(),
+                            rateLimitedService,
+                            EthBlockNumber.class);
+
+            RateLimitException thrown =
+                    assertThrows(
+                            RateLimitException.class,
+                            () -> rateLimitedService.send(request, EthBlockNumber.class));
+            assertEquals(0L, thrown.getRetryAfterSeconds());
+            assertNotNull(thrown.getResponseBody());
+        }
+    }
+
+    @Test
+    void rateLimitWithMalformedRetryAfterHeader() throws IOException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(
+                    new MockResponse()
+                            .setResponseCode(429)
+                            .setHeader("Retry-After", "not-a-number-or-date")
+                            .setBody("rate limited"));
+            server.start();
+            HttpService rateLimitedService = new HttpService(server.url("/").toString());
+
+            Request<String, EthBlockNumber> request =
+                    new Request<>(
+                            "eth_blockNumber",
+                            Collections.emptyList(),
+                            rateLimitedService,
+                            EthBlockNumber.class);
+
+            RateLimitException thrown =
+                    assertThrows(
+                            RateLimitException.class,
+                            () -> rateLimitedService.send(request, EthBlockNumber.class));
+            assertEquals(0L, thrown.getRetryAfterSeconds());
+        }
+    }
+
+    @Test
+    void rateLimitWithDateBasedRetryAfterHeader() throws IOException {
+        ZonedDateTime futureDate = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(120);
+        String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(futureDate);
+
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(
+                    new MockResponse()
+                            .setResponseCode(429)
+                            .setHeader("Retry-After", httpDate)
+                            .setBody("rate limited"));
+            server.start();
+            HttpService rateLimitedService = new HttpService(server.url("/").toString());
+
+            Request<String, EthBlockNumber> request =
+                    new Request<>(
+                            "eth_blockNumber",
+                            Collections.emptyList(),
+                            rateLimitedService,
+                            EthBlockNumber.class);
+
+            RateLimitException thrown =
+                    assertThrows(
+                            RateLimitException.class,
+                            () -> rateLimitedService.send(request, EthBlockNumber.class));
+            assertTrue(
+                    thrown.getRetryAfterSeconds() >= 115 && thrown.getRetryAfterSeconds() <= 125,
+                    "Expected ~120s, got " + thrown.getRetryAfterSeconds());
+        }
+    }
+
+    // ---- parseRetryAfterSeconds unit tests ----
+
+    @Test
+    void parseRetryAfterSeconds_null() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds(null));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_empty() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds(""));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_whitespaceOnly() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("   "));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_validInteger() {
+        assertEquals(60L, HttpService.parseRetryAfterSeconds("60"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_validIntegerWithWhitespace() {
+        assertEquals(45L, HttpService.parseRetryAfterSeconds("  45  "));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_decimalRoundedUp() {
+        assertEquals(3L, HttpService.parseRetryAfterSeconds("2.7"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_negativeReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("-10"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_zero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("0"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_nanReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("NaN"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_infinityReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("Infinity"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_negativeInfinityReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("-Infinity"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_veryLargeValueCappedToMax() {
+        assertEquals(
+                HttpService.MAX_RETRY_AFTER_SECONDS,
+                HttpService.parseRetryAfterSeconds("999999999"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_httpDateInFuture() {
+        ZonedDateTime future = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(300);
+        String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(future);
+        long result = HttpService.parseRetryAfterSeconds(httpDate);
+        assertTrue(
+                result >= 295 && result <= 305,
+                "Expected ~300s, got " + result);
+    }
+
+    @Test
+    void parseRetryAfterSeconds_httpDateInPastReturnsZero() {
+        ZonedDateTime past = ZonedDateTime.now(ZoneOffset.UTC).minusHours(1);
+        String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(past);
+        assertEquals(0L, HttpService.parseRetryAfterSeconds(httpDate));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_httpDateFarFutureCappedToMax() {
+        ZonedDateTime farFuture = ZonedDateTime.now(ZoneOffset.UTC).plusDays(7);
+        String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME.format(farFuture);
+        assertEquals(
+                HttpService.MAX_RETRY_AFTER_SECONDS,
+                HttpService.parseRetryAfterSeconds(httpDate));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_malformedDateReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("not-a-date"));
+    }
+
+    @Test
+    void parseRetryAfterSeconds_garbageReturnsZero() {
+        assertEquals(0L, HttpService.parseRetryAfterSeconds("abc123!@#"));
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Introduces RateLimitException to handle HTTP 429 status codes. It enhances HttpService to intercept rate-limit responses and parse the Retry-After header (supporting both delay-seconds and HTTP-date formats per RFC 7231).

### Where should the reviewer start?
core/src/main/java/org/web3j/protocol/exceptions/RateLimitException.java: Review the new exception structure.
core/src/main/java/org/web3j/protocol/http/HttpService.java: Check the performIO method for the 429 handling and header parsing logic.

### Why is it needed?
High-throughput Layer 2 networks (like Base) and RPC providers frequently trigger 429 limits. Currently, web3j treats these as generic connection errors. This change allows upstream schedulers (especially those using Project Loom) to implement intelligent backpressure and adaptive retries based on explicit Retry-After metadata.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests  (see HttpServiceTest.rateLimitIncludesRetryAfterSeconds).
- [x] I've added a changelog entry if necessary.