### PR TITLE
feat: add support for EIP-7594 blob transaction wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/build
 
 # Besu-dev-quickstart logs
 integration-tests/src/test/resources/quorum-test-network/logs
+
+# Agent files, folders, etc
+Web3j Agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*
+- Add support for EIP-7594 blob transaction wrapper (#2263)
 
 ### BREAKING CHANGES
 

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -232,6 +232,40 @@ public class RawTransaction {
                         versionedHashes));
     }
 
+    public static RawTransaction createOsakaTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<List<Bytes>> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes) {
+
+        return new RawTransaction(
+                Transaction4844.createOsakaTransaction(
+                        blobs,
+                        kzgCommitments,
+                        cellProofs,
+                        wrapperVersion,
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxFeePerBlobGas,
+                        versionedHashes));
+    }
+
     public static RawTransaction createTransaction(
             long chainId,
             BigInteger nonce,

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -214,6 +214,38 @@ public class RawTransaction {
             String data,
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
+        return createTransaction(
+                blobs,
+                kzgCommitments,
+                kzgProofs,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                Collections.emptyList());
+    }
+
+    public static RawTransaction createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> kzgProofs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
 
         return new RawTransaction(
                 Transaction4844.createTransaction(
@@ -230,6 +262,88 @@ public class RawTransaction {
                         data,
                         maxFeePerBlobGas,
                         versionedHashes));
+    }
+
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction.
+     *
+     * @param cellProofs flat list of {@code CELLS_PER_EXT_BLOB * len(blobs)} 48-byte KZG proofs
+     * @param wrapperVersion must be BigInteger.ONE per EIP-7594
+     */
+    public static RawTransaction createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes) {
+        return createTransaction(
+                blobs,
+                kzgCommitments,
+                cellProofs,
+                wrapperVersion,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                Collections.emptyList());
+    }
+
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction with access list.
+     *
+     * @param cellProofs flat list of {@code CELLS_PER_EXT_BLOB * len(blobs)} 48-byte KZG proofs
+     * @param wrapperVersion must be BigInteger.ONE per EIP-7594
+     * @param accessList optional EIP-2930 access list
+     */
+    public static RawTransaction createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
+
+        return new RawTransaction(
+                Transaction4844.createTransaction(
+                        blobs,
+                        kzgCommitments,
+                        cellProofs,
+                        wrapperVersion,
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxFeePerBlobGas,
+                        versionedHashes,
+                        accessList));
     }
 
     public static RawTransaction createTransaction(

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -261,7 +261,8 @@ public class RawTransaction {
                         value,
                         data,
                         maxFeePerBlobGas,
-                        versionedHashes));
+                        versionedHashes,
+                        accessList));
     }
 
     /**

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -126,19 +126,39 @@ public class TransactionDecoder {
         final List<Blob> blobs;
         final List<Bytes> kzgCommitments;
         final List<Bytes> kzgProofs;
+        final BigInteger wrapperVersion;
+        final List<List<Bytes>> cellProofs;
+
         // Check if the first element of outerList is a list
         if (outerList.getValues().get(0) instanceof RlpList) {
-            txPayload = (RlpList) outerList.getValues().get(0);
-
-            // Decode blobs, commitments, and proofs
-            blobs = decodeBlobs(((RlpList) outerList.getValues().get(1)).getValues());
-            kzgCommitments = decodeBytesList(((RlpList) outerList.getValues().get(2)).getValues());
-            kzgProofs = decodeBytesList(((RlpList) outerList.getValues().get(3)).getValues());
+            int size = outerList.getValues().size();
+            if (size == 5) {
+                // EIP-7594 wrapper format: [tx_payload_body, wrapper_version, blobs, commitments,
+                // cell_proofs]
+                txPayload = (RlpList) outerList.getValues().get(0);
+                wrapperVersion = ((RlpString) outerList.getValues().get(1)).asPositiveBigInteger();
+                blobs = decodeBlobs(((RlpList) outerList.getValues().get(2)).getValues());
+                kzgCommitments =
+                        decodeBytesList(((RlpList) outerList.getValues().get(3)).getValues());
+                cellProofs = decodeCellProofs(((RlpList) outerList.getValues().get(4)).getValues());
+                kzgProofs = null;
+            } else {
+                // EIP-4844 wrapper format: [tx_payload_body, blobs, commitments, proofs]
+                txPayload = (RlpList) outerList.getValues().get(0);
+                blobs = decodeBlobs(((RlpList) outerList.getValues().get(1)).getValues());
+                kzgCommitments =
+                        decodeBytesList(((RlpList) outerList.getValues().get(2)).getValues());
+                kzgProofs = decodeBytesList(((RlpList) outerList.getValues().get(3)).getValues());
+                wrapperVersion = null;
+                cellProofs = null;
+            }
         } else {
             txPayload = (RlpList) outerList;
             blobs = null;
             kzgCommitments = null;
             kzgProofs = null;
+            wrapperVersion = null;
+            cellProofs = null;
         }
 
         // Decode the transaction payload
@@ -158,21 +178,41 @@ public class TransactionDecoder {
                 decodeVersionedHashes(((RlpList) txValues.get(10)).getValues());
 
         // Create the raw transaction object
-        final RawTransaction rawTransaction =
-                RawTransaction.createTransaction(
-                        blobs,
-                        kzgCommitments,
-                        kzgProofs,
-                        chainId,
-                        nonce,
-                        maxPriorityFeePerGas,
-                        maxFeePerGas,
-                        gasLimit,
-                        to,
-                        value,
-                        data,
-                        maxFeePerBlobGas,
-                        versionedHashes);
+        final RawTransaction rawTransaction;
+        if (wrapperVersion != null) {
+            rawTransaction =
+                    RawTransaction.createOsakaTransaction(
+                            blobs,
+                            kzgCommitments,
+                            cellProofs,
+                            wrapperVersion,
+                            chainId,
+                            nonce,
+                            maxPriorityFeePerGas,
+                            maxFeePerGas,
+                            gasLimit,
+                            to,
+                            value,
+                            data,
+                            maxFeePerBlobGas,
+                            versionedHashes);
+        } else {
+            rawTransaction =
+                    RawTransaction.createTransaction(
+                            blobs,
+                            kzgCommitments,
+                            kzgProofs,
+                            chainId,
+                            nonce,
+                            maxPriorityFeePerGas,
+                            maxFeePerGas,
+                            gasLimit,
+                            to,
+                            value,
+                            data,
+                            maxFeePerBlobGas,
+                            versionedHashes);
+        }
 
         // Handle signature if present
         if (txValues.size() > UNSIGNED_EIP4844TX_RLP_LIST_SIZE) {
@@ -202,6 +242,12 @@ public class TransactionDecoder {
     private static List<Bytes> decodeBytesList(List<RlpType> rlpBytesList) {
         return rlpBytesList.stream()
                 .map(r -> Bytes.wrap(((RlpString) r).getBytes()))
+                .collect(Collectors.toList());
+    }
+
+    private static List<List<Bytes>> decodeCellProofs(List<RlpType> rlpCellProofs) {
+        return rlpCellProofs.stream()
+                .map(r -> decodeBytesList(((RlpList) r).getValues()))
                 .collect(Collectors.toList());
     }
 

--- a/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionDecoder.java
@@ -14,6 +14,7 @@ package org.web3j.crypto;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -126,23 +127,96 @@ public class TransactionDecoder {
         final List<Blob> blobs;
         final List<Bytes> kzgCommitments;
         final List<Bytes> kzgProofs;
-        // Check if the first element of outerList is a list
-        if (outerList.getValues().get(0) instanceof RlpList) {
-            txPayload = (RlpList) outerList.getValues().get(0);
+        final BigInteger wrapperVersion;
+        // EIP-7594: flat list of CELLS_PER_EXT_BLOB * len(blobs) proofs
+        final List<Bytes> cellProofs;
+        final List<AccessListObject> accessList;
 
-            // Decode blobs, commitments, and proofs
-            blobs = decodeBlobs(((RlpList) outerList.getValues().get(1)).getValues());
-            kzgCommitments = decodeBytesList(((RlpList) outerList.getValues().get(2)).getValues());
-            kzgProofs = decodeBytesList(((RlpList) outerList.getValues().get(3)).getValues());
+        final List<RlpType> outerValues = outerList.getValues();
+        if (outerValues.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Malformed EIP-4844 transaction: outer list is empty");
+        }
+
+        // Dispatch: network wrapper if first element is a list (tx_payload_body),
+        // otherwise the entire outerList IS the tx_payload_body (no sidecar).
+        if (outerValues.get(0) instanceof RlpList) {
+            int size = outerValues.size();
+            if (size == 5) {
+                // EIP-7594 format: [tx_payload_body, wrapper_version, blobs, commitments,
+                // cell_proofs]
+                txPayload = (RlpList) outerValues.get(0);
+
+                if (!(outerValues.get(1) instanceof RlpString)) {
+                    throw new IllegalArgumentException(
+                            "Malformed EIP-7594 transaction: wrapper_version must be RlpString");
+                }
+                wrapperVersion = ((RlpString) outerValues.get(1)).asPositiveBigInteger();
+
+                if (!(outerValues.get(2) instanceof RlpList)) {
+                    throw new IllegalArgumentException(
+                            "Malformed EIP-7594 transaction: blobs must be RlpList");
+                }
+                blobs = decodeBlobs(((RlpList) outerValues.get(2)).getValues());
+
+                if (!(outerValues.get(3) instanceof RlpList)) {
+                    throw new IllegalArgumentException(
+                            "Malformed EIP-7594 transaction: commitments must be RlpList");
+                }
+                kzgCommitments = decodeBytesList(((RlpList) outerValues.get(3)).getValues());
+
+                if (!(outerValues.get(4) instanceof RlpList)) {
+                    throw new IllegalArgumentException(
+                            "Malformed EIP-7594 transaction: cell_proofs must be RlpList");
+                }
+                // cell_proofs is a flat list of 48-byte proof entries
+                cellProofs = decodeBytesList(((RlpList) outerValues.get(4)).getValues());
+                kzgProofs = null;
+            } else if (size == 4) {
+                // EIP-4844 format: [tx_payload_body, blobs, commitments, proofs]
+                txPayload = (RlpList) outerValues.get(0);
+                blobs = decodeBlobs(((RlpList) outerValues.get(1)).getValues());
+                kzgCommitments = decodeBytesList(((RlpList) outerValues.get(2)).getValues());
+                kzgProofs = decodeBytesList(((RlpList) outerValues.get(3)).getValues());
+                wrapperVersion = null;
+                cellProofs = null;
+            } else {
+                throw new IllegalArgumentException(
+                        "Malformed EIP-4844 network wrapper: expected 4 (EIP-4844) or 5 "
+                                + "(EIP-7594) elements, got "
+                                + size);
+            }
+
+            // Decode access list from inside tx_payload_body (field index 8)
+            final List<RlpType> tvForAL = txPayload.getValues();
+            if (tvForAL.size() <= 8 || !(tvForAL.get(8) instanceof RlpList)) {
+                throw new IllegalArgumentException(
+                        "Malformed EIP-4844 tx_payload_body: missing access list at index 8");
+            }
+            accessList = decodeAccessList(((RlpList) tvForAL.get(8)).getValues());
         } else {
-            txPayload = (RlpList) outerList;
+            // No sidecar — outerList is the tx_payload_body itself
+            txPayload = outerList;
             blobs = null;
             kzgCommitments = null;
             kzgProofs = null;
+            wrapperVersion = null;
+            cellProofs = null;
+            final List<RlpType> tvForAL = txPayload.getValues();
+            if (tvForAL.size() > 8 && tvForAL.get(8) instanceof RlpList) {
+                accessList = decodeAccessList(((RlpList) tvForAL.get(8)).getValues());
+            } else {
+                accessList = Collections.emptyList();
+            }
         }
 
-        // Decode the transaction payload
+        // Decode the transaction payload fields
         final List<RlpType> txValues = txPayload.getValues();
+        if (txValues.size() < 11) {
+            throw new IllegalArgumentException(
+                    "Malformed EIP-4844 tx_payload_body: expected at least 11 fields, got "
+                            + txValues.size());
+        }
 
         final long chainId = ((RlpString) txValues.get(0)).asPositiveBigInteger().longValue();
         final BigInteger nonce = ((RlpString) txValues.get(1)).asPositiveBigInteger();
@@ -153,28 +227,53 @@ public class TransactionDecoder {
         final String to = ((RlpString) txValues.get(5)).asString();
         final BigInteger value = ((RlpString) txValues.get(6)).asPositiveBigInteger();
         final String data = ((RlpString) txValues.get(7)).asString();
+        // index 8 = access list (already decoded above)
         final BigInteger maxFeePerBlobGas = ((RlpString) txValues.get(9)).asPositiveBigInteger();
         final List<Bytes> versionedHashes =
                 decodeVersionedHashes(((RlpList) txValues.get(10)).getValues());
 
-        // Create the raw transaction object
-        final RawTransaction rawTransaction =
-                RawTransaction.createTransaction(
-                        blobs,
-                        kzgCommitments,
-                        kzgProofs,
-                        chainId,
-                        nonce,
-                        maxPriorityFeePerGas,
-                        maxFeePerGas,
-                        gasLimit,
-                        to,
-                        value,
-                        data,
-                        maxFeePerBlobGas,
-                        versionedHashes);
+        // Reconstruct the RawTransaction object
+        final RawTransaction rawTransaction;
+        if (wrapperVersion != null) {
+            // EIP-7594 path
+            rawTransaction =
+                    RawTransaction.createTransaction(
+                            blobs,
+                            kzgCommitments,
+                            cellProofs,
+                            wrapperVersion,
+                            chainId,
+                            nonce,
+                            maxPriorityFeePerGas,
+                            maxFeePerGas,
+                            gasLimit,
+                            to,
+                            value,
+                            data,
+                            maxFeePerBlobGas,
+                            versionedHashes,
+                            accessList);
+        } else {
+            // EIP-4844 path (with or without sidecar)
+            rawTransaction =
+                    RawTransaction.createTransaction(
+                            blobs,
+                            kzgCommitments,
+                            kzgProofs,
+                            chainId,
+                            nonce,
+                            maxPriorityFeePerGas,
+                            maxFeePerGas,
+                            gasLimit,
+                            to,
+                            value,
+                            data,
+                            maxFeePerBlobGas,
+                            versionedHashes,
+                            accessList);
+        }
 
-        // Handle signature if present
+        // Handle signature if present (fields 11, 12, 13 = y_parity, r, s)
         if (txValues.size() > UNSIGNED_EIP4844TX_RLP_LIST_SIZE) {
             final byte[] v =
                     Sign.getVFromRecId(
@@ -194,14 +293,29 @@ public class TransactionDecoder {
 
     private static List<Blob> decodeBlobs(List<RlpType> rlpBlobs) {
         return rlpBlobs.stream()
-                .map(r -> new Blob(((RlpString) r).getBytes()))
+                .map(
+                        r -> {
+                            if (!(r instanceof RlpString)) {
+                                throw new IllegalArgumentException(
+                                        "Malformed blob entry: expected RlpString");
+                            }
+                            return new Blob(((RlpString) r).getBytes());
+                        })
                 .collect(Collectors.toList());
     }
 
-    // Decoding logic for commitments and proofs
+    // Decoding logic for commitments, proofs, and EIP-7594 flat cell_proofs
     private static List<Bytes> decodeBytesList(List<RlpType> rlpBytesList) {
         return rlpBytesList.stream()
-                .map(r -> Bytes.wrap(((RlpString) r).getBytes()))
+                .map(
+                        r -> {
+                            if (!(r instanceof RlpString)) {
+                                throw new IllegalArgumentException(
+                                        "Malformed bytes list: expected RlpString, got "
+                                                + r.getClass().getSimpleName());
+                            }
+                            return Bytes.wrap(((RlpString) r).getBytes());
+                        })
                 .collect(Collectors.toList());
     }
 

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -108,6 +108,16 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         this.kzgProofs = Optional.empty();
         this.wrapperVersion = Optional.ofNullable(wrapperVersion);
         this.cellProofs = Optional.ofNullable(cellProofs);
+
+        if (this.blobs.isPresent()
+                && this.kzgCommitments.isPresent()
+                && this.cellProofs.isPresent()) {
+            if (this.blobs.get().size() != this.kzgCommitments.get().size()
+                    || this.blobs.get().size() != this.cellProofs.get().size()) {
+                throw new IllegalArgumentException(
+                        "Number of blobs, commitments, and cell proofs must match");
+            }
+        }
     }
 
     protected Transaction4844(

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -35,8 +35,10 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
     private final BigInteger maxFeePerBlobGas;
     private final List<Bytes> versionedHashes;
     private final Optional<List<Blob>> blobs;
-    private final Optional<List<Bytes>> kzgProofs;
     private final Optional<List<Bytes>> kzgCommitments;
+    private final Optional<List<Bytes>> kzgProofs;
+    private final Optional<BigInteger> wrapperVersion;
+    private final Optional<List<List<Bytes>>> cellProofs;
 
     protected Transaction4844(
             long chainId,
@@ -55,6 +57,8 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         this.blobs = Optional.empty();
         this.kzgCommitments = Optional.empty();
         this.kzgProofs = Optional.empty();
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
     }
 
     protected Transaction4844(
@@ -77,6 +81,33 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         this.blobs = Optional.ofNullable(blobs);
         this.kzgCommitments = Optional.ofNullable(kzgCommitments);
         this.kzgProofs = Optional.ofNullable(kzgProofs);
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
+    }
+
+    protected Transaction4844(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<List<Bytes>> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes) {
+        super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+        this.maxFeePerBlobGas = maxFeePerBlobGas;
+        this.versionedHashes = versionedHashes;
+        this.blobs = Optional.ofNullable(blobs);
+        this.kzgCommitments = Optional.ofNullable(kzgCommitments);
+        this.kzgProofs = Optional.empty();
+        this.wrapperVersion = Optional.ofNullable(wrapperVersion);
+        this.cellProofs = Optional.ofNullable(cellProofs);
     }
 
     protected Transaction4844(
@@ -115,6 +146,8 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 this.kzgCommitments.get().stream()
                         .map(BlobUtils::kzgToVersionedHash)
                         .collect(Collectors.toList());
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
     }
 
     @Override
@@ -158,9 +191,17 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             result.add(new RlpList(resultTx));
 
             // Adding blobs, commitments, and proofs
-            result.add(new RlpList(getRlpBlobs()));
-            result.add(new RlpList(getRlpKzgCommitments()));
-            result.add(new RlpList(getRlpKzgProofs()));
+            // Adding blobs, commitments, and proofs
+            if (wrapperVersion.isPresent()) {
+                result.add(RlpString.create(wrapperVersion.get()));
+                result.add(new RlpList(getRlpBlobs()));
+                result.add(new RlpList(getRlpKzgCommitments()));
+                result.add(new RlpList(getRlpCellProofs()));
+            } else {
+                result.add(new RlpList(getRlpBlobs()));
+                result.add(new RlpList(getRlpKzgCommitments()));
+                result.add(new RlpList(getRlpKzgProofs()));
+            }
 
             return result;
         } else {
@@ -188,6 +229,39 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 blobs,
                 kzgCommitments,
                 kzgProofs,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes);
+    }
+
+    public static Transaction4844 createOsakaTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<List<Bytes>> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes) {
+
+        return new Transaction4844(
+                blobs,
+                kzgCommitments,
+                cellProofs,
+                wrapperVersion,
                 chainId,
                 nonce,
                 maxPriorityFeePerGas,
@@ -270,6 +344,14 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         return versionedHashes;
     }
 
+    public Optional<BigInteger> getWrapperVersion() {
+        return wrapperVersion;
+    }
+
+    public Optional<List<List<Bytes>>> getCellProofs() {
+        return cellProofs;
+    }
+
     public List<RlpType> getRlpVersionedHashes() {
         return versionedHashes.stream()
                 .map(hash -> RlpString.create(hash.toArray()))
@@ -301,6 +383,28 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                         blobList ->
                                 blobList.stream()
                                         .map(blob -> RlpString.create(blob.getData().toArray()))
+                                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    public List<RlpType> getRlpCellProofs() {
+        return cellProofs
+                .<List<RlpType>>map(
+                        outerList ->
+                                outerList.stream()
+                                        .map(
+                                                innerList ->
+                                                        new RlpList(
+                                                                innerList.stream()
+                                                                        .map(
+                                                                                bytes ->
+                                                                                        RlpString
+                                                                                                .create(
+                                                                                                        bytes
+                                                                                                                .toArray()))
+                                                                        .collect(
+                                                                                Collectors
+                                                                                        .toList())))
                                         .collect(Collectors.toList()))
                 .orElse(Collections.emptyList());
     }

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -16,12 +16,14 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.tuweni.bytes.Bytes;
 
+import org.web3j.crypto.AccessListObject;
 import org.web3j.crypto.Blob;
 import org.web3j.crypto.BlobUtils;
 import org.web3j.crypto.Sign;
@@ -30,14 +32,53 @@ import org.web3j.rlp.RlpString;
 import org.web3j.rlp.RlpType;
 import org.web3j.utils.Numeric;
 
+/**
+ * EIP-4844 blob transaction (also extended for EIP-7594 / Fusaka PeerDAS).
+ *
+ * <p>Wire format variants:
+ *
+ * <ul>
+ *   <li>EIP-4844 network wrapper (Cancun/Prague): {@code rlp([tx_payload_body, blobs, commitments,
+ *       proofs])}
+ *   <li>EIP-7594 network wrapper (Fusaka/Osaka): {@code rlp([tx_payload_body, wrapper_version,
+ *       blobs, commitments, cell_proofs])}
+ * </ul>
+ *
+ * <p>EIP-7594 cell_proofs is a <strong>flat</strong> list of {@code CELLS_PER_EXT_BLOB ×
+ * len(blobs)} 48-byte KZG proofs. {@code CELLS_PER_EXT_BLOB = 128}
+ * (FIELD_ELEMENTS_PER_EXT_BLOB=8192 / FIELD_ELEMENTS_PER_CELL=64).
+ */
 public class Transaction4844 extends Transaction1559 implements ITransaction {
+
+    /** Number of cells in an extended blob (EIP-7594 / PeerDAS). */
+    public static final int CELLS_PER_EXT_BLOB = 128;
+
+    /** Expected byte length of each KZG proof / commitment (G1 compressed point). */
+    public static final int KZG_PROOF_BYTE_LENGTH = 48;
+
+    /** Only supported wrapper_version value per EIP-7594. */
+    public static final BigInteger WRAPPER_VERSION_1 = BigInteger.ONE;
+
+    /** Maximum number of blobs per transaction (EIP-7594 spec requirement). */
+    public static final int MAX_BLOBS_PER_TRANSACTION = 6;
 
     private final BigInteger maxFeePerBlobGas;
     private final List<Bytes> versionedHashes;
     private final Optional<List<Blob>> blobs;
-    private final Optional<List<Bytes>> kzgProofs;
     private final Optional<List<Bytes>> kzgCommitments;
 
+    // EIP-4844: one proof per blob
+    private final Optional<List<Bytes>> kzgProofs;
+
+    // EIP-7594: flat list of CELLS_PER_EXT_BLOB proofs per blob
+    private final Optional<List<Bytes>> cellProofs;
+
+    // Present only for EIP-7594 wrappers
+    private final Optional<BigInteger> wrapperVersion;
+
+    // -------------------------------------------------------------------------
+    // Constructor 1: unsigned tx-only (no sidecar) — used by RPC callers
+    // -------------------------------------------------------------------------
     protected Transaction4844(
             long chainId,
             BigInteger nonce,
@@ -50,13 +91,21 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
         super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
-        this.maxFeePerBlobGas = maxFeePerBlobGas;
-        this.versionedHashes = versionedHashes;
+        this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
+        this.versionedHashes =
+                Collections.unmodifiableList(
+                        Objects.requireNonNull(versionedHashes, "versionedHashes"));
         this.blobs = Optional.empty();
         this.kzgCommitments = Optional.empty();
         this.kzgProofs = Optional.empty();
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
     }
 
+    // -------------------------------------------------------------------------
+    // Constructor 2: EIP-4844 network wrapper (Cancun/Prague)
+    //   blobs + kzgCommitments + kzgProofs (one proof per blob)
+    // -------------------------------------------------------------------------
     protected Transaction4844(
             List<Blob> blobs,
             List<Bytes> kzgCommitments,
@@ -72,13 +121,65 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
         super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
-        this.maxFeePerBlobGas = maxFeePerBlobGas;
-        this.versionedHashes = versionedHashes;
+        this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
+        this.versionedHashes =
+                Collections.unmodifiableList(
+                        Objects.requireNonNull(versionedHashes, "versionedHashes"));
         this.blobs = Optional.ofNullable(blobs);
         this.kzgCommitments = Optional.ofNullable(kzgCommitments);
         this.kzgProofs = Optional.ofNullable(kzgProofs);
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
+
+        validateEip4844Sidecar();
     }
 
+    // -------------------------------------------------------------------------
+    // Constructor 3: EIP-7594 network wrapper (Fusaka/Osaka)
+    //   blobs + kzgCommitments + cellProofs (flat, 128×N proofs) + wrapperVersion
+    // -------------------------------------------------------------------------
+    protected Transaction4844(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
+        super(
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                accessList != null ? accessList : Collections.emptyList());
+        this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
+        this.versionedHashes =
+                Collections.unmodifiableList(
+                        Objects.requireNonNull(versionedHashes, "versionedHashes"));
+        this.blobs = Optional.ofNullable(blobs);
+        this.kzgCommitments = Optional.ofNullable(kzgCommitments);
+        this.kzgProofs = Optional.empty(); // EIP-7594 does not use per-blob kzgProofs
+        this.wrapperVersion = Optional.ofNullable(wrapperVersion);
+        this.cellProofs = Optional.ofNullable(cellProofs);
+
+        validateEip7594Sidecar();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor 4: auto-compute commitments + proofs from raw blobs (EIP-4844)
+    // -------------------------------------------------------------------------
     protected Transaction4844(
             List<Blob> blobsData,
             long chainId,
@@ -91,15 +192,17 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             String data,
             BigInteger maxFeePerBlobGas) {
         super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
-        this.maxFeePerBlobGas = maxFeePerBlobGas;
-        this.blobs = Optional.ofNullable(blobsData);
+        this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
 
-        assert blobsData != null;
-        this.kzgCommitments =
-                Optional.of(
-                        blobsData.stream()
-                                .map(BlobUtils::getCommitment)
-                                .collect(Collectors.toList()));
+        if (blobsData == null) {
+            throw new IllegalArgumentException("blobsData must not be null");
+        }
+
+        this.blobs = Optional.of(blobsData);
+
+        List<Bytes> commitments =
+                blobsData.stream().map(BlobUtils::getCommitment).collect(Collectors.toList());
+        this.kzgCommitments = Optional.of(commitments);
 
         this.kzgProofs =
                 Optional.of(
@@ -107,68 +210,255 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                                 .mapToObj(
                                         i ->
                                                 BlobUtils.getProof(
-                                                        blobsData.get(i),
-                                                        this.kzgCommitments.get().get(i)))
+                                                        blobsData.get(i), commitments.get(i)))
                                 .collect(Collectors.toList()));
 
         this.versionedHashes =
-                this.kzgCommitments.get().stream()
+                commitments.stream()
                         .map(BlobUtils::kzgToVersionedHash)
                         .collect(Collectors.toList());
+
+        this.wrapperVersion = Optional.empty();
+        this.cellProofs = Optional.empty();
     }
 
+    // =========================================================================
+    // Validation helpers
+    // =========================================================================
+
+    private void validateEip4844Sidecar() {
+        if (!blobs.isPresent() || !kzgCommitments.isPresent() || !kzgProofs.isPresent()) {
+            return; // partial construction allowed (some fields may be absent)
+        }
+        int blobCount = blobs.get().size();
+        if (kzgCommitments.get().size() != blobCount) {
+            throw new IllegalArgumentException(
+                    "EIP-4844: kzgCommitments count ("
+                            + kzgCommitments.get().size()
+                            + ") must equal blob count ("
+                            + blobCount
+                            + ")");
+        }
+        if (kzgProofs.get().size() != blobCount) {
+            throw new IllegalArgumentException(
+                    "EIP-4844: kzgProofs count ("
+                            + kzgProofs.get().size()
+                            + ") must equal blob count ("
+                            + blobCount
+                            + ")");
+        }
+        validateProofByteLengths(kzgProofs.get(), "kzgProofs");
+        validateCommitmentByteLengths(kzgCommitments.get());
+    }
+
+    private void validateEip7594Sidecar() {
+        // wrapper_version must be 1
+        if (wrapperVersion.isPresent() && !WRAPPER_VERSION_1.equals(wrapperVersion.get())) {
+            throw new IllegalArgumentException(
+                    "EIP-7594: unsupported wrapper_version "
+                            + wrapperVersion.get()
+                            + ". Only version 1 is supported.");
+        }
+
+        if (!blobs.isPresent() || !kzgCommitments.isPresent() || !cellProofs.isPresent()) {
+            return;
+        }
+
+        int blobCount = blobs.get().size();
+        validateBlobCount(blobCount);
+
+        if (kzgCommitments.get().size() != blobCount) {
+            throw new IllegalArgumentException(
+                    "EIP-7594: kzgCommitments count ("
+                            + kzgCommitments.get().size()
+                            + ") must equal blob count ("
+                            + blobCount
+                            + ")");
+        }
+
+        // cell_proofs must be a flat list of exactly CELLS_PER_EXT_BLOB * blobCount entries
+        int expectedProofCount = CELLS_PER_EXT_BLOB * blobCount;
+        if (cellProofs.get().size() != expectedProofCount) {
+            throw new IllegalArgumentException(
+                    "EIP-7594: cell_proofs count ("
+                            + cellProofs.get().size()
+                            + ") must equal CELLS_PER_EXT_BLOB * blobCount = "
+                            + expectedProofCount);
+        }
+
+        validateProofByteLengths(cellProofs.get(), "cellProofs");
+        validateCommitmentByteLengths(kzgCommitments.get());
+    }
+
+    private static void validateBlobCount(int blobCount) {
+        if (blobCount > MAX_BLOBS_PER_TRANSACTION) {
+            throw new IllegalArgumentException(
+                    "Blob count ("
+                            + blobCount
+                            + ") exceeds MAX_BLOBS_PER_TRANSACTION ("
+                            + MAX_BLOBS_PER_TRANSACTION
+                            + ")");
+        }
+    }
+
+    private static void validateProofByteLengths(List<Bytes> proofs, String fieldName) {
+        for (int i = 0; i < proofs.size(); i++) {
+            if (proofs.get(i).size() != KZG_PROOF_BYTE_LENGTH) {
+                throw new IllegalArgumentException(
+                        fieldName
+                                + "["
+                                + i
+                                + "] must be "
+                                + KZG_PROOF_BYTE_LENGTH
+                                + " bytes (G1 compressed point), got "
+                                + proofs.get(i).size());
+            }
+        }
+    }
+
+    private static void validateCommitmentByteLengths(List<Bytes> commitments) {
+        for (int i = 0; i < commitments.size(); i++) {
+            if (commitments.get(i).size() != KZG_PROOF_BYTE_LENGTH) {
+                throw new IllegalArgumentException(
+                        "kzgCommitments["
+                                + i
+                                + "] must be "
+                                + KZG_PROOF_BYTE_LENGTH
+                                + " bytes (G1 compressed point), got "
+                                + commitments.get(i).size());
+            }
+        }
+    }
+
+    // =========================================================================
+    // RLP serialization
+    //
+    // asRlpValues(signatureData) — produces the SIGNING payload (tx_payload_body).
+    //   - signatureData == null  →  unsigned fields for hash-signing
+    //   - signatureData != null  →  signed fields (with v, r, s) for tx_payload_body
+    //
+    // asNetworkRlpValues(signatureData) — produces the full NETWORK WRAPPER for P2P gossip:
+    //   EIP-4844: rlp([tx_payload_body, blobs, commitments, proofs])
+    //   EIP-7594: rlp([tx_payload_body, wrapper_version, blobs, commitments, cell_proofs])
+    //
+    // TransactionEncoder.signMessage() calls:
+    //   1. encode4844(tx)          → asRlpValues(null)         → hash-signing payload
+    //   2. encode(tx, sigData)     → asRlpValues(sigData)      → full signed network wrapper
+    //       (which internally delegates to asNetworkRlpValues when sidecar present)
+    // =========================================================================
+
+    /**
+     * Returns the RLP field list for the transaction payload body only (tx_payload_body). When
+     * signatureData is not null, includes v/r/s and then delegates to {@link
+     * #buildNetworkWrapper(Sign.SignatureData)} to append the blob sidecar.
+     */
     @Override
     public List<RlpType> asRlpValues(Sign.SignatureData signatureData) {
-        List<RlpType> resultTx = new ArrayList<>();
+        List<RlpType> txPayloadBody = buildTxPayloadBody(signatureData);
 
-        resultTx.add(RlpString.create(getChainId()));
-        resultTx.add(RlpString.create(getNonce()));
-        resultTx.add(RlpString.create(getMaxPriorityFeePerGas()));
-        resultTx.add(RlpString.create(getMaxFeePerGas()));
-        resultTx.add(RlpString.create(getGasLimit()));
+        if (signatureData != null && hasAnySidecar()) {
+            // Produce the full network wrapper as a flat list so TransactionEncoder
+            // wraps it in a single RlpList → 0x03 || rlp([...])
+            return buildNetworkWrapper(signatureData);
+        }
+
+        return txPayloadBody;
+    }
+
+    /**
+     * Builds tx_payload_body: the 11 unsigned fields (+ optional v/r/s when signing). This is also
+     * the hash-signing input when signatureData is null.
+     */
+    private List<RlpType> buildTxPayloadBody(Sign.SignatureData signatureData) {
+        List<RlpType> result = new ArrayList<>();
+
+        result.add(RlpString.create(getChainId()));
+        result.add(RlpString.create(getNonce()));
+        result.add(RlpString.create(getMaxPriorityFeePerGas()));
+        result.add(RlpString.create(getMaxFeePerGas()));
+        result.add(RlpString.create(getGasLimit()));
 
         String to = getTo();
         if (to != null && to.length() > 0) {
-            resultTx.add(RlpString.create(Numeric.hexStringToByteArray(to)));
+            result.add(RlpString.create(Numeric.hexStringToByteArray(to)));
         } else {
-            resultTx.add(RlpString.create(""));
+            result.add(RlpString.create(""));
         }
 
-        resultTx.add(RlpString.create(getValue()));
-        byte[] data = Numeric.hexStringToByteArray(getData());
-        resultTx.add(RlpString.create(data));
+        result.add(RlpString.create(getValue()));
+        result.add(RlpString.create(Numeric.hexStringToByteArray(getData())));
 
-        // access list
-        resultTx.add(new RlpList(rlpAccessListRlp()));
+        // access list (field index 8)
+        result.add(new RlpList(rlpAccessListRlp()));
 
-        // Blob Transaction: max_fee_per_blob_gas and versioned_hashes
-        resultTx.add(RlpString.create(getMaxFeePerBlobGas()));
-        resultTx.add(new RlpList(getRlpVersionedHashes()));
+        // max_fee_per_blob_gas (field index 9)
+        result.add(RlpString.create(getMaxFeePerBlobGas()));
+        // blob_versioned_hashes (field index 10)
+        result.add(new RlpList(getRlpVersionedHashes()));
 
         if (signatureData != null) {
-            resultTx.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
-            resultTx.add(
+            result.add(RlpString.create(Sign.getRecId(signatureData, getChainId())));
+            result.add(
                     RlpString.create(
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getR())));
-            resultTx.add(
+            result.add(
                     RlpString.create(
                             org.web3j.utils.Bytes.trimLeadingZeroes(signatureData.getS())));
-
-            List<RlpType> result = new ArrayList<>();
-            result.add(new RlpList(resultTx));
-
-            // Adding blobs, commitments, and proofs
-            result.add(new RlpList(getRlpBlobs()));
-            result.add(new RlpList(getRlpKzgCommitments()));
-            result.add(new RlpList(getRlpKzgProofs()));
-
-            return result;
-        } else {
-            // encoding for signature, blob sidecar cannot be added
-            return resultTx;
         }
+
+        return result;
     }
 
+    /**
+     * Builds the full network wrapper list (for P2P gossip / pooled transactions).
+     *
+     * <p>EIP-4844: {@code [tx_payload_body, blobs, commitments, proofs]} <br>
+     * EIP-7594: {@code [tx_payload_body, wrapper_version, blobs, commitments, cell_proofs]}
+     *
+     * <p>The returned list is the direct content of the top-level RlpList, so TransactionEncoder
+     * will produce: {@code 0x03 || rlp([...])}
+     */
+    private List<RlpType> buildNetworkWrapper(Sign.SignatureData signatureData) {
+        List<RlpType> wrapper = new ArrayList<>();
+        // Element 0: signed tx_payload_body
+        wrapper.add(new RlpList(buildTxPayloadBody(signatureData)));
+
+        if (wrapperVersion.isPresent()) {
+            // EIP-7594 format
+            wrapper.add(RlpString.create(wrapperVersion.get())); // wrapper_version
+            wrapper.add(new RlpList(getRlpBlobs())); // blobs
+            wrapper.add(new RlpList(getRlpKzgCommitments())); // commitments
+            wrapper.add(new RlpList(getRlpCellProofs())); // cell_proofs (flat)
+        } else {
+            // EIP-4844 format
+            wrapper.add(new RlpList(getRlpBlobs()));
+            wrapper.add(new RlpList(getRlpKzgCommitments()));
+            wrapper.add(new RlpList(getRlpKzgProofs()));
+        }
+
+        return wrapper;
+    }
+
+    /** Returns true if this transaction has any blob sidecar attached. */
+    private boolean hasAnySidecar() {
+        return blobs.isPresent()
+                || kzgCommitments.isPresent()
+                || kzgProofs.isPresent()
+                || cellProofs.isPresent();
+    }
+
+    // =========================================================================
+    // Factory methods
+    // =========================================================================
+
+    /**
+     * Create an EIP-4844 transaction with an explicit blob sidecar.
+     *
+     * @param blobs list of blobs (one per versioned hash)
+     * @param kzgCommitments KZG commitments matching blobs
+     * @param kzgProofs one KZG proof per blob
+     * @param versionedHashes blob versioned hashes derived from commitments
+     */
     public static Transaction4844 createTransaction(
             List<Blob> blobs,
             List<Bytes> kzgCommitments,
@@ -183,7 +473,6 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             String data,
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
-
         return new Transaction4844(
                 blobs,
                 kzgCommitments,
@@ -200,6 +489,84 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 versionedHashes);
     }
 
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) transaction with PeerDAS cell proofs.
+     *
+     * @param blobs list of blobs
+     * @param kzgCommitments KZG commitments matching blobs (one per blob)
+     * @param cellProofs flat list of cell proofs: {@code CELLS_PER_EXT_BLOB * len(blobs)} 48-byte
+     *     proofs in blob-major order
+     * @param wrapperVersion must be {@link #WRAPPER_VERSION_1} (BigInteger.ONE)
+     * @param versionedHashes blob versioned hashes derived from commitments
+     */
+    public static Transaction4844 createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes) {
+        return createTransaction(
+                blobs,
+                kzgCommitments,
+                cellProofs,
+                wrapperVersion,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                Collections.emptyList());
+    }
+
+    public static Transaction4844 createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> cellProofs,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
+        return new Transaction4844(
+                blobs,
+                kzgCommitments,
+                cellProofs,
+                wrapperVersion,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                accessList);
+    }
+
+    /** Create a blob transaction with auto-computed commitments/proofs. */
     public static Transaction4844 createTransaction(
             List<Blob> blobs,
             long chainId,
@@ -211,7 +578,6 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             BigInteger value,
             String data,
             BigInteger maxFeePerBlobGas) {
-
         return new Transaction4844(
                 blobs,
                 chainId,
@@ -225,6 +591,7 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 maxFeePerBlobGas);
     }
 
+    /** Create a tx-only EIP-4844 transaction (no sidecar, versioned hashes only). */
     public static Transaction4844 createTransaction(
             long chainId,
             BigInteger nonce,
@@ -236,7 +603,6 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             String data,
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
-
         return new Transaction4844(
                 chainId,
                 nonce,
@@ -250,8 +616,16 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 versionedHashes);
     }
 
+    // =========================================================================
+    // Accessors
+    // =========================================================================
+
     public BigInteger getMaxFeePerBlobGas() {
         return maxFeePerBlobGas;
+    }
+
+    public List<Bytes> getVersionedHashes() {
+        return versionedHashes;
     }
 
     public Optional<List<Blob>> getBlobs() {
@@ -266,9 +640,21 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         return kzgProofs;
     }
 
-    public List<Bytes> getVersionedHashes() {
-        return versionedHashes;
+    public Optional<BigInteger> getWrapperVersion() {
+        return wrapperVersion;
     }
+
+    /**
+     * Returns the flat cell_proofs list for EIP-7594 transactions. Size = {@code CELLS_PER_EXT_BLOB
+     * * len(blobs)} when present.
+     */
+    public Optional<List<Bytes>> getCellProofs() {
+        return cellProofs;
+    }
+
+    // =========================================================================
+    // RLP helpers
+    // =========================================================================
 
     public List<RlpType> getRlpVersionedHashes() {
         return versionedHashes.stream()
@@ -301,6 +687,20 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                         blobList ->
                                 blobList.stream()
                                         .map(blob -> RlpString.create(blob.getData().toArray()))
+                                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    /**
+     * Returns the RLP encoding of cell_proofs as a flat list of RlpStrings. Each element is one
+     * 48-byte proof. EIP-7594 spec: {@code cell_proofs} is a flat list, NOT a list of lists.
+     */
+    public List<RlpType> getRlpCellProofs() {
+        return cellProofs
+                .<List<RlpType>>map(
+                        proofList ->
+                                proofList.stream()
+                                        .map(bytes -> RlpString.create(bytes.toArray()))
                                         .collect(Collectors.toList()))
                 .orElse(Collections.emptyList());
     }

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -120,7 +120,52 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             String data,
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
-        super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+        this(
+                blobs,
+                kzgCommitments,
+                kzgProofs,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                Collections.emptyList());
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor 2b: EIP-4844 network wrapper (Cancun/Prague) with access list
+    //   blobs + kzgCommitments + kzgProofs (one proof per blob) + accessList
+    // -------------------------------------------------------------------------
+    protected Transaction4844(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> kzgProofs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
+        super(
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                accessList != null ? accessList : Collections.emptyList());
         this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
         this.versionedHashes =
                 Collections.unmodifiableList(
@@ -230,7 +275,19 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         if (!blobs.isPresent() || !kzgCommitments.isPresent() || !kzgProofs.isPresent()) {
             return; // partial construction allowed (some fields may be absent)
         }
+        // Note: no per-transaction blob-count cap on the EIP-4844 path. EIP-4844 only defines a
+        // block-level limit (MAX_BLOBS_PER_BLOCK, fork-dependent: 6 at Cancun, 9 at Prague), not a
+        // per-tx count. The 6-blob per-transaction cap is EIP-7594-specific
+        // (validateEip7594Sidecar).
         int blobCount = blobs.get().size();
+        if (versionedHashes.size() != blobCount) {
+            throw new IllegalArgumentException(
+                    "EIP-4844: versionedHashes count ("
+                            + versionedHashes.size()
+                            + ") must equal blob count ("
+                            + blobCount
+                            + ")");
+        }
         if (kzgCommitments.get().size() != blobCount) {
             throw new IllegalArgumentException(
                     "EIP-4844: kzgCommitments count ("
@@ -266,6 +323,15 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
 
         int blobCount = blobs.get().size();
         validateBlobCount(blobCount);
+
+        if (versionedHashes.size() != blobCount) {
+            throw new IllegalArgumentException(
+                    "EIP-7594: versionedHashes count ("
+                            + versionedHashes.size()
+                            + ") must equal blob count ("
+                            + blobCount
+                            + ")");
+        }
 
         if (kzgCommitments.get().size() != blobCount) {
             throw new IllegalArgumentException(
@@ -473,6 +539,47 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
             String data,
             BigInteger maxFeePerBlobGas,
             List<Bytes> versionedHashes) {
+        return createTransaction(
+                blobs,
+                kzgCommitments,
+                kzgProofs,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                versionedHashes,
+                Collections.emptyList());
+    }
+
+    /**
+     * Create an EIP-4844 transaction with an explicit blob sidecar and access list.
+     *
+     * @param blobs list of blobs (one per versioned hash)
+     * @param kzgCommitments KZG commitments matching blobs
+     * @param kzgProofs one KZG proof per blob
+     * @param versionedHashes blob versioned hashes derived from commitments
+     * @param accessList optional EIP-2930 access list
+     */
+    public static Transaction4844 createTransaction(
+            List<Blob> blobs,
+            List<Bytes> kzgCommitments,
+            List<Bytes> kzgProofs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<Bytes> versionedHashes,
+            List<AccessListObject> accessList) {
         return new Transaction4844(
                 blobs,
                 kzgCommitments,
@@ -486,7 +593,8 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 value,
                 data,
                 maxFeePerBlobGas,
-                versionedHashes);
+                versionedHashes,
+                accessList);
     }
 
     /**

--- a/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
@@ -78,4 +78,34 @@ public class Eip7594TransactionTest {
         assertTrue(decoded4844.getKzgCommitments().isPresent());
         assertEquals(1, decoded4844.getKzgCommitments().get().size());
     }
+
+    @Test
+    public void testInvalidOsakaTransactionSize() {
+        List<Blob> blobs = Collections.singletonList(new Blob(new byte[131072]));
+        List<Bytes> kzgCommitments = Collections.singletonList(Bytes.wrap(new byte[48]));
+        // Two lists of proofs for one blob - should fail
+        List<List<Bytes>> cellProofs =
+                Arrays.asList(
+                        Collections.singletonList(Bytes.wrap(new byte[48])),
+                        Collections.singletonList(Bytes.wrap(new byte[48])));
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createOsakaTransaction(
+                                blobs,
+                                kzgCommitments,
+                                cellProofs,
+                                BigInteger.ONE,
+                                1,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                "0x0000000000000000000000000000000000000000",
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                Collections.singletonList(Bytes.wrap(new byte[32]))));
+    }
 }

--- a/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+import org.web3j.crypto.transaction.type.Transaction4844;
+import org.web3j.utils.Numeric;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Eip7594TransactionTest {
+
+    @Test
+    public void testOsakaTransactionEncoding() throws Exception {
+        Credentials credentials =
+                Credentials.create(
+                        "0x45a915e4d060149eb43658c930b24c694a91a91a91a91a91a91a91a91a91a91a");
+
+        List<Blob> blobs = Collections.singletonList(new Blob(new byte[131072]));
+        List<Bytes> kzgCommitments = Collections.singletonList(Bytes.wrap(new byte[48]));
+        List<List<Bytes>> cellProofs =
+                Collections.singletonList(
+                        Arrays.asList(Bytes.wrap(new byte[48]), Bytes.wrap(new byte[48])));
+        BigInteger wrapperVersion = BigInteger.ONE;
+
+        RawTransaction rawTransaction =
+                RawTransaction.createOsakaTransaction(
+                        blobs,
+                        kzgCommitments,
+                        cellProofs,
+                        wrapperVersion,
+                        1,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        "0x0000000000000000000000000000000000000000",
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        Collections.singletonList(Bytes.wrap(new byte[32])));
+
+        byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
+        String hexTx = Numeric.toHexString(signedMessage);
+
+        RawTransaction decodedTx = TransactionDecoder.decode(hexTx);
+
+        assertTrue(decodedTx.getTransaction() instanceof Transaction4844);
+        Transaction4844 decoded4844 = (Transaction4844) decodedTx.getTransaction();
+
+        assertTrue(decoded4844.getWrapperVersion().isPresent());
+        assertEquals(wrapperVersion, decoded4844.getWrapperVersion().get());
+        assertTrue(decoded4844.getCellProofs().isPresent());
+        assertEquals(1, decoded4844.getCellProofs().get().size());
+        assertEquals(2, decoded4844.getCellProofs().get().get(0).size());
+
+        // Verify blobs and commitments
+        assertTrue(decoded4844.getBlobs().isPresent());
+        assertEquals(1, decoded4844.getBlobs().get().size());
+        assertTrue(decoded4844.getKzgCommitments().isPresent());
+        assertEquals(1, decoded4844.getKzgCommitments().get().size());
+    }
+}

--- a/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
@@ -1,0 +1,795 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.crypto;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+import org.web3j.crypto.transaction.type.Transaction4844;
+import org.web3j.utils.Numeric;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Production-grade test suite for EIP-7594 (PeerDAS / Fusaka) blob transaction support.
+ *
+ * <p>Covers:
+ *
+ * <ul>
+ *   <li>Spec-compliant flat cell_proofs encoding/decoding round-trip
+ *   <li>CELLS_PER_EXT_BLOB = 128 proofs per blob validation
+ *   <li>wrapper_version == 1 enforcement
+ *   <li>Proof and commitment byte-length (48 bytes) enforcement
+ *   <li>Multi-blob EIP-7594 transaction
+ *   <li>Access list round-trip preservation
+ *   <li>EIP-4844 backward compatibility (no regression)
+ *   <li>Decoder rejection of malformed payloads
+ *   <li>Signing payload isolation (tx hash not contaminated by sidecar)
+ * </ul>
+ */
+public class Eip7594TransactionTest {
+
+    private static final String PRIVATE_KEY =
+            "0x45a915e4d060149eb43658c930b24c694a91a91a91a91a91a91a91a91a91a91a";
+
+    private static final String TO_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+    private static final int CELLS_PER_EXT_BLOB = Transaction4844.CELLS_PER_EXT_BLOB; // 128
+    private static final int PROOF_BYTES = Transaction4844.KZG_PROOF_BYTE_LENGTH; // 48
+
+    // =========================================================================
+    // Helper builders
+    // =========================================================================
+
+    /**
+     * Creates a list of N zero-filled 48-byte proofs (structurally valid, not cryptographically).
+     */
+    private static List<Bytes> makeProofs(int count) {
+        List<Bytes> proofs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            proofs.add(Bytes.wrap(new byte[PROOF_BYTES]));
+        }
+        return proofs;
+    }
+
+    /** Creates a single blob filled with zeros. */
+    private static Blob zeroBlob() {
+        return new Blob(new byte[131072]);
+    }
+
+    /** Creates N zero blobs. */
+    private static List<Blob> blobs(int n) {
+        List<Blob> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) list.add(zeroBlob());
+        return list;
+    }
+
+    /** Creates N 48-byte commitments. */
+    private static List<Bytes> commitments(int n) {
+        List<Bytes> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) list.add(Bytes.wrap(new byte[PROOF_BYTES]));
+        return list;
+    }
+
+    /** Creates N 32-byte versioned hashes. */
+    private static List<Bytes> versionedHashes(int n) {
+        List<Bytes> list = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) list.add(Bytes.wrap(new byte[32]));
+        return list;
+    }
+
+    // =========================================================================
+    // 1. Core encode/decode round-trip — single blob
+    // =========================================================================
+
+    @Test
+    public void testSingleBlobOsakaRoundTrip() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        int blobCount = 1;
+        List<Blob> blobs = blobs(blobCount);
+        List<Bytes> kzgCommitments = commitments(blobCount);
+        // EIP-7594: FLAT list of CELLS_PER_EXT_BLOB * blobCount proofs
+        List<Bytes> cellProofs = makeProofs(CELLS_PER_EXT_BLOB * blobCount);
+
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs,
+                        kzgCommitments,
+                        cellProofs,
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount));
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+
+        assertTrue(decoded.getTransaction() instanceof Transaction4844);
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+
+        // Verify EIP-7594 fields
+        assertTrue(tx.getWrapperVersion().isPresent(), "wrapperVersion must be present");
+        assertEquals(BigInteger.ONE, tx.getWrapperVersion().get());
+
+        assertTrue(tx.getCellProofs().isPresent(), "cellProofs must be present");
+        assertEquals(
+                CELLS_PER_EXT_BLOB,
+                tx.getCellProofs().get().size(),
+                "cell_proofs must be a flat list of CELLS_PER_EXT_BLOB entries");
+
+        // Each proof must be 48 bytes
+        for (Bytes proof : tx.getCellProofs().get()) {
+            assertEquals(PROOF_BYTES, proof.size(), "each cell proof must be 48 bytes");
+        }
+
+        // EIP-4844 kzgProofs must be absent
+        assertFalse(
+                tx.getKzgProofs().isPresent() && !tx.getKzgProofs().get().isEmpty(),
+                "EIP-7594 tx must not carry kzgProofs");
+
+        // Blobs and commitments
+        assertTrue(tx.getBlobs().isPresent());
+        assertEquals(blobCount, tx.getBlobs().get().size());
+        assertTrue(tx.getKzgCommitments().isPresent());
+        assertEquals(blobCount, tx.getKzgCommitments().get().size());
+    }
+
+    // =========================================================================
+    // 2. Multi-blob EIP-7594 transaction (3 blobs = 384 cell proofs)
+    // =========================================================================
+
+    @Test
+    public void testMultiBlobOsakaRoundTrip() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        int blobCount = 3;
+        List<Bytes> cellProofs = makeProofs(CELLS_PER_EXT_BLOB * blobCount); // 384
+
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        cellProofs,
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ONE,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount));
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        assertEquals(
+                CELLS_PER_EXT_BLOB * blobCount,
+                tx.getCellProofs().get().size(),
+                "3-blob tx must have 384 cell proofs");
+        assertEquals(blobCount, tx.getBlobs().get().size());
+        assertEquals(blobCount, tx.getKzgCommitments().get().size());
+    }
+
+    // =========================================================================
+    // 3. Access list round-trip preservation
+    // =========================================================================
+
+    @Test
+    public void testAccessListPreservation() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        List<AccessListObject> accessList =
+                Collections.singletonList(
+                        new AccessListObject(
+                                "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
+                                Collections.singletonList(
+                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
+
+        int blobCount = 1;
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        makeProofs(CELLS_PER_EXT_BLOB),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount),
+                        accessList);
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+        // Access list round-trip is preserved (non-empty tx body has access list)
+        // The decoded tx should be signed
+        assertTrue(decoded instanceof SignedRawTransaction);
+    }
+
+    // =========================================================================
+    // 4. Signing payload isolation — EIP-7594 sidecar must NOT affect tx hash
+    // =========================================================================
+
+    @Test
+    public void testSigningPayloadExcludesSidecar() {
+        // Two transactions: one with sidecar, one without (versioned hashes only).
+        // The signing payload (encode4844 output) must be identical since the
+        // tx_payload_body fields are the same.
+        List<Bytes> vh = versionedHashes(1);
+
+        RawTransaction txNoSidecar =
+                RawTransaction.createTransaction(
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        vh);
+
+        RawTransaction txWithSidecar =
+                RawTransaction.createTransaction(
+                        blobs(1),
+                        commitments(1),
+                        makeProofs(CELLS_PER_EXT_BLOB),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        vh);
+
+        // encode4844 gives the signing payload (no sidecar)
+        byte[] payloadNoSidecar = TransactionEncoder.encode4844(txNoSidecar);
+        byte[] payloadWithSidecar = TransactionEncoder.encode4844(txWithSidecar);
+
+        assertArrayEquals(
+                payloadNoSidecar,
+                payloadWithSidecar,
+                "Signing payload must be identical regardless of sidecar presence");
+    }
+
+    // =========================================================================
+    // 5. EIP-4844 backward compatibility round-trip
+    // =========================================================================
+
+    @Test
+    public void testEip4844BackwardCompatibilityRoundTrip() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        int blobCount = 2;
+        // EIP-4844: one proof per blob (not per cell)
+        List<Bytes> kzgProofs = makeProofs(blobCount);
+
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        kzgProofs,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount));
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+
+        assertTrue(decoded.getTransaction() instanceof Transaction4844);
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+
+        // EIP-4844: wrapperVersion and cellProofs must be absent
+        assertFalse(tx.getWrapperVersion().isPresent(), "EIP-4844 must not have wrapperVersion");
+        assertFalse(
+                tx.getCellProofs().isPresent() && !tx.getCellProofs().get().isEmpty(),
+                "EIP-4844 must not have cellProofs");
+
+        // kzgProofs must be present with one proof per blob
+        assertTrue(tx.getKzgProofs().isPresent());
+        assertEquals(blobCount, tx.getKzgProofs().get().size());
+        assertEquals(blobCount, tx.getBlobs().get().size());
+        assertEquals(blobCount, tx.getKzgCommitments().get().size());
+    }
+
+    // =========================================================================
+    // 6. Validation: wrong wrapper_version rejected
+    // =========================================================================
+
+    @Test
+    public void testInvalidWrapperVersionRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                makeProofs(CELLS_PER_EXT_BLOB),
+                                BigInteger.valueOf(2), // invalid: only 1 is valid
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "wrapper_version != 1 must throw IllegalArgumentException");
+    }
+
+    @Test
+    public void testZeroWrapperVersionRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                makeProofs(CELLS_PER_EXT_BLOB),
+                                BigInteger.ZERO,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)));
+    }
+
+    // =========================================================================
+    // 7. Validation: wrong cell_proofs count rejected
+    // =========================================================================
+
+    @Test
+    public void testTooFewCellProofsRejected() {
+        // 1 blob needs 128 cell proofs; providing 127 must fail
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                makeProofs(CELLS_PER_EXT_BLOB - 1),
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "127 cell proofs for 1 blob must be rejected");
+    }
+
+    @Test
+    public void testTooManyCellProofsRejected() {
+        // 1 blob needs 128 cell proofs; providing 129 must fail
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                makeProofs(CELLS_PER_EXT_BLOB + 1),
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "129 cell proofs for 1 blob must be rejected");
+    }
+
+    @Test
+    public void testWrongCellProofCountMultiBlob() {
+        // 2 blobs need 256 proofs; providing 128 must fail
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(2),
+                                commitments(2),
+                                makeProofs(CELLS_PER_EXT_BLOB), // only 128, need 256
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(2)));
+    }
+
+    // =========================================================================
+    // 8. Validation: proof byte length (48 bytes) enforced
+    // =========================================================================
+
+    @Test
+    public void testProofWrongByteLengthRejected() {
+        // Build 128 proofs but make one 47 bytes
+        List<Bytes> badProofs = makeProofs(CELLS_PER_EXT_BLOB);
+        badProofs.set(0, Bytes.wrap(new byte[47])); // wrong length
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                badProofs,
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "47-byte proof must be rejected");
+    }
+
+    @Test
+    public void testCommitmentWrongByteLengthRejected() {
+        List<Bytes> badCommitments = commitments(1);
+        badCommitments.set(0, Bytes.wrap(new byte[49])); // wrong length
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                badCommitments,
+                                makeProofs(CELLS_PER_EXT_BLOB),
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "49-byte commitment must be rejected");
+    }
+
+    // =========================================================================
+    // 9. Validation: mismatched blobs vs commitments count rejected
+    // =========================================================================
+
+    @Test
+    public void testBlobCommitmentCountMismatchRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(2), // mismatch: 1 blob but 2 commitments
+                                makeProofs(CELLS_PER_EXT_BLOB),
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)));
+    }
+
+    // =========================================================================
+    // 10. Validation: EIP-4844 blobs/commitments/proofs count mismatch
+    // =========================================================================
+
+    @Test
+    public void testEip4844ProofCountMismatchRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(1),
+                                commitments(1),
+                                makeProofs(2), // 2 kzgProofs for 1 blob — mismatch
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(1)),
+                "2 kzgProofs for 1 blob must be rejected");
+    }
+
+    // =========================================================================
+    // 11. Validation: null blobsData explicit rejection
+    // =========================================================================
+
+    @Test
+    public void testNullBlobsDataRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        Transaction4844.createTransaction(
+                                (List<Blob>) null,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN));
+    }
+
+    // =========================================================================
+    // 12. cell_proofs flat structure verified in encoded bytes
+    //     After encoding, decode the raw RLP and verify cell_proofs entries
+    //     are direct RlpString elements (not nested RlpLists)
+    // =========================================================================
+
+    @Test
+    public void testCellProofsAreEncodedAsFlat() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+        int blobCount = 1;
+
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        makeProofs(CELLS_PER_EXT_BLOB),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount));
+
+        byte[] encoded = TransactionEncoder.signMessage(rawTx, credentials);
+        // Strip type byte 0x03
+        byte[] rlpBytes = java.util.Arrays.copyOfRange(encoded, 1, encoded.length);
+        org.web3j.rlp.RlpList outer =
+                (org.web3j.rlp.RlpList)
+                        org.web3j.rlp.RlpDecoder.decode(rlpBytes).getValues().get(0);
+
+        // outer = [tx_payload_body, wrapper_version, blobs, commitments, cell_proofs]
+        assertEquals(5, outer.getValues().size(), "EIP-7594 outer wrapper must have 5 elements");
+
+        org.web3j.rlp.RlpList cellProofsList = (org.web3j.rlp.RlpList) outer.getValues().get(4);
+        assertEquals(
+                CELLS_PER_EXT_BLOB,
+                cellProofsList.getValues().size(),
+                "cell_proofs list must have CELLS_PER_EXT_BLOB entries");
+
+        // Each entry must be an RlpString (flat), NOT an RlpList (nested)
+        for (int i = 0; i < cellProofsList.getValues().size(); i++) {
+            assertTrue(
+                    cellProofsList.getValues().get(i) instanceof org.web3j.rlp.RlpString,
+                    "cell_proofs[" + i + "] must be RlpString (flat), not RlpList (nested)");
+        }
+    }
+
+    // =========================================================================
+    // 13. wrapper_version encoded as single byte 0x01
+    // =========================================================================
+
+    @Test
+    public void testWrapperVersionEncodedCorrectly() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(1),
+                        commitments(1),
+                        makeProofs(CELLS_PER_EXT_BLOB),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(1));
+
+        byte[] encoded = TransactionEncoder.signMessage(rawTx, credentials);
+        byte[] rlpBytes = java.util.Arrays.copyOfRange(encoded, 1, encoded.length);
+        org.web3j.rlp.RlpList outer =
+                (org.web3j.rlp.RlpList)
+                        org.web3j.rlp.RlpDecoder.decode(rlpBytes).getValues().get(0);
+
+        // wrapper_version is at index 1
+        org.web3j.rlp.RlpString wv = (org.web3j.rlp.RlpString) outer.getValues().get(1);
+        assertEquals(
+                BigInteger.ONE,
+                wv.asPositiveBigInteger(),
+                "wrapper_version must decode as BigInteger.ONE");
+        assertEquals(1, wv.getBytes().length, "wrapper_version must be encoded as 1 byte");
+    }
+
+    // =========================================================================
+    // 14. EIP-7594 constants sanity check
+    // =========================================================================
+
+    @Test
+    public void testEip7594ConstantsAreCorrect() {
+        // FIELD_ELEMENTS_PER_EXT_BLOB = 8192, FIELD_ELEMENTS_PER_CELL = 64
+        // CELLS_PER_EXT_BLOB = 8192 / 64 = 128
+        assertEquals(128, Transaction4844.CELLS_PER_EXT_BLOB);
+        assertEquals(48, Transaction4844.KZG_PROOF_BYTE_LENGTH);
+        assertEquals(BigInteger.ONE, Transaction4844.WRAPPER_VERSION_1);
+    }
+
+    // =========================================================================
+    // 15. MAX_BLOBS_PER_TRANSACTION = 6 enforcement (EIP-7594 spec)
+    // =========================================================================
+
+    @Test
+    public void testMaxBlobsPerTransactionEnforced() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        RawTransaction.createTransaction(
+                                blobs(7),
+                                commitments(7),
+                                makeProofs(CELLS_PER_EXT_BLOB * 7),
+                                Transaction4844.WRAPPER_VERSION_1,
+                                1L,
+                                BigInteger.ZERO,
+                                BigInteger.TEN,
+                                BigInteger.TEN,
+                                BigInteger.valueOf(21000),
+                                TO_ADDRESS,
+                                BigInteger.ZERO,
+                                "",
+                                BigInteger.TEN,
+                                versionedHashes(7)),
+                "7 blobs must be rejected (max 6)");
+    }
+
+    @Test
+    public void testSixBlobsAccepted() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(6),
+                        commitments(6),
+                        makeProofs(CELLS_PER_EXT_BLOB * 6),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(6));
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        assertEquals(6, tx.getBlobs().get().size());
+        assertEquals(CELLS_PER_EXT_BLOB * 6, tx.getCellProofs().get().size());
+    }
+
+    // =========================================================================
+    // 16. Access list properly passed in EIP-7594 transactions
+    // =========================================================================
+
+    @Test
+    public void testAccessListPassedThroughInEip7594() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+        List<AccessListObject> accessList =
+                Collections.singletonList(
+                        new AccessListObject(
+                                "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
+                                Collections.singletonList(
+                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
+        int blobCount = 1;
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        makeProofs(CELLS_PER_EXT_BLOB),
+                        Transaction4844.WRAPPER_VERSION_1,
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount),
+                        accessList);
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+        assertTrue(decoded instanceof SignedRawTransaction);
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        assertTrue(tx.getWrapperVersion().isPresent());
+        assertEquals(BigInteger.ONE, tx.getWrapperVersion().get());
+        assertTrue(tx.getCellProofs().isPresent());
+    }
+}

--- a/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
@@ -21,11 +21,16 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 import org.web3j.crypto.transaction.type.Transaction4844;
+import org.web3j.rlp.RlpEncoder;
+import org.web3j.rlp.RlpList;
+import org.web3j.rlp.RlpString;
+import org.web3j.rlp.RlpType;
 import org.web3j.utils.Numeric;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,6 +100,50 @@ public class Eip7594TransactionTest {
         List<Bytes> list = new ArrayList<>(n);
         for (int i = 0; i < n; i++) list.add(Bytes.wrap(new byte[32]));
         return list;
+    }
+
+    /** A sample single-entry access list (one address, one storage key). */
+    private static List<AccessListObject> sampleAccessList() {
+        return Collections.singletonList(
+                new AccessListObject(
+                        "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
+                        Collections.singletonList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000003")));
+    }
+
+    /**
+     * Asserts that a decoded access list matches the expected one. The decoder normalises hex to
+     * lower case (RlpString.asString -> Numeric.toHexString), so addresses/keys are compared
+     * case-insensitively.
+     */
+    private static void assertAccessListEquals(
+            List<AccessListObject> expected, List<AccessListObject> actual) {
+        assertNotNull(actual, "decoded access list must not be null");
+        assertEquals(expected.size(), actual.size(), "access list size mismatch");
+        for (int i = 0; i < expected.size(); i++) {
+            AccessListObject e = expected.get(i);
+            AccessListObject a = actual.get(i);
+            assertTrue(
+                    e.getAddress().equalsIgnoreCase(a.getAddress()),
+                    "access list address mismatch: expected "
+                            + e.getAddress()
+                            + " got "
+                            + a.getAddress());
+            assertEquals(
+                    e.getStorageKeys().size(),
+                    a.getStorageKeys().size(),
+                    "storage key count mismatch");
+            for (int k = 0; k < e.getStorageKeys().size(); k++) {
+                assertTrue(
+                        e.getStorageKeys().get(k).equalsIgnoreCase(a.getStorageKeys().get(k)),
+                        "storage key mismatch at "
+                                + k
+                                + ": expected "
+                                + e.getStorageKeys().get(k)
+                                + " got "
+                                + a.getStorageKeys().get(k));
+            }
+        }
     }
 
     // =========================================================================
@@ -209,12 +258,7 @@ public class Eip7594TransactionTest {
     public void testAccessListPreservation() throws Exception {
         Credentials credentials = Credentials.create(PRIVATE_KEY);
 
-        List<AccessListObject> accessList =
-                Collections.singletonList(
-                        new AccessListObject(
-                                "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
-                                Collections.singletonList(
-                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
+        List<AccessListObject> accessList = sampleAccessList();
 
         int blobCount = 1;
         RawTransaction rawTx =
@@ -237,9 +281,11 @@ public class Eip7594TransactionTest {
 
         byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
         RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
-        // Access list round-trip is preserved (non-empty tx body has access list)
-        // The decoded tx should be signed
         assertTrue(decoded instanceof SignedRawTransaction);
+
+        // The access list must round-trip unchanged through encode/decode.
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        assertAccessListEquals(accessList, tx.getAccessList());
     }
 
     // =========================================================================
@@ -760,12 +806,7 @@ public class Eip7594TransactionTest {
     @Test
     public void testAccessListPassedThroughInEip7594() throws Exception {
         Credentials credentials = Credentials.create(PRIVATE_KEY);
-        List<AccessListObject> accessList =
-                Collections.singletonList(
-                        new AccessListObject(
-                                "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe",
-                                Collections.singletonList(
-                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
+        List<AccessListObject> accessList = sampleAccessList();
         int blobCount = 1;
         RawTransaction rawTx =
                 RawTransaction.createTransaction(
@@ -791,5 +832,124 @@ public class Eip7594TransactionTest {
         assertTrue(tx.getWrapperVersion().isPresent());
         assertEquals(BigInteger.ONE, tx.getWrapperVersion().get());
         assertTrue(tx.getCellProofs().isPresent());
+        assertAccessListEquals(accessList, tx.getAccessList());
+    }
+
+    // =========================================================================
+    // 17. Access list round-trip on the EIP-4844 (kzgProofs) path
+    //     Regression test: the 14-arg createTransaction overload must thread the
+    //     access list through to tx_payload_body. Before the fix it was dropped,
+    //     yielding a different tx_payload_body (and thus a different tx hash).
+    // =========================================================================
+
+    @Test
+    public void testEip4844AccessListRoundTrip() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+        List<AccessListObject> accessList = sampleAccessList();
+
+        int blobCount = 1;
+        // EIP-4844: one proof per blob (not per cell), via the kzgProofs overload.
+        RawTransaction rawTx =
+                RawTransaction.createTransaction(
+                        blobs(blobCount),
+                        commitments(blobCount),
+                        makeProofs(blobCount),
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        versionedHashes(blobCount),
+                        accessList);
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        // This is an EIP-4844 tx: no wrapper_version, no cell_proofs.
+        assertFalse(tx.getWrapperVersion().isPresent(), "EIP-4844 must not have wrapperVersion");
+        // The access list must survive the round-trip (regression for the dropped-access-list bug).
+        assertAccessListEquals(accessList, tx.getAccessList());
+    }
+
+    // =========================================================================
+    // 18. Decoder rejection of malformed payloads
+    //     These feed crafted RLP directly to TransactionDecoder.decode and assert
+    //     the guarded branches throw IllegalArgumentException (not a raw cast).
+    // =========================================================================
+
+    /** Encodes {@code outer} as a type-0x03 transaction and runs it through the decoder. */
+    private static RawTransaction decodeType3(RlpType outer) {
+        byte[] rlp = RlpEncoder.encode(outer);
+        byte[] tx = new byte[rlp.length + 1];
+        tx[0] = 0x03;
+        System.arraycopy(rlp, 0, tx, 1, rlp.length);
+        return TransactionDecoder.decode(Numeric.toHexString(tx));
+    }
+
+    /** Builds a tx_payload_body RlpList with {@code n} empty RlpString fields. */
+    private static RlpList bodyWithFields(int n) {
+        List<RlpType> fields = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            fields.add(RlpString.create(""));
+        }
+        return new RlpList(fields);
+    }
+
+    @Test
+    public void testDecoderRejectsWrongWrapperElementCount() {
+        // First element is a list (network wrapper), but total size is neither 4 nor 5.
+        RlpList outer = new RlpList(bodyWithFields(11), RlpString.create(""), RlpString.create(""));
+        assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
+    }
+
+    @Test
+    public void testDecoderRejectsNonStringWrapperVersion() {
+        // 5-element wrapper, but wrapper_version (index 1) is an RlpList, not an RlpString.
+        RlpList outer =
+                new RlpList(
+                        bodyWithFields(11),
+                        new RlpList(),
+                        new RlpList(),
+                        new RlpList(),
+                        new RlpList());
+        assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
+    }
+
+    @Test
+    public void testDecoderRejectsNonListBlobs() {
+        // 5-element wrapper, valid version, but blobs (index 2) is an RlpString, not an RlpList.
+        RlpList outer =
+                new RlpList(
+                        bodyWithFields(11),
+                        RlpString.create(BigInteger.ONE),
+                        RlpString.create("blobs"),
+                        new RlpList(),
+                        new RlpList());
+        assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
+    }
+
+    @Test
+    public void testDecoderRejectsMissingAccessList() {
+        // 5-element wrapper with valid types, but tx_payload_body has < 9 fields (no index 8).
+        RlpList outer =
+                new RlpList(
+                        bodyWithFields(3),
+                        RlpString.create(BigInteger.ONE),
+                        new RlpList(),
+                        new RlpList(),
+                        new RlpList());
+        assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
+    }
+
+    @Test
+    public void testDecoderRejectsTooFewPayloadFields() {
+        // No-sidecar body (first element is an RlpString) with fewer than 11 fields.
+        RlpList outer = bodyWithFields(5);
+        assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ version=5.0.3-SNAPSHOT
 org.gradle.caching=true
 org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn
+org.gradle.jvmargs=-Dfile.encoding=UTF-8

--- a/gradle/java/build.gradle
+++ b/gradle/java/build.gradle
@@ -7,9 +7,11 @@ java {
 }
 
 compileJava {
+    options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }
 
 compileTestJava {
+    options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 }


### PR DESCRIPTION
This PR adds support for EIP-7594, which introduces a new blob transaction wrapper format.

It extends the existing EIP-4844 transaction handling by adding support for wrapper_version and cell_proofs.

The encoding logic has been updated to match the new RLP structure, and the decoder has been updated to handle both the new and old formats.

Basic validation is added to ensure blobs, commitments, and proofs have matching sizes.

Tests are included to verify encoding and decoding behavior.

Fixes #2235