### PR TITLE
Add getImplementationName() to generated contract wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*
+* Add getImplementationName() to generated contract wrappers for better visibility (#2078)
 
 ### BREAKING CHANGES
 

--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -275,9 +275,23 @@ public class SolidityFunctionWrapper extends Generator {
             classBuilder.addMethod(buildGetDeploymentBinaryMethod());
         }
 
+        classBuilder.addMethod(buildGetImplementationNameMethod(contractName));
+
         addAddressesSupport(classBuilder, addresses);
 
         write(basePackageName, classBuilder.build(), destinationDir);
+    }
+
+    MethodSpec buildGetImplementationNameMethod(String contractName) {
+        return MethodSpec.methodBuilder("getImplementationName")
+                .addJavadoc(
+                        "Returns the contract name used during code generation.\n<p>\n"
+                                + "This method is strictly for identifying the generated contract name and does not perform runtime detection.\n\n"
+                                + "@return the generated contract name\n")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(String.class)
+                .addStatement("return $S", contractName)
+                .build();
     }
 
     private void buildStructsNamedTypesList(List<AbiDefinition> abi) {

--- a/codegen/src/test/java/org/web3j/codegen/ContractImplementationNameTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/ContractImplementationNameTest.java
@@ -1,0 +1,78 @@
+package org.web3j.codegen;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.web3j.TempFileProvider;
+import org.web3j.protocol.core.methods.response.AbiDefinition;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.web3j.codegen.FunctionWrapperGenerator.JAVA_TYPES_ARG;
+
+public class ContractImplementationNameTest extends TempFileProvider {
+
+    @Test
+    public void testGetImplementationNameAtRuntime() throws Exception {
+        String contractName = "TestContract";
+        String packageName = "org.web3j.test.generated";
+        
+        // Use a simple ABI with one function
+        AbiDefinition function = new AbiDefinition();
+        function.setName("hi");
+        function.setType("function");
+        function.setInputs(Collections.emptyList());
+        function.setOutputs(Collections.emptyList());
+        function.setConstant(true);
+        function.setPayable(false);
+        function.setStateMutability("view");
+
+        // Generate the Java file
+        new SolidityFunctionWrapper(true, 160, false)
+                .generateJavaFiles(
+                        contractName,
+                        "0x1234",
+                        Arrays.asList(function),
+                        tempDirPath,
+                        packageName,
+                        Collections.emptyMap());
+
+        // Compile the generated file
+        String sourcePath = tempDirPath + File.separator + 
+                packageName.replace('.', File.separatorChar) + File.separator + 
+                contractName + ".java";
+        
+        GeneraterTestUtils.verifyGeneratedCode(sourcePath);
+
+        // Load and verify the class
+        File classesDir = new File(tempDirPath);
+        URLClassLoader classLoader = new URLClassLoader(new URL[]{classesDir.toURI().toURL()});
+        Class<?> contractClass = classLoader.loadClass(packageName + "." + contractName);
+        
+        // Call getImplementationName and assert
+        // Use the public static load method with non-null dummies to avoid NPE in base Contract class
+        java.lang.reflect.Method loadMethod = contractClass.getMethod("load", 
+                String.class, org.web3j.protocol.Web3j.class, 
+                org.web3j.crypto.Credentials.class, 
+                org.web3j.tx.gas.ContractGasProvider.class);
+        
+        org.web3j.protocol.Web3j web3j = (org.web3j.protocol.Web3j) java.lang.reflect.Proxy.newProxyInstance(
+                org.web3j.protocol.Web3j.class.getClassLoader(),
+                new Class[]{org.web3j.protocol.Web3j.class},
+                (proxy, method1, args1) -> null);
+
+        Object instance = loadMethod.invoke(null, 
+                "0x0000000000000000000000000000000000000000", 
+                web3j,
+                org.web3j.crypto.Credentials.create("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"), 
+                new org.web3j.tx.gas.StaticGasProvider(java.math.BigInteger.ZERO, java.math.BigInteger.ZERO));
+        
+        java.lang.reflect.Method method = contractClass.getMethod("getImplementationName");
+        Object result = method.invoke(instance);
+        
+        assertEquals(contractName, result, "The implementation name should match the contract name used during generation");
+    }
+}

--- a/codegen/src/test/java/org/web3j/codegen/ContractJsonParseTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/ContractJsonParseTest.java
@@ -57,7 +57,7 @@ public class ContractJsonParseTest {
     @BeforeEach
     public void setUp() throws Exception {
         URL url = SolidityFunctionWrapperGeneratorTest.class.getResource("/truffle");
-        contractBaseDir = url.getPath();
+        contractBaseDir = java.net.URLDecoder.decode(url.getPath(), "UTF-8");
     }
 
     @Test

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -49,7 +49,7 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
         super.setUp();
 
         URL url = SolidityFunctionWrapperGeneratorTest.class.getResource("/solidity");
-        solidityBaseDir = url.getPath();
+        solidityBaseDir = java.net.URLDecoder.decode(url.getPath(), "UTF-8");
     }
 
     @Test

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -1161,6 +1161,26 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
+    public void testBuildGetImplementationNameMethod() throws Exception {
+        MethodSpec methodSpec =
+                solidityFunctionWrapperBoth.buildGetImplementationNameMethod("MyContractName");
+
+        String expected =
+                "/**\n"
+                        + " * Returns the contract name used during code generation.\n"
+                        + " * <p>\n"
+                        + " * This method is strictly for identifying the generated contract name and does not perform runtime detection.\n"
+                        + " *\n"
+                        + " * @return the generated contract name\n"
+                        + " */\n"
+                        + "public java.lang.String getImplementationName() {\n"
+                        + "  return \"MyContractName\";\n"
+                        + "}\n";
+
+        assertEquals(expected, methodSpec.toString());
+    }
+
+    @Test
     public void testBinaryWithUnlinkedLibraryLengthOver65534() throws Exception {
         solidityFunctionWrapper.createBinaryDefinition(
                 "0x"

--- a/codegen/src/test/java/org/web3j/codegen/TruffleJsonFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/TruffleJsonFunctionWrapperGeneratorTest.java
@@ -38,7 +38,7 @@ public class TruffleJsonFunctionWrapperGeneratorTest extends TempFileProvider {
         super.setUp();
 
         URL url = SolidityFunctionWrapperGeneratorTest.class.getResource("/truffle");
-        contractBaseDir = url.getPath();
+        contractBaseDir = java.net.URLDecoder.decode(url.getPath(), "UTF-8");
     }
 
     @Test

--- a/codegen/src/test/resources/solidity/abifuncs/build/java/AbiFuncs.java
+++ b/codegen/src/test/resources/solidity/abifuncs/build/java/AbiFuncs.java
@@ -90,4 +90,15 @@ public class AbiFuncs extends Contract {
             TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
         return new AbiFuncs(contractAddress, web3j, transactionManager, contractGasProvider);
     }
+
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "AbiFuncs";
+    }
 }

--- a/codegen/src/test/resources/solidity/arrayofstructandstruct/build/java/ArrayOfStructAndStruct.java
+++ b/codegen/src/test/resources/solidity/arrayofstructandstruct/build/java/ArrayOfStructAndStruct.java
@@ -133,6 +133,17 @@ public class ArrayOfStructAndStruct extends Contract {
         }
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "ArrayOfStructAndStruct";
+    }
+
     public static class Foo extends StaticStruct {
         public Boolean dummy;
 

--- a/codegen/src/test/resources/solidity/arrayofstructclassgeneration/build/java/ArrayOfStructClassGeneration.java
+++ b/codegen/src/test/resources/solidity/arrayofstructclassgeneration/build/java/ArrayOfStructClassGeneration.java
@@ -123,6 +123,17 @@ public class ArrayOfStructClassGeneration extends Contract {
         }
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "ArrayOfStructClassGeneration";
+    }
+
     public static class Foo extends StaticStruct {
         public Boolean dummy;
 

--- a/codegen/src/test/resources/solidity/arraysinstruct/build/java/ArraysInStruct.java
+++ b/codegen/src/test/resources/solidity/arraysinstruct/build/java/ArraysInStruct.java
@@ -101,6 +101,17 @@ public class ArraysInStruct extends Contract {
         return new ArraysInStruct(contractAddress, web3j, transactionManager, contractGasProvider);
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "ArraysInStruct";
+    }
+
     public static class Entity extends DynamicStruct {
         public byte[] bytesField;
 

--- a/codegen/src/test/resources/solidity/eventparameters/build/java/EventParameters.java
+++ b/codegen/src/test/resources/solidity/eventparameters/build/java/EventParameters.java
@@ -155,6 +155,17 @@ public class EventParameters extends Contract {
         return new EventParameters(contractAddress, web3j, transactionManager, contractGasProvider);
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "EventParameters";
+    }
+
     public static class TestEventEventResponse extends BaseEventResponse {
         public BigInteger _contractNumber;
 

--- a/codegen/src/test/resources/solidity/metacoin/build/java/MetaCoin.java
+++ b/codegen/src/test/resources/solidity/metacoin/build/java/MetaCoin.java
@@ -190,6 +190,17 @@ public class MetaCoin extends Contract {
         }
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "MetaCoin";
+    }
+
     public static class TransferEventResponse extends BaseEventResponse {
         public String _from;
 

--- a/codegen/src/test/resources/solidity/onlyinarraystruct/build/java/OnlyInArrayStruct.java
+++ b/codegen/src/test/resources/solidity/onlyinarraystruct/build/java/OnlyInArrayStruct.java
@@ -105,6 +105,17 @@ public class OnlyInArrayStruct extends Contract {
         return new OnlyInArrayStruct(contractAddress, web3j, transactionManager, contractGasProvider);
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "OnlyInArrayStruct";
+    }
+
     public static class Foo extends DynamicStruct {
         public String id;
 

--- a/codegen/src/test/resources/solidity/sameinnerstructname/build/java/SameInnerStructName.java
+++ b/codegen/src/test/resources/solidity/sameinnerstructname/build/java/SameInnerStructName.java
@@ -124,6 +124,17 @@ public class SameInnerStructName extends Contract {
         }
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "SameInnerStructName";
+    }
+
     public static class Foo_Info extends StaticStruct {
         public Boolean dummy;
 

--- a/codegen/src/test/resources/solidity/staticarrayofstructsinstruct/build/java/StaticArrayOfStructsInStruct.java
+++ b/codegen/src/test/resources/solidity/staticarrayofstructsinstruct/build/java/StaticArrayOfStructsInStruct.java
@@ -127,6 +127,17 @@ public class StaticArrayOfStructsInStruct extends Contract {
         }
     }
 
+    /**
+     * Returns the contract name used during code generation.
+     * <p>
+     * This method is strictly for identifying the generated contract name and does not perform runtime detection.
+     *
+     * @return the generated contract name
+     */
+    public String getImplementationName() {
+        return "StaticArrayOfStructsInStruct";
+    }
+
     public static class Player extends StaticStruct {
         public String addr;
 


### PR DESCRIPTION
### What does this PR do?

Adds a `getImplementationName()` method to generated contract wrapper classes.

This method returns the contract name used during code generation, making it easier to identify which wrapper class is being used.

### Where should the reviewer start?

codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java

### Why is it needed?

When loading contracts via interfaces or abstract wrappers, it is not obvious which concrete contract wrapper is being used.

This change improves visibility by exposing the generated contract name directly in the wrapper.

Note: This does not perform runtime implementation detection.

Fixes #2078