### PR TITLE
feat: add ABI-based event log decoder utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-*
+* Add utility to decode event logs using ABI into structured objects (#1870)
 
 ### BREAKING CHANGES
 

--- a/core/src/main/java/org/web3j/abi/EventDecoder.java
+++ b/core/src/main/java/org/web3j/abi/EventDecoder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.abi;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.protocol.ObjectMapperFactory;
+import org.web3j.protocol.core.methods.response.AbiDefinition;
+import org.web3j.protocol.core.methods.response.Log;
+
+public class EventDecoder {
+
+    /**
+     * Decodes an event log into a structured map using ABI definitions.
+     *
+     * @param abiJson the ABI json string (can be a JSON array of definitions or a single definition
+     *     object)
+     * @param log the transaction log to decode
+     * @return a map containing the decoded indexed and non-indexed parameter names and values
+     */
+    public static Map<String, Object> decodeEvent(String abiJson, Log log) {
+        ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
+        List<AbiDefinition> abiDefinitions = new ArrayList<>();
+
+        try {
+            JsonNode node = objectMapper.readTree(abiJson);
+            if (node.isArray()) {
+                abiDefinitions =
+                        objectMapper.readValue(
+                                abiJson, new TypeReference<List<AbiDefinition>>() {});
+            } else {
+                abiDefinitions.add(objectMapper.readValue(abiJson, AbiDefinition.class));
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid ABI JSON", e);
+        }
+
+        // Find the matching event definition
+        List<String> topics = log.getTopics();
+        if (topics == null || topics.isEmpty()) {
+            throw new IllegalArgumentException("Log does not contain any topics");
+        }
+        String eventSignature = topics.get(0);
+
+        AbiDefinition targetEventDefinition = null;
+        Event targetEvent = null;
+
+        for (AbiDefinition abiDef : abiDefinitions) {
+            if ("event".equals(abiDef.getType())) {
+                List<org.web3j.abi.TypeReference<?>> parameters = new ArrayList<>();
+                try {
+                    for (AbiDefinition.NamedType namedType : abiDef.getInputs()) {
+                        parameters.add(
+                                org.web3j.abi.TypeReference.makeTypeReference(
+                                        namedType.getType(), namedType.isIndexed(), false));
+                    }
+                } catch (Exception e) {
+                    // Skip if the ABI definition cannot be parsed into an Event object
+                    continue;
+                }
+
+                Event event = new Event(abiDef.getName(), parameters);
+                String encodedSignature = EventEncoder.encode(event);
+
+                if (encodedSignature.equals(eventSignature)) {
+                    targetEventDefinition = abiDef;
+                    targetEvent = event;
+                    break;
+                }
+            }
+        }
+
+        if (targetEvent == null || targetEventDefinition == null) {
+            throw new IllegalArgumentException(
+                    "No matching event definition found in ABI for log signature: "
+                            + eventSignature);
+        }
+
+        // Re-implement Contract's decoding since staticExtractEventParametersWithLog is protected
+        List<Type> indexedValues = new ArrayList<>();
+        List<org.web3j.abi.TypeReference<Type>> indexedParameters =
+                targetEvent.getIndexedParameters();
+        for (int i = 0; i < indexedParameters.size(); i++) {
+            if (i + 1 < topics.size()) {
+                Type value =
+                        FunctionReturnDecoder.decodeIndexedValue(
+                                topics.get(i + 1), indexedParameters.get(i));
+                indexedValues.add(value);
+            }
+        }
+
+        List<Type> nonIndexedValues =
+                FunctionReturnDecoder.decode(log.getData(), targetEvent.getNonIndexedParameters());
+
+        Map<String, Object> decodedResult = new HashMap<>();
+        List<AbiDefinition.NamedType> inputs = targetEventDefinition.getInputs();
+
+        int indexedIdx = 0;
+        int nonIndexedIdx = 0;
+
+        for (int i = 0; i < inputs.size(); i++) {
+            AbiDefinition.NamedType input = inputs.get(i);
+            Object value = null;
+            if (input.isIndexed()) {
+                if (indexedIdx < indexedValues.size()) {
+                    Type<?> typeValue = indexedValues.get(indexedIdx++);
+                    if (typeValue != null) {
+                        value = typeValue.getValue();
+                    }
+                }
+            } else {
+                if (nonIndexedIdx < nonIndexedValues.size()) {
+                    Type<?> typeValue = nonIndexedValues.get(nonIndexedIdx++);
+                    if (typeValue != null) {
+                        value = typeValue.getValue();
+                    }
+                }
+            }
+
+            String name = input.getName();
+            // Provide a fallback name if name is empty
+            if (name == null || name.trim().isEmpty()) {
+                name = "param" + i;
+            }
+
+            decodedResult.put(name, value);
+        }
+
+        return decodedResult;
+    }
+}

--- a/core/src/test/java/org/web3j/abi/EventDecoderTest.java
+++ b/core/src/test/java/org/web3j/abi/EventDecoderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.abi;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.protocol.core.methods.response.Log;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EventDecoderTest {
+
+    @Test
+    public void testDecodeEvent() {
+        // ABI for Transfer(address indexed from, address indexed to, uint256 value)
+        String abiJson =
+                "[{"
+                        + "\"anonymous\":false,"
+                        + "\"inputs\":["
+                        + "  {\"indexed\":true,\"name\":\"from\",\"type\":\"address\"},"
+                        + "  {\"indexed\":true,\"name\":\"to\",\"type\":\"address\"},"
+                        + "  {\"indexed\":false,\"name\":\"value\",\"type\":\"uint256\"}"
+                        + "],"
+                        + "\"name\":\"Transfer\","
+                        + "\"type\":\"event\""
+                        + "}]";
+
+        // Synthetic Log
+        Log log = new Log();
+
+        // Setup signature and indexed parameters for Transfer event
+        Event transferEvent =
+                new Event(
+                        "Transfer",
+                        Arrays.asList(
+                                new TypeReference<Address>(true) {},
+                                new TypeReference<Address>(true) {},
+                                new TypeReference<Uint256>(false) {}));
+
+        String encodedEventSignature = EventEncoder.encode(transferEvent);
+
+        // Topics: [signature, from, to]
+        log.setTopics(
+                Arrays.asList(
+                        encodedEventSignature,
+                        "0x0000000000000000000000001234567890123456789012345678901234567890",
+                        "0x0000000000000000000000000987654321098765432109876543210987654321"));
+
+        // Data: value (100)
+        log.setData("0x0000000000000000000000000000000000000000000000000000000000000064");
+
+        Map<String, Object> result = EventDecoder.decodeEvent(abiJson, log);
+
+        assertEquals(3, result.size());
+        assertEquals("0x1234567890123456789012345678901234567890", result.get("from"));
+        assertEquals("0x0987654321098765432109876543210987654321", result.get("to"));
+        assertEquals(new BigInteger("100"), result.get("value"));
+    }
+}


### PR DESCRIPTION
Adds a utility to decode event logs using ABI into a simple structured map.

This makes it easier to extract event data without writing manual decoding logic.

Supports both indexed and non-indexed parameters and uses existing Web3j decoding internally. A basic test is included to verify the behavior.

Fixes #1870
