### PR TITLE
fix: handle struct and enum prefixes in ABI internalType for code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Bug Fixes
 
 * Replace raw usage of `EthLog.LogResult` with parameterized type to improve type safety (#2252)
+* Fix code generation failure when ABI contains struct types prefixed with `struct` keyword (#1978)
 (https://github.com/LFDT-web3j/web3j/pull/2254)
 
 ### Features

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperTest.java
@@ -81,6 +81,18 @@ public class SolidityFunctionWrapperTest extends TempFileProvider {
     }
 
     @Test
+    public void testCleanInternalType() {
+        NamedType namedType =
+                new NamedType("op", "tuple", Collections.emptyList(), "struct UserOperation", false);
+        assertEquals("UserOperation", namedType.structIdentifier());
+        assertEquals("UserOperation", namedType.getInternalType());
+
+        namedType.setInternalType("enum MyEnum");
+        assertEquals("MyEnum", namedType.structIdentifier());
+        assertEquals("MyEnum", namedType.getInternalType());
+    }
+
+    @Test
     public void testBuildTypeName() throws Exception {
         assertEquals(buildTypeName("uint256"), (ClassName.get(Uint256.class)));
         assertEquals(buildTypeName("uint64"), (ClassName.get(Uint64.class)));

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
@@ -222,6 +222,19 @@ public class AbiDefinition {
             this(name, type, Collections.emptyList(), DEFAULT_INTERNAL_TYPE, indexed);
         }
 
+    private String cleanInternalType(String internalType) {
+        if (internalType != null) {
+            String clean = internalType;
+            if (clean.startsWith("struct ")) {
+                clean = clean.substring(7);
+            } else if (clean.startsWith("enum ")) {
+                clean = clean.substring(5);
+            }
+            return clean;
+        }
+        return internalType;
+    }
+
         public NamedType(
                 String name,
                 String type,
@@ -231,7 +244,7 @@ public class AbiDefinition {
             this.name = name;
             this.type = type;
             this.components = components;
-            this.internalType = internalType;
+            this.internalType = cleanInternalType(internalType);
             this.indexed = indexed;
         }
 
@@ -256,7 +269,7 @@ public class AbiDefinition {
         }
 
         public void setInternalType(final String internalType) {
-            this.internalType = internalType;
+            this.internalType = cleanInternalType(internalType);
         }
 
         public boolean isIndexed() {


### PR DESCRIPTION
Fixes an issue where code generation fails when ABI contains types prefixed with "struct" or "enum" (for example "struct UserOperation").

Previously, these prefixes were not handled correctly, which led to invalid Java code being generated.

This change cleans the internalType by removing these prefixes so that valid Java class names are produced during code generation.

A test is added to verify the behavior.

Fixes #1978