### PR TITLE
perf(abi): cache type bit-width parsing in TypeDecoder.getTypeLength

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.web3j.abi.datatypes.AbiTypes;
@@ -70,6 +71,9 @@ import static org.web3j.abi.Utils.staticStructNestedPublicFieldsFlatList;
 public class TypeDecoder {
 
     static final int MAX_BYTE_LENGTH_FOR_HEX_STRING = Type.MAX_BYTE_LENGTH << 1;
+
+    private static final ConcurrentHashMap<Class<?>, Integer> TYPE_LENGTH_CACHE =
+            new ConcurrentHashMap<>();
 
     public static Type instantiateType(String solidityType, Object value)
             throws InvocationTargetException,
@@ -173,6 +177,10 @@ public class TypeDecoder {
     }
 
     static <T extends NumericType> int getTypeLength(Class<T> type) {
+        return TYPE_LENGTH_CACHE.computeIfAbsent(type, TypeDecoder::computeTypeLength);
+    }
+
+    private static int computeTypeLength(Class<?> type) {
         if (IntType.class.isAssignableFrom(type)) {
             String regex = "(" + Uint.class.getSimpleName() + "|" + Int.class.getSimpleName() + ")";
             String[] splitName = type.getSimpleName().split(regex);


### PR DESCRIPTION
## Summary

`TypeDecoder.getTypeLength(Class<T>)` is called on every `decodeNumeric` invocation. For each call it builds a regex (`"(Uint|Int)"`), compiles it via `String.split`, splits the class's simple name, and parses an int. The result for a given `Class<?>` never changes, so this PR memoizes it in a `ConcurrentHashMap`.

## Why

`String.split(regex)` recompiles the `Pattern` on every invocation (it does not match the single-character fast path), which is genuinely expensive on a hot path. CPU profiles of decoders processing many event logs showed `Pattern.compile` and `String.split` as a significant chunk of decode time.

## Benchmark

Same harness as #2279, single-JVM, 200k warmup + 2M measure ops, best of 3, OpenJDK 25 / arm64.

| Type    | main (ns/op) | patch (ns/op) | speedup |
|---------|-------------:|--------------:|--------:|
| Uint256 |        172   |         47    |  **3.7x** |
| Int128  |        193   |         62    |  **3.1x** |
| Address |        190   |         57    |  **3.3x** |
| Bytes32 |        132   |        123    |  1.07x (does not call `getTypeLength`) |

This patch independently delivers larger numeric-type wins than #2279 (direct constructor), because regex compilation was the dominant cost, not reflection.

## Compatibility

- Cache key is `Class<?>`. The value (bit width) is derived purely from the class identity, so the cache is safe under concurrent access and does not need invalidation.
- Classloader leak risk is bounded: the only callers pass NumericType subclasses, and there's a small finite set of those.

## Test plan

- [x] `./gradlew :abi:test` passes
- [x] Benchmark numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)