### PR TITLE
Fix Codegen fails when trying to create wrapper from ABI compiled by …

### DIFF
--- a/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java
@@ -1325,29 +1325,20 @@ public class SolidityFunctionWrapper extends Generator {
             if (typeNames.size() != 1) {
                 throw new UnsupportedOperationException(
                         "Only a single parameterized type is supported");
-            } else if (structClassNameMap.values().stream()
-                    .map(ClassName::simpleName)
-                    .anyMatch(
-                            name ->
-                                    name.equals(
-                                            ((ClassName)
-                                                            ((ParameterizedTypeName)
-                                                                            parameterSpec.type)
-                                                                    .typeArguments.get(0))
-                                                    .simpleName()))) {
+            }
+            TypeName firstTypeArg = typeNames.get(0);
+            if (firstTypeArg instanceof ClassName
+                    && structClassNameMap.values().stream()
+                            .map(ClassName::simpleName)
+                            .anyMatch(
+                                    name -> name.equals(((ClassName) firstTypeArg).simpleName()))) {
                 String structName =
                         structClassNameMap.values().stream()
                                 .map(ClassName::simpleName)
                                 .filter(
                                         name ->
                                                 name.equals(
-                                                        ((ClassName)
-                                                                        ((ParameterizedTypeName)
-                                                                                        parameterSpec
-                                                                                                .type)
-                                                                                .typeArguments.get(
-                                                                                        0))
-                                                                .simpleName()))
+                                                        ((ClassName) firstTypeArg).simpleName()))
                                 .collect(Collectors.toList())
                                 .get(0);
                 return "new "


### PR DESCRIPTION
Fixes #1925 

### What does this PR do?
Codegen fails when trying to create wrapper from ABI compiled by truffle for T-REX 4.0.0+. The root cause is in `createMappedParameterTypes()` in `SolidityFunctionWrapper.java`, where the code blindly casts a `TypeName` to `ClassName` without checking its actual type first. When the inner type argument is a `ParameterizedTypeName` (which happens with nested arrays like `uint256[][]`), the cast fails.

Added an `instanceof ClassName` guard before the cast, and extracted the type argument into a variable to avoid redundant calls:
```java
TypeName firstTypeArg = typeNames.get(0);
if (firstTypeArg instanceof ClassName && structClassNameMap.values().stream()...)
```
If the type argument is not a `ClassName` (i.e. it's a nested array), it correctly falls through to the existing `else` block which handles `ParameterizedTypeName` properly.

### Where should the reviewer start?
The reviewer must just look into the `codegen/src/main/java/org/web3j/codegen/SolidityFunctionWrapper.java` file.

### Why is it needed?
Because the code assumed every type inside an array is a simple type (`ClassName`), but for nested arrays like `uint256[][]`, the inner type is itself another array (`ParameterizedTypeName`).

## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.