### PR TITLE
fix: pass accessList to parent in Transaction7702 constructor

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java
@@ -14,6 +14,7 @@ package org.web3j.crypto.transaction.type;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.web3j.crypto.AccessListObject;
@@ -39,7 +40,16 @@ public class Transaction7702 extends Transaction1559 implements ITransaction {
             String data,
             List<AccessListObject> accessList,
             List<AuthorizationTuple> authorizationList) {
-        super(chainId, nonce, gasLimit, to, value, data, maxPriorityFeePerGas, maxFeePerGas);
+        super(
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                accessList == null ? Collections.emptyList() : accessList);
         this.authorizationList = authorizationList;
     }
 

--- a/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/TransactionDecoderTest.java
@@ -534,6 +534,21 @@ public class TransactionDecoderTest {
     }
 
     @Test
+    public void testEip7702RetainsAccessList() {
+        final RawTransaction rawTransaction = createEip7702RawTransaction();
+        final Transaction7702 tx7702 = (Transaction7702) rawTransaction.getTransaction();
+
+        final List<AccessListObject> expectedAccessList =
+                Collections.singletonList(
+                        new AccessListObject(
+                                "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+                                Collections.singletonList(
+                                        "0x0000000000000000000000000000000000000000000000000000000000000003")));
+
+        assertIterableEquals(expectedAccessList, tx7702.getAccessList());
+    }
+
+    @Test
     public void testDecoding7702() {
         final RawTransaction rawTransaction = createEip7702RawTransaction();
         final Transaction7702 tx7702 = (Transaction7702) rawTransaction.getTransaction();


### PR DESCRIPTION
### What does this PR do?
`Transaction7702.createTransaction()` accepted an `accessList` argument but never forwarded it to the parent constructor, so the field stayed empty and was dropped from RLP encoding. This forwards it to the `Transaction1559` constructor that takes an access list.

### Where should the reviewer start?
`crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction7702.java` and the new `testEip7702RetainsAccessList` in `TransactionDecoderTest`.

### Why is it needed?
Without it, EIP-7702 transactions silently lose their access list, producing incorrect RLP encoding and transaction hashes. Closes #2291.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.