### PR TITLE
fix: prevent Transaction serialization failures when fee fields are null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
--
+- Fix Transaction serialization failure when fee fields are null [#2293](https://github.com/LFDT-web3j/web3j/pull/2293)
+
 
 ### Features
 

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/Transaction.java
@@ -282,8 +282,10 @@ public class Transaction {
     }
 
     public BigInteger getNonce() {
+        if (nonce == null) return null;
         return Numeric.decodeQuantity(nonce);
     }
+
 
     public void setNonce(String nonce) {
         this.nonce = nonce;
@@ -302,8 +304,10 @@ public class Transaction {
     }
 
     public BigInteger getBlockNumber() {
+        if (blockNumber == null) return null;
         return Numeric.decodeQuantity(blockNumber);
     }
+
 
     public void setBlockNumber(String blockNumber) {
         this.blockNumber = blockNumber;
@@ -314,8 +318,10 @@ public class Transaction {
     }
 
     public BigInteger getTransactionIndex() {
+        if (transactionIndex == null) return null;
         return Numeric.decodeQuantity(transactionIndex);
     }
+
 
     public void setTransactionIndex(String transactionIndex) {
         this.transactionIndex = transactionIndex;
@@ -342,8 +348,10 @@ public class Transaction {
     }
 
     public BigInteger getValue() {
+        if (value == null) return null;
         return Numeric.decodeQuantity(value);
     }
+
 
     public void setValue(String value) {
         this.value = value;
@@ -354,8 +362,10 @@ public class Transaction {
     }
 
     public BigInteger getGasPrice() {
+        if (gasPrice == null) return null;
         return Numeric.decodeQuantity(gasPrice);
     }
+
 
     public void setGasPrice(String gasPrice) {
         this.gasPrice = gasPrice;
@@ -366,8 +376,10 @@ public class Transaction {
     }
 
     public BigInteger getGas() {
+        if (gas == null) return null;
         return Numeric.decodeQuantity(gas);
     }
+
 
     public void setGas(String gas) {
         this.gas = gas;
@@ -494,8 +506,10 @@ public class Transaction {
     }
 
     public BigInteger getMaxPriorityFeePerGas() {
+        if (maxPriorityFeePerGas == null) return null;
         return Numeric.decodeQuantity(maxPriorityFeePerGas);
     }
+
 
     public void setMaxPriorityFeePerGas(String maxPriorityFeePerGas) {
         this.maxPriorityFeePerGas = maxPriorityFeePerGas;
@@ -514,8 +528,10 @@ public class Transaction {
     }
 
     public BigInteger getMaxFeePerBlobGas() {
+        if (maxFeePerBlobGas == null) return null;
         return Numeric.decodeQuantity(maxFeePerBlobGas);
     }
+
 
     public void setMaxFeePerBlobGas(String maxFeePerBlobGas) {
         this.maxFeePerBlobGas = maxFeePerBlobGas;

--- a/core/src/test/java/org/web3j/protocol/core/methods/response/TransactionTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/methods/response/TransactionTest.java
@@ -14,11 +14,17 @@ package org.web3j.protocol.core.methods.response;
 
 import java.util.Arrays;
 import java.util.List;
+import tools.jackson.databind.ObjectMapper;
+
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
 
 public class TransactionTest {
 
@@ -124,4 +130,14 @@ public class TransactionTest {
         assertEquals(tx1, tx2);
         assertNotEquals(tx1, tx3);
     }
+
+    @Test
+    void testTransactionSerializationWithNullFields() {
+        Transaction transaction = new Transaction();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        assertDoesNotThrow(() -> objectMapper.writeValueAsString(transaction));
+    }
+
+
 }


### PR DESCRIPTION

This fixes a Transaction serialization issue caused by nullable numeric fields being decoded without null checks.

During Jackson serialization, getters such as `getMaxPriorityFeePerGas()` were calling `Numeric.decodeQuantity(...)` directly. If the underlying field was null, serialization failed with a decoding exception.

## Changes

Added explicit null checks to Transaction getters using `Numeric.decodeQuantity(...)`, including:

- getNonce()
- getBlockNumber()
- getTransactionIndex()
- getValue()
- getGasPrice()
- getGas()
- getMaxPriorityFeePerGas()
- getMaxFeePerBlobGas()

This keeps the behavior consistent with existing null-safe getters such as `getMaxFeePerGas()`.

## Testing

Added a regression test to verify that Transaction objects with null fee fields can be serialized successfully without throwing exceptions.

Verified locally with:

./gradlew :core:test --tests org.web3j.protocol.core.methods.response.TransactionTest
./gradlew :core:test --tests org.web3j.protocol.core.methods.response.EthBlockTest

Fixes #1830