### PR TITLE
Full EIP-7594 tx and Kzg cell proof generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [5.0.3]() (Upcoming)
+# [5.0.4]() (Upcoming)
 
 ### Bug Fixes
 
-* Fix Async executor lifecycle to support safe shutdown and reuse (#2244)
-* Fix Async executor lifecycle to safely recreate executor after shutdown and prevent RejectedExecutionException (#2255)
-* Replace raw usage of EthLog.LogResult with parameterized type to improve type safety (#2252)
+-
+
+### Features
+
+- Add support for EIP-7594 blob transaction wrapper [#2263](https://github.com/LFDT-web3j/web3j/pull/2263)
+- Full EIP-7594 tx and Kzg cell proof generation [#2295](https://github.com/LFDT-web3j/web3j/pull/2295)
+
+### BREAKING CHANGES
+
+-
+
+# [5.0.3](https://github.com/LFDT-web3j/web3j/releases/tag/v5.0.3) (2026-06-01)
+
+### Bug Fixes
+
+- Fix Async executor lifecycle to support safe shutdown and reuse (#2244)
+- Fix Async executor lifecycle to safely recreate executor after shutdown and prevent RejectedExecutionException (#2255)
+- Replace raw usage of EthLog.LogResult with parameterized type to improve type safety (#2252)
 
 ### Features
 
@@ -17,233 +32,226 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-*
+-
 
 # [5.0.2](https://github.com/LFDT-web3j/web3j/releases/tag/v5.0.2) (2026-01-21)
 
 ### Bug Fixes
 
-* Fix failing integration tests [#2248](https://github.com/LFDT-web3j/web3j/pull/2248)
-* Fix 4844 transaction serialized with access list [#2205](https://github.com/LFDT-web3j/web3j/pull/2205)
-* fix NPE when encoding transaction with null data [#2237](https://github.com/LFDT-web3j/web3j/pull/2237)
-* fix encoding for non-ASCII chars. [#1741](https://github.com/LFDT-web3j/web3j/issues/1741)
+- Fix failing integration tests [#2248](https://github.com/LFDT-web3j/web3j/pull/2248)
+- Fix 4844 transaction serialized with access list [#2205](https://github.com/LFDT-web3j/web3j/pull/2205)
+- fix NPE when encoding transaction with null data [#2237](https://github.com/LFDT-web3j/web3j/pull/2237)
+- fix encoding for non-ASCII chars. [#1741](https://github.com/LFDT-web3j/web3j/issues/1741)
 
 ### Features
 
-* Add EIP-7702 authorization list support to Transaction [#2246](https://github.com/LFDT-web3j/web3j/pull/2246)
+- Add EIP-7702 authorization list support to Transaction [#2246](https://github.com/LFDT-web3j/web3j/pull/2246)
 
 ### BREAKING CHANGES
 
-* bump to snapshot version 5.0.2 [#2231](https://github.com/LFDT-web3j/web3j/pull/2231)
-* Update to gradle 9 [#2249](https://github.com/LFDT-web3j/web3j/pull/2249)
+- bump to snapshot version 5.0.2 [#2231](https://github.com/LFDT-web3j/web3j/pull/2231)
+- Update to gradle 9 [#2249](https://github.com/LFDT-web3j/web3j/pull/2249)
 
 # [5.0.1](https://github.com/LFDT-web3j/web3j/releases/tag/v5.0.1) (2025-09-23)
 
 ### Bug Fixes
 
-* fix multidimensional array encoding [#1912](https://github.com/LFDT-web3j/web3j/issues/1912)
+- fix multidimensional array encoding [#1912](https://github.com/LFDT-web3j/web3j/issues/1912)
 
 ### Features
 
-* bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)
-* add encoding/decoding for EIP-7702 transactions [#2178](https://github.com/LFDT-web3j/web3j/pull/2178)
-* add @javax.annotation.Generated to generated java classes [#2081](https://github.com/LFDT-web3j/web3j/issues/2081)
-* add support for Account Abstraction EIP-4337 transactions [#2187](https://github.com/LFDT-web3j/web3j/pull/2187)
-* fix missing weiValue in transaction when estimating gas for payable function [#1268](https://github.com/LFDT-web3j/web3j/issues/1268)
-
+- bump snapshot version to 4.14.1 [#2176](https://github.com/hyperledger-web3j/web3j/pull/2176)
+- add encoding/decoding for EIP-7702 transactions [#2178](https://github.com/LFDT-web3j/web3j/pull/2178)
+- add @javax.annotation.Generated to generated java classes [#2081](https://github.com/LFDT-web3j/web3j/issues/2081)
+- add support for Account Abstraction EIP-4337 transactions [#2187](https://github.com/LFDT-web3j/web3j/pull/2187)
+- fix missing weiValue in transaction when estimating gas for payable function [#1268](https://github.com/LFDT-web3j/web3j/issues/1268)
 
 ### BREAKING CHANGES
 
-*
+-
 
 # [4.14.0](https://github.com/LFDT-web3j/web3j/releases/tag/v4.14.0) (2025-04-09)
 
 ### Bug Fixes
 
-* update copyright year to 2025 [#2152](https://github.com/LFDT-web3j/web3j/pull/2152)
-* fix: ENS CCIP Read improvements [#2164](https://github.com/LFDT-web3j/web3j/pull/2164)
-
+- update copyright year to 2025 [#2152](https://github.com/LFDT-web3j/web3j/pull/2152)
+- fix: ENS CCIP Read improvements [#2164](https://github.com/LFDT-web3j/web3j/pull/2164)
 
 ### Features
 
-* bump snapshot version to 4.13.1 [#2160](https://github.com/hyperledger-web3j/web3j/pull/2160)
-* Upgrade to https://github.com/Consensys/tuweni/releases/tag/v2.7.0 [#2170](https://github.com/LFDT-web3j/web3j/pull/2170)
-* Add support for code generation of custom error type introduced with `solidity v0.8.4` [#2173](https://github.com/LFDT-web3j/web3j/pull/2173)
-
+- bump snapshot version to 4.13.1 [#2160](https://github.com/hyperledger-web3j/web3j/pull/2160)
+- Upgrade to https://github.com/Consensys/tuweni/releases/tag/v2.7.0 [#2170](https://github.com/LFDT-web3j/web3j/pull/2170)
+- Add support for code generation of custom error type introduced with `solidity v0.8.4` [#2173](https://github.com/LFDT-web3j/web3j/pull/2173)
 
 ### BREAKING CHANGES
 
-* Upgrade to Java 21 and Besu 25.2.1 [#2165](https://github.com/LFDT-web3j/web3j/pull/2165)
+- Upgrade to Java 21 and Besu 25.2.1 [#2165](https://github.com/LFDT-web3j/web3j/pull/2165)
 
 # [4.13.0](https://github.com/hyperledger-web3j/web3j/releases/tag/v4.13.0) (2025-03-05)
 
 ### Bug Fixes
 
-* fix Transaction.getChainId when v=27 must return null [#2133](https://github.com/hyperledger-web3j/web3j/pull/2133)
-* Fix android scripts [#2138](https://github.com/hyperledger-web3j/web3j/pull/2138)
-* fixed subscription id conflict [#2127](https://github.com/hyperledger/web3j/pull/2127)
-* Fix pipeline by disabling failing integration tests [#2159](https://github.com/hyperledger-web3j/web3j/pull/2159)
+- fix Transaction.getChainId when v=27 must return null [#2133](https://github.com/hyperledger-web3j/web3j/pull/2133)
+- Fix android scripts [#2138](https://github.com/hyperledger-web3j/web3j/pull/2138)
+- fixed subscription id conflict [#2127](https://github.com/hyperledger/web3j/pull/2127)
+- Fix pipeline by disabling failing integration tests [#2159](https://github.com/hyperledger-web3j/web3j/pull/2159)
 
 ### Features
 
-* bump snapshot version to 4.12.4 [#2132](https://github.com/hyperledger-web3j/web3j/pull/2132)
-* ENS - Label Hash function added [#2140](https://github.com/hyperledger-web3j/web3j/pull/2140)
-* Added Dynamic gas providers [#2142](https://github.com/hyperledger-web3j/web3j/pull/2142)
-* Added Linea RPC APIs [#2150](https://github.com/hyperledger-web3j/web3j/pull/2150)
-
+- bump snapshot version to 4.12.4 [#2132](https://github.com/hyperledger-web3j/web3j/pull/2132)
+- ENS - Label Hash function added [#2140](https://github.com/hyperledger-web3j/web3j/pull/2140)
+- Added Dynamic gas providers [#2142](https://github.com/hyperledger-web3j/web3j/pull/2142)
+- Added Linea RPC APIs [#2150](https://github.com/hyperledger-web3j/web3j/pull/2150)
 
 ### BREAKING CHANGES
 
-* 
+-
 
 # [4.12.3](https://github.com/hyperledger-web3j/web3j/releases/tag/v4.12.3) (2024-12-17)
 
 ### Bug Fixes
 
-* fixed several code issues found by sonar [#2113](https://github.com/hyperledger/web3j/pull/2113)
-* update GitHub actions versions [#2114](https://github.com/hyperledger/web3j/pull/2114)
-* fixed request parsing exception handling [#2120](https://github.com/hyperledger/web3j/pull/2120)
-* fixed subscription object leaking after disconnect [#2121](https://github.com/hyperledger/web3j/pull/2121)
+- fixed several code issues found by sonar [#2113](https://github.com/hyperledger/web3j/pull/2113)
+- update GitHub actions versions [#2114](https://github.com/hyperledger/web3j/pull/2114)
+- fixed request parsing exception handling [#2120](https://github.com/hyperledger/web3j/pull/2120)
+- fixed subscription object leaking after disconnect [#2121](https://github.com/hyperledger/web3j/pull/2121)
 
 ### Features
 
-* bump snapshot version to 4.12.3 [#2101](https://github.com/hyperledger/web3j/pull/2101)
-* Add HSM kms implementation [#2105](https://github.com/hyperledger/web3j/pull/2105)
-* Added support for Holesky [#2111](https://github.com/hyperledger/web3j/pull/2111)
-* Advance ENS features and metadata retrieval [#2116](https://github.com/hyperledger/web3j/pull/2116)
+- bump snapshot version to 4.12.3 [#2101](https://github.com/hyperledger/web3j/pull/2101)
+- Add HSM kms implementation [#2105](https://github.com/hyperledger/web3j/pull/2105)
+- Added support for Holesky [#2111](https://github.com/hyperledger/web3j/pull/2111)
+- Advance ENS features and metadata retrieval [#2116](https://github.com/hyperledger/web3j/pull/2116)
 
 ### BREAKING CHANGES
 
-* Change organization name [#2131](https://github.com/hyperledger-web3j/web3j/pull/2131)
+- Change organization name [#2131](https://github.com/hyperledger-web3j/web3j/pull/2131)
 
 # [4.12.2](https://github.com/hyperledger/web3j/releases/tag/v4.12.2) (2024-09-18)
 
 ### Bug Fixes
 
-*
+-
 
 ### Features
 
-* bump snapshot version to 4.12.2 [#2093](https://github.com/hyperledger/web3j/pull/2093)
-* Adds Support for Linea ENS [#2094](https://github.com/hyperledger/web3j/pull/2094)
-* Upgrade jc-kzg-4844 to 2.0.0 [#2095](https://github.com/hyperledger/web3j/pull/2095)
- 
+- bump snapshot version to 4.12.2 [#2093](https://github.com/hyperledger/web3j/pull/2093)
+- Adds Support for Linea ENS [#2094](https://github.com/hyperledger/web3j/pull/2094)
+- Upgrade jc-kzg-4844 to 2.0.0 [#2095](https://github.com/hyperledger/web3j/pull/2095)
+
 ### BREAKING CHANGES
 
-*
+-
 
 # [4.12.1](https://github.com/hyperledger/web3j/releases/tag/v4.12.1) (2024-08-14)
 
 ### Bug Fixes
 
-* Bug fix for Int256 decode range [#2070](https://github.com/hyperledger/web3j/pull/2070)
-* Bug fix for BytesType.bytes32PaddedLength [#2089](https://github.com/hyperledger/web3j/pull/2089)
-* Bug fix for FastRawTransactionManager.resetNonce [#2084](https://github.com/hyperledger/web3j/pull/2084)
-* Fix licence type [#2090](https://github.com/hyperledger/web3j/pull/2090)
+- Bug fix for Int256 decode range [#2070](https://github.com/hyperledger/web3j/pull/2070)
+- Bug fix for BytesType.bytes32PaddedLength [#2089](https://github.com/hyperledger/web3j/pull/2089)
+- Bug fix for FastRawTransactionManager.resetNonce [#2084](https://github.com/hyperledger/web3j/pull/2084)
+- Fix licence type [#2090](https://github.com/hyperledger/web3j/pull/2090)
 
 ### Features
 
-* bump snapshot version to 4.12.1 [#2058](https://github.com/hyperledger/web3j/pull/2058)
-* Update maintainer requirements status [#2064](https://github.com/hyperledger/web3j/pull/2064)
-* Add struct support in java without the need of having a corresponding Java class [#2076](https://github.com/hyperledger/web3j/pull/2076)
+- bump snapshot version to 4.12.1 [#2058](https://github.com/hyperledger/web3j/pull/2058)
+- Update maintainer requirements status [#2064](https://github.com/hyperledger/web3j/pull/2064)
+- Add struct support in java without the need of having a corresponding Java class [#2076](https://github.com/hyperledger/web3j/pull/2076)
 
 ### BREAKING CHANGES
 
-*
+-
 
 # [4.12.0](https://github.com/hyperledger/web3j/releases/tag/v4.12.0) (2024-05-23)
 
 ### Bug Fixes
 
-* 
+-
 
 ### Features
 
-* bump snapshot version to 4.11.4 [#2049](https://github.com/web3j/web3j/pull/2049)
-* Fixed DefaultFunctionEncoder calculating offset for nested StaticArray [#2054](https://github.com/web3j/web3j/pull/2054)
+- bump snapshot version to 4.11.4 [#2049](https://github.com/web3j/web3j/pull/2049)
+- Fixed DefaultFunctionEncoder calculating offset for nested StaticArray [#2054](https://github.com/web3j/web3j/pull/2054)
 
 ### BREAKING CHANGES
 
-* Upgrade gradle to 8.7 and remove Consensys Repo dependency [#2057](https://github.com/hyperledger/web3j/pull/2057)
+- Upgrade gradle to 8.7 and remove Consensys Repo dependency [#2057](https://github.com/hyperledger/web3j/pull/2057)
 
 # [4.11.3](https://github.com/hyperledger/web3j/releases/tag/v4.11.3) (2024-05-01)
 
 ### Bug Fixes
 
-* Fix for test wrappers generation [#2025](https://github.com/web3j/web3j/pull/2025)
-* Fix Snapshot release secrets [#2031](https://github.com/hyperledger/web3j/pull/2031)
-* Fix Sign method [#2033](https://github.com/hyperledger/web3j/pull/2033)
-* Revert 2031 and 2033 [#2034](https://github.com/hyperledger/web3j/pull/2034)
-* Web3j release fix [#2037](https://github.com/hyperledger/web3j/pull/2037)
-* Fix encodePacked DynamicBytes [2042](https://github.com/hyperledger/web3j/pull/2042)
-* Repo owner changed [#2048](https://github.com/hyperledger/web3j/pull/2048)
+- Fix for test wrappers generation [#2025](https://github.com/web3j/web3j/pull/2025)
+- Fix Snapshot release secrets [#2031](https://github.com/hyperledger/web3j/pull/2031)
+- Fix Sign method [#2033](https://github.com/hyperledger/web3j/pull/2033)
+- Revert 2031 and 2033 [#2034](https://github.com/hyperledger/web3j/pull/2034)
+- Web3j release fix [#2037](https://github.com/hyperledger/web3j/pull/2037)
+- Fix encodePacked DynamicBytes [2042](https://github.com/hyperledger/web3j/pull/2042)
+- Repo owner changed [#2048](https://github.com/hyperledger/web3j/pull/2048)
 
 ### Features
 
-* Bump snapshot version to 4.11.3 [#2024](https://github.com/web3j/web3j/pull/2024)
+- Bump snapshot version to 4.11.3 [#2024](https://github.com/web3j/web3j/pull/2024)
 
 ### BREAKING CHANGES
 
-* Rename default master branch to main. [#2029](https://github.com/hyperledger/web3j/pull/2029)
-
+- Rename default master branch to main. [#2029](https://github.com/hyperledger/web3j/pull/2029)
 
 # [4.11.2](https://github.com/web3j/web3j/releases/tag/v4.11.2) (2024-03-27)
 
 ### Bug Fixes
 
-* Bug fix for large binary with unlink libraries codegen [#2016](https://github.com/web3j/web3j/pull/2016)
-* Fix contract wrapper generation [#2017](https://github.com/web3j/web3j/pull/2017)
-* Fix for test java wrappers with duplicate name [#2020](https://github.com/web3j/web3j/pull/2020)
+- Bug fix for large binary with unlink libraries codegen [#2016](https://github.com/web3j/web3j/pull/2016)
+- Fix contract wrapper generation [#2017](https://github.com/web3j/web3j/pull/2017)
+- Fix for test java wrappers with duplicate name [#2020](https://github.com/web3j/web3j/pull/2020)
 
 ### Features
 
-* Changelog entry and PR template edited [#2021](https://github.com/web3j/web3j/pull/2021)
-* bump snapshot version to 4.11.2  [#2015](https://github.com/web3j/web3j/pull/2015)
-* Enrich generateBothCallAndSend feature in TruffleJsonFunctionWrapperGenerator [#1986](https://github.com/web3j/web3j/pull/1986)
+- Changelog entry and PR template edited [#2021](https://github.com/web3j/web3j/pull/2021)
+- bump snapshot version to 4.11.2 [#2015](https://github.com/web3j/web3j/pull/2015)
+- Enrich generateBothCallAndSend feature in TruffleJsonFunctionWrapperGenerator [#1986](https://github.com/web3j/web3j/pull/1986)
 
 ### BREAKING CHANGES
 
-* 
-
+-
 
 # [4.11.1](https://github.com/web3j/web3j/releases/tag/v4.11.1) (2024-03-14)
 
 ### Bug Fixes
 
-* fix versionedHashes to blobVersionedHashes [#2009](https://github.com/web3j/web3j/pull/2009)
-* Fix typos [#2010](https://github.com/web3j/web3j/pull/2010)
+- fix versionedHashes to blobVersionedHashes [#2009](https://github.com/web3j/web3j/pull/2009)
+- Fix typos [#2010](https://github.com/web3j/web3j/pull/2010)
 
 ### Features
 
-* **EIP-4844:** Calculate baseFeePerBlobGas value and other EIP4844 changes [#2006](https://github.com/web3j/web3j/pull/2006)
-* **EIP-4788:** add parentBeaconBlockRoot field [#2007](https://github.com/web3j/web3j/pull/2007)
-* Add function to link binary with reference libraries in wrappers contract deployment [#1988](https://github.com/web3j/web3j/pull/1988)
-* Added files for repo migration [#2011](https://github.com/web3j/web3j/pull/2011)
+- **EIP-4844:** Calculate baseFeePerBlobGas value and other EIP4844 changes [#2006](https://github.com/web3j/web3j/pull/2006)
+- **EIP-4788:** add parentBeaconBlockRoot field [#2007](https://github.com/web3j/web3j/pull/2007)
+- Add function to link binary with reference libraries in wrappers contract deployment [#1988](https://github.com/web3j/web3j/pull/1988)
+- Added files for repo migration [#2011](https://github.com/web3j/web3j/pull/2011)
 
 ### BREAKING CHANGES
 
-* NIL
-
+- NIL
 
 # [4.11.0](https://github.com/web3j/web3j/compare/v4.10.3...v4.11.0) (2024-02-14)
 
 ### Bug Fixes
 
-* **Integration Tests:** Fixed all the failing and skipped Integration tests specially Besu privacy tests [#1958](https://github.com/web3j/web3j/pull/1958)
-* Fixed Dynamic Arrays encoder [#1961](https://github.com/web3j/web3j/pull/1961)
-* Fixed dynamic arrays decoder [#1974](https://github.com/web3j/web3j/pull/1974)
-* Fixed generateJavaFiles ArrayInStruct [#1962](https://github.com/web3j/web3j/pull/1962)
-* Fixed encoding of structs without members [#1968](https://github.com/web3j/web3j/pull/1968)
-* Fixed java reserved words codegen errors [#1975](https://github.com/web3j/web3j/pull/1975)
+- **Integration Tests:** Fixed all the failing and skipped Integration tests specially Besu privacy tests [#1958](https://github.com/web3j/web3j/pull/1958)
+- Fixed Dynamic Arrays encoder [#1961](https://github.com/web3j/web3j/pull/1961)
+- Fixed dynamic arrays decoder [#1974](https://github.com/web3j/web3j/pull/1974)
+- Fixed generateJavaFiles ArrayInStruct [#1962](https://github.com/web3j/web3j/pull/1962)
+- Fixed encoding of structs without members [#1968](https://github.com/web3j/web3j/pull/1968)
+- Fixed java reserved words codegen errors [#1975](https://github.com/web3j/web3j/pull/1975)
 
 ### Features
 
-* **EIP-4844:** Added Support for sending EIP-4844 Blob Transactions [#2000](https://github.com/web3j/web3j/pull/2000)
-* Added yParity for Geth compatibility [#1959](https://github.com/web3j/web3j/pull/1959)
-* Sepolia network added [#1971](https://github.com/web3j/web3j/pull/1971)
-* Adding support for EIP1559 Private Transactions [#1980](https://github.com/web3j/web3j/pull/1980)
-* Add AccessList to 1559 transaction rlp encoding [#1992](https://github.com/web3j/web3j/pull/1992)
+- **EIP-4844:** Added Support for sending EIP-4844 Blob Transactions [#2000](https://github.com/web3j/web3j/pull/2000)
+- Added yParity for Geth compatibility [#1959](https://github.com/web3j/web3j/pull/1959)
+- Sepolia network added [#1971](https://github.com/web3j/web3j/pull/1971)
+- Adding support for EIP1559 Private Transactions [#1980](https://github.com/web3j/web3j/pull/1980)
+- Add AccessList to 1559 transaction rlp encoding [#1992](https://github.com/web3j/web3j/pull/1992)
 
 ### BREAKING CHANGES
 
-* NIL
+- NIL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 - Add support for EIP-7594 blob transaction wrapper [#2263](https://github.com/LFDT-web3j/web3j/pull/2263)
-- Full EIP-7594 tx and Kzg cell proof generation [#2295](https://github.com/LFDT-web3j/web3j/pull/2295)
+- Full EIP-7594 tx and Kzg cell proof generation [#2296](https://github.com/LFDT-web3j/web3j/pull/2296)
 
 ### BREAKING CHANGES
 
@@ -28,11 +28,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- Add support for EIP-7594 blob transaction wrapper (#2263)
+- ens: route resolve() through the Universal Resolver (ENSv2 readiness) [#2283](https://github.com/LFDT-web3j/web3j/pull/2283)
 
 ### BREAKING CHANGES
 
--
+- update Jackson imports to use tools.jackson package [#2285](https://github.com/LFDT-web3j/web3j/pull/2285)
 
 # [5.0.2](https://github.com/LFDT-web3j/web3j/releases/tag/v5.0.2) (2026-01-21)
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     javaWebSocketVersion = '1.5.6'
     picocliVersion = '4.7.6'
     ensAdraffyVersion = '0.2.0'
-    kzg4844Version = '2.0.0'
+    kzg4844Version = '2.1.6'
     awsSdkVersion = '2.27.24'
     tuweniVersion = '2.7.0'
     // test dependencies

--- a/crypto/src/main/java/org/web3j/crypto/BlobUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/BlobUtils.java
@@ -63,10 +63,10 @@ public class BlobUtils {
     }
 
     /**
-     * Computes the EIP-7594 cell proofs for multiple blobs as a single flat list in <strong>blob-major
-     * order</strong>: {@code [blob0.proof0..127, blob1.proof0..127, ...]}, total {@code
-     * CELLS_PER_EXT_BLOB * blobs.size()} proofs. This is the exact layout the EIP-7594 network wrapper
-     * expects for its flat {@code cell_proofs} field.
+     * Computes the EIP-7594 cell proofs for multiple blobs as a single flat list in
+     * <strong>blob-major order</strong>: {@code [blob0.proof0..127, blob1.proof0..127, ...]}, total
+     * {@code CELLS_PER_EXT_BLOB * blobs.size()} proofs. This is the exact layout the EIP-7594
+     * network wrapper expects for its flat {@code cell_proofs} field.
      *
      * @param blobs the blobs to compute cell proofs for
      * @return the flat, blob-major list of cell proofs
@@ -80,13 +80,14 @@ public class BlobUtils {
     }
 
     /**
-     * Verifies a flat, blob-major list of EIP-7594 cell proofs against the blobs and their commitments
-     * using {@link CKZG4844JNI#verifyCellKzgProofBatch}. The cells are recomputed from the blobs.
+     * Verifies a flat, blob-major list of EIP-7594 cell proofs against the blobs and their
+     * commitments using {@link CKZG4844JNI#verifyCellKzgProofBatch}. The cells are recomputed from
+     * the blobs.
      *
      * @param blobs the blobs
      * @param commitments one 48-byte KZG commitment per blob
-     * @param cellProofs the flat {@code CELLS_PER_EXT_BLOB * blobs.size()} cell proofs in blob-major
-     *     order (as produced by {@link #getCellProofs(List)})
+     * @param cellProofs the flat {@code CELLS_PER_EXT_BLOB * blobs.size()} cell proofs in
+     *     blob-major order (as produced by {@link #getCellProofs(List)})
      * @return true if every cell proof verifies
      */
     public static boolean checkCellProofsValidity(

--- a/crypto/src/main/java/org/web3j/crypto/BlobUtils.java
+++ b/crypto/src/main/java/org/web3j/crypto/BlobUtils.java
@@ -12,7 +12,12 @@
  */
 package org.web3j.crypto;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import ethereum.ckzg4844.CKZG4844JNI;
+import ethereum.ckzg4844.CellsAndProofs;
 import org.apache.tuweni.bytes.Bytes;
 
 public class BlobUtils {
@@ -42,6 +47,100 @@ public class BlobUtils {
     public static boolean checkProofValidity(Blob blobData, Bytes commitment, Bytes proof) {
         return CKZG4844JNI.verifyBlobKzgProof(
                 blobData.data.toArray(), commitment.toArray(), proof.toArray());
+    }
+
+    /**
+     * Computes the EIP-7594 (PeerDAS) cell proofs for a single blob: a flat list of {@code
+     * CELLS_PER_EXT_BLOB} (128) 48-byte KZG proofs, one per cell of the extended blob.
+     *
+     * @param blobData the blob to compute cell proofs for
+     * @return the 128 cell proofs for this blob, in cell-index order
+     */
+    public static List<Bytes> getCellProofs(Blob blobData) {
+        CellsAndProofs cellsAndProofs =
+                CKZG4844JNI.computeCellsAndKzgProofs(blobData.data.toArray());
+        return splitFlatProofs(cellsAndProofs.getProofs());
+    }
+
+    /**
+     * Computes the EIP-7594 cell proofs for multiple blobs as a single flat list in <strong>blob-major
+     * order</strong>: {@code [blob0.proof0..127, blob1.proof0..127, ...]}, total {@code
+     * CELLS_PER_EXT_BLOB * blobs.size()} proofs. This is the exact layout the EIP-7594 network wrapper
+     * expects for its flat {@code cell_proofs} field.
+     *
+     * @param blobs the blobs to compute cell proofs for
+     * @return the flat, blob-major list of cell proofs
+     */
+    public static List<Bytes> getCellProofs(List<Blob> blobs) {
+        List<Bytes> all = new ArrayList<>(CKZG4844JNI.CELLS_PER_EXT_BLOB * blobs.size());
+        for (Blob blob : blobs) {
+            all.addAll(getCellProofs(blob));
+        }
+        return all;
+    }
+
+    /**
+     * Verifies a flat, blob-major list of EIP-7594 cell proofs against the blobs and their commitments
+     * using {@link CKZG4844JNI#verifyCellKzgProofBatch}. The cells are recomputed from the blobs.
+     *
+     * @param blobs the blobs
+     * @param commitments one 48-byte KZG commitment per blob
+     * @param cellProofs the flat {@code CELLS_PER_EXT_BLOB * blobs.size()} cell proofs in blob-major
+     *     order (as produced by {@link #getCellProofs(List)})
+     * @return true if every cell proof verifies
+     */
+    public static boolean checkCellProofsValidity(
+            List<Blob> blobs, List<Bytes> commitments, List<Bytes> cellProofs) {
+        int cellsPerBlob = CKZG4844JNI.CELLS_PER_EXT_BLOB;
+        int totalCells = cellsPerBlob * blobs.size();
+
+        long[] cellIndices = new long[totalCells];
+        byte[] commitmentsBytes = new byte[totalCells * CKZG4844JNI.BYTES_PER_COMMITMENT];
+        byte[] cellsBytes = new byte[totalCells * CKZG4844JNI.BYTES_PER_CELL];
+        byte[] proofsBytes = new byte[totalCells * CKZG4844JNI.BYTES_PER_PROOF];
+
+        for (int b = 0; b < blobs.size(); b++) {
+            CellsAndProofs cellsAndProofs =
+                    CKZG4844JNI.computeCellsAndKzgProofs(blobs.get(b).data.toArray());
+            System.arraycopy(
+                    cellsAndProofs.getCells(),
+                    0,
+                    cellsBytes,
+                    b * cellsPerBlob * CKZG4844JNI.BYTES_PER_CELL,
+                    cellsPerBlob * CKZG4844JNI.BYTES_PER_CELL);
+
+            byte[] commitment = commitments.get(b).toArray();
+            for (int i = 0; i < cellsPerBlob; i++) {
+                int cellGlobal = b * cellsPerBlob + i;
+                cellIndices[cellGlobal] = i;
+                System.arraycopy(
+                        commitment,
+                        0,
+                        commitmentsBytes,
+                        cellGlobal * CKZG4844JNI.BYTES_PER_COMMITMENT,
+                        CKZG4844JNI.BYTES_PER_COMMITMENT);
+                System.arraycopy(
+                        cellProofs.get(cellGlobal).toArray(),
+                        0,
+                        proofsBytes,
+                        cellGlobal * CKZG4844JNI.BYTES_PER_PROOF,
+                        CKZG4844JNI.BYTES_PER_PROOF);
+            }
+        }
+
+        return CKZG4844JNI.verifyCellKzgProofBatch(
+                commitmentsBytes, cellIndices, cellsBytes, proofsBytes);
+    }
+
+    /** Splits the flat per-blob proofs byte array into {@code CELLS_PER_EXT_BLOB} equal chunks. */
+    private static List<Bytes> splitFlatProofs(byte[] flatProofs) {
+        int cells = CKZG4844JNI.CELLS_PER_EXT_BLOB;
+        int chunk = flatProofs.length / cells; // == BYTES_PER_PROOF (48)
+        List<Bytes> proofs = new ArrayList<>(cells);
+        for (int i = 0; i < cells; i++) {
+            proofs.add(Bytes.wrap(Arrays.copyOfRange(flatProofs, i * chunk, (i + 1) * chunk)));
+        }
+        return proofs;
     }
 
     public static Bytes kzgToVersionedHash(Bytes commitment) {

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -201,8 +201,8 @@ public class RawTransaction {
     }
 
     /**
-     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs. The KZG commitments,
-     * flat cell proofs, and blob versioned hashes are computed automatically.
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs. The KZG
+     * commitments, flat cell proofs, and blob versioned hashes are computed automatically.
      *
      * @param blobs the raw blobs
      */
@@ -233,8 +233,8 @@ public class RawTransaction {
     }
 
     /**
-     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs, with an access list.
-     * The KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs, with an access
+     * list. The KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
      *
      * @param blobs the raw blobs
      * @param accessList optional EIP-2930 access list

--- a/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
+++ b/crypto/src/main/java/org/web3j/crypto/RawTransaction.java
@@ -200,6 +200,73 @@ public class RawTransaction {
                         maxFeePerBlobGas));
     }
 
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs. The KZG commitments,
+     * flat cell proofs, and blob versioned hashes are computed automatically.
+     *
+     * @param blobs the raw blobs
+     */
+    public static RawTransaction createEip7594Transaction(
+            List<Blob> blobs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas) {
+
+        return new RawTransaction(
+                Transaction4844.createEip7594Transaction(
+                        blobs,
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxFeePerBlobGas));
+    }
+
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) blob transaction directly from raw blobs, with an access list.
+     * The KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
+     *
+     * @param blobs the raw blobs
+     * @param accessList optional EIP-2930 access list
+     */
+    public static RawTransaction createEip7594Transaction(
+            List<Blob> blobs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<AccessListObject> accessList) {
+
+        return new RawTransaction(
+                Transaction4844.createEip7594Transaction(
+                        blobs,
+                        chainId,
+                        nonce,
+                        maxPriorityFeePerGas,
+                        maxFeePerGas,
+                        gasLimit,
+                        to,
+                        value,
+                        data,
+                        maxFeePerBlobGas,
+                        accessList));
+    }
+
     public static RawTransaction createTransaction(
             List<Blob> blobs,
             List<Bytes> kzgCommitments,

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -753,9 +753,9 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
     }
 
     /**
-     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs. The KZG commitments, the
-     * flat {@code CELLS_PER_EXT_BLOB * len(blobs)} cell proofs, and the blob versioned hashes are all
-     * computed automatically via {@link BlobUtils}.
+     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs. The KZG commitments,
+     * the flat {@code CELLS_PER_EXT_BLOB * len(blobs)} cell proofs, and the blob versioned hashes
+     * are all computed automatically via {@link BlobUtils}.
      *
      * @param blobs the raw blobs
      */
@@ -785,8 +785,8 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
     }
 
     /**
-     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs, with an access list. The
-     * KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
+     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs, with an access list.
+     * The KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
      *
      * @param blobs the raw blobs
      * @param accessList optional EIP-2930 access list

--- a/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
+++ b/crypto/src/main/java/org/web3j/crypto/transaction/type/Transaction4844.java
@@ -267,6 +267,59 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
         this.cellProofs = Optional.empty();
     }
 
+    // -------------------------------------------------------------------------
+    // Constructor 5: auto-compute commitments + cell proofs from raw blobs (EIP-7594)
+    //   The leading wrapperVersion param differentiates this from Constructor 4.
+    // -------------------------------------------------------------------------
+    protected Transaction4844(
+            List<Blob> blobsData,
+            BigInteger wrapperVersion,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<AccessListObject> accessList) {
+        super(
+                chainId,
+                nonce,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                accessList != null ? accessList : Collections.emptyList());
+        this.maxFeePerBlobGas = Objects.requireNonNull(maxFeePerBlobGas, "maxFeePerBlobGas");
+
+        if (blobsData == null) {
+            throw new IllegalArgumentException("blobsData must not be null");
+        }
+
+        this.blobs = Optional.of(blobsData);
+
+        List<Bytes> commitments =
+                blobsData.stream().map(BlobUtils::getCommitment).collect(Collectors.toList());
+        this.kzgCommitments = Optional.of(commitments);
+
+        // EIP-7594: flat, blob-major list of CELLS_PER_EXT_BLOB * blobCount cell proofs.
+        this.cellProofs = Optional.of(BlobUtils.getCellProofs(blobsData));
+        this.kzgProofs = Optional.empty(); // EIP-7594 does not use per-blob kzgProofs
+
+        this.versionedHashes =
+                commitments.stream()
+                        .map(BlobUtils::kzgToVersionedHash)
+                        .collect(Collectors.toList());
+
+        this.wrapperVersion = Optional.of(WRAPPER_VERSION_1);
+
+        validateEip7594Sidecar();
+    }
+
     // =========================================================================
     // Validation helpers
     // =========================================================================
@@ -697,6 +750,72 @@ public class Transaction4844 extends Transaction1559 implements ITransaction {
                 value,
                 data,
                 maxFeePerBlobGas);
+    }
+
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs. The KZG commitments, the
+     * flat {@code CELLS_PER_EXT_BLOB * len(blobs)} cell proofs, and the blob versioned hashes are all
+     * computed automatically via {@link BlobUtils}.
+     *
+     * @param blobs the raw blobs
+     */
+    public static Transaction4844 createEip7594Transaction(
+            List<Blob> blobs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas) {
+        return createEip7594Transaction(
+                blobs,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                Collections.emptyList());
+    }
+
+    /**
+     * Create an EIP-7594 (Osaka/Fusaka) transaction directly from raw blobs, with an access list. The
+     * KZG commitments, flat cell proofs, and versioned hashes are computed automatically.
+     *
+     * @param blobs the raw blobs
+     * @param accessList optional EIP-2930 access list
+     */
+    public static Transaction4844 createEip7594Transaction(
+            List<Blob> blobs,
+            long chainId,
+            BigInteger nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            String data,
+            BigInteger maxFeePerBlobGas,
+            List<AccessListObject> accessList) {
+        return new Transaction4844(
+                blobs,
+                WRAPPER_VERSION_1,
+                chainId,
+                nonce,
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                to,
+                value,
+                data,
+                maxFeePerBlobGas,
+                accessList);
     }
 
     /** Create a tx-only EIP-4844 transaction (no sidecar, versioned hashes only). */

--- a/crypto/src/test/java/org/web3j/crypto/BlobUtilsTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/BlobUtilsTest.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import ethereum.ckzg4844.CKZG4844JNI;
@@ -28,10 +29,12 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;
 
+import org.web3j.crypto.transaction.type.Transaction4844;
 import org.web3j.utils.Numeric;
 
 import static java.util.stream.IntStream.range;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BlobUtilsTest {
@@ -39,25 +42,22 @@ public class BlobUtilsTest {
 
     @Test
     public void testBlobToCommitmentProofVersionedHashes() throws Exception {
-        CKZG4844JNI.loadNativeLibrary();
-        CKZG4844JNI.loadTrustedSetupFromResource("/trusted_setup.txt", BlobUtils.class, 0);
-
+        // Use the shared trusted setup loaded once by BlobUtils' static initializer (do not
+        // manually load/free it here — that conflicts with every other BlobUtils-based test).
         Blob blob =
                 new Blob(
                         Numeric.hexStringToByteArray(
                                 loadResourceAsString("blob_data/blob_data_1.txt")));
-        byte[] commitment = CKZG4844JNI.blobToKzgCommitment(blob.getData().toArray());
-        byte[] proofs = CKZG4844JNI.computeBlobKzgProof(blob.getData().toArray(), commitment);
+        Bytes commitment = BlobUtils.getCommitment(blob);
+        Bytes proofs = BlobUtils.getProof(blob, commitment);
 
-        assertTrue(CKZG4844JNI.verifyBlobKzgProof(blob.data.toArray(), commitment, proofs));
+        assertTrue(BlobUtils.checkProofValidity(blob, commitment, proofs));
         assertEquals(
                 "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                Numeric.toHexString(commitment));
+                commitment.toHexString());
         assertEquals(
                 "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                Numeric.toHexString(proofs));
-
-        CKZG4844JNI.freeTrustedSetup();
+                proofs.toHexString());
     }
 
     @Test
@@ -80,6 +80,90 @@ public class BlobUtilsTest {
         assertEquals(
                 "0x018ef96865998238a5e1783b6cafbc1253235d636f15d318f1fb50ef6a5b8f6a",
                 versionedHashes.toHexString());
+    }
+
+    @Test
+    public void testGetCellProofsSingleBlob() throws Exception {
+        Blob blob =
+                new Blob(
+                        Numeric.hexStringToByteArray(
+                                loadResourceAsString("blob_data/blob_data_1.txt")));
+
+        List<Bytes> cellProofs = BlobUtils.getCellProofs(blob);
+
+        assertEquals(
+                Transaction4844.CELLS_PER_EXT_BLOB,
+                cellProofs.size(),
+                "a single blob must yield CELLS_PER_EXT_BLOB (128) cell proofs");
+        for (Bytes proof : cellProofs) {
+            assertEquals(
+                    Transaction4844.KZG_PROOF_BYTE_LENGTH,
+                    proof.size(),
+                    "each cell proof must be 48 bytes");
+        }
+    }
+
+    @Test
+    public void testCheckCellProofsValidity() throws Exception {
+        // Use the non-trivial blob (blob_data_2) so its 128 cell proofs are distinct — a zero blob
+        // would have identical proofs, making the mis-assignment negative case a no-op.
+        Blob blob =
+                new Blob(
+                        Numeric.hexStringToByteArray(
+                                loadResourceAsString("blob_data/blob_data_2.txt")));
+        Bytes commitment = BlobUtils.getCommitment(blob);
+        List<Bytes> cellProofs = BlobUtils.getCellProofs(blob);
+
+        assertTrue(
+                BlobUtils.checkCellProofsValidity(
+                        java.util.Collections.singletonList(blob),
+                        java.util.Collections.singletonList(commitment),
+                        cellProofs),
+                "freshly generated cell proofs must verify");
+
+        // Mis-assign two proofs (both still valid G1 points, but for the wrong cells): the batch
+        // must now fail verification cleanly (rather than throwing on a malformed point).
+        Bytes p0 = cellProofs.get(0);
+        cellProofs.set(0, cellProofs.get(1));
+        cellProofs.set(1, p0);
+        assertFalse(
+                BlobUtils.checkCellProofsValidity(
+                        java.util.Collections.singletonList(blob),
+                        java.util.Collections.singletonList(commitment),
+                        cellProofs),
+                "mis-assigned cell proofs must fail verification");
+    }
+
+    @Test
+    public void testGetCellProofsMultiBlobOrdering() throws Exception {
+        Blob blobA =
+                new Blob(
+                        Numeric.hexStringToByteArray(
+                                loadResourceAsString("blob_data/blob_data_1.txt")));
+        Blob blobB =
+                new Blob(
+                        Numeric.hexStringToByteArray(
+                                loadResourceAsString("blob_data/blob_data_2.txt")));
+
+        List<Bytes> proofsA = BlobUtils.getCellProofs(blobA);
+        List<Bytes> proofsB = BlobUtils.getCellProofs(blobB);
+        List<Bytes> combined = BlobUtils.getCellProofs(Arrays.asList(blobA, blobB));
+
+        int cells = Transaction4844.CELLS_PER_EXT_BLOB;
+        assertEquals(2 * cells, combined.size(), "two blobs must yield 256 cell proofs");
+        // Blob-major order: first 128 == blobA's proofs, next 128 == blobB's proofs.
+        assertEquals(proofsA, combined.subList(0, cells));
+        assertEquals(proofsB, combined.subList(cells, 2 * cells));
+
+        // Cross-check the combined flat list verifies as a batch.
+        Bytes commitmentA = BlobUtils.getCommitment(blobA);
+        Bytes commitmentB = BlobUtils.getCommitment(blobB);
+        assertTrue(
+                BlobUtils.checkCellProofsValidity(
+                        Arrays.asList(blobA, blobB),
+                        Arrays.asList(commitmentA, commitmentB),
+                        combined),
+                "blob-major batch of cell proofs must verify");
     }
 
     public static String loadResourceAsString(String filePath) throws Exception {

--- a/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
+++ b/crypto/src/test/java/org/web3j/crypto/Eip7594TransactionTest.java
@@ -952,4 +952,116 @@ public class Eip7594TransactionTest {
         RlpList outer = bodyWithFields(5);
         assertThrows(IllegalArgumentException.class, () -> decodeType3(outer));
     }
+
+    // =========================================================================
+    // 19. End-to-end: build a valid EIP-7594 tx directly from raw blobs
+    //     (commitments, cell proofs, and versioned hashes auto-computed via
+    //     BlobUtils / jc-kzg). Uses REAL proofs, not the zero-filled dummies.
+    // =========================================================================
+
+    @Test
+    public void testBuildEip7594FromRawBlobs() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        int blobCount = 2;
+        RawTransaction rawTx =
+                RawTransaction.createEip7594Transaction(
+                        blobs(blobCount),
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN);
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+        assertTrue(tx.getWrapperVersion().isPresent());
+        assertEquals(BigInteger.ONE, tx.getWrapperVersion().get());
+        assertFalse(
+                tx.getKzgProofs().isPresent() && !tx.getKzgProofs().get().isEmpty(),
+                "EIP-7594 tx must not carry per-blob kzgProofs");
+
+        assertTrue(tx.getCellProofs().isPresent());
+        assertEquals(CELLS_PER_EXT_BLOB * blobCount, tx.getCellProofs().get().size());
+        for (Bytes proof : tx.getCellProofs().get()) {
+            assertEquals(PROOF_BYTES, proof.size());
+        }
+
+        // Commitments auto-derived (48 bytes each), versioned hashes start with 0x01.
+        assertTrue(tx.getKzgCommitments().isPresent());
+        assertEquals(blobCount, tx.getKzgCommitments().get().size());
+        for (Bytes commitment : tx.getKzgCommitments().get()) {
+            assertEquals(PROOF_BYTES, commitment.size());
+        }
+        assertEquals(blobCount, tx.getVersionedHashes().size());
+        for (Bytes vh : tx.getVersionedHashes()) {
+            assertEquals(
+                    0x01, vh.toArray()[0] & 0xff, "versioned hash must use KZG version byte 0x01");
+        }
+    }
+
+    @Test
+    public void testEip7594RawBlobsProofIntegrityRoundTrip() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+
+        int blobCount = 2;
+        RawTransaction rawTx =
+                RawTransaction.createEip7594Transaction(
+                        blobs(blobCount),
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN);
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+
+        // The proofs that survived RLP encode/decode must still verify against the blobs.
+        assertTrue(
+                BlobUtils.checkCellProofsValidity(
+                        tx.getBlobs().get(),
+                        tx.getKzgCommitments().get(),
+                        tx.getCellProofs().get()),
+                "decoded cell proofs must remain cryptographically valid");
+    }
+
+    @Test
+    public void testCreateEip7594FromRawBlobsWithAccessList() throws Exception {
+        Credentials credentials = Credentials.create(PRIVATE_KEY);
+        List<AccessListObject> accessList = sampleAccessList();
+
+        RawTransaction rawTx =
+                RawTransaction.createEip7594Transaction(
+                        blobs(1),
+                        1L,
+                        BigInteger.ZERO,
+                        BigInteger.TEN,
+                        BigInteger.TEN,
+                        BigInteger.valueOf(21000),
+                        TO_ADDRESS,
+                        BigInteger.ZERO,
+                        "",
+                        BigInteger.TEN,
+                        accessList);
+
+        byte[] signed = TransactionEncoder.signMessage(rawTx, credentials);
+        RawTransaction decoded = TransactionDecoder.decode(Numeric.toHexString(signed));
+        Transaction4844 tx = (Transaction4844) decoded.getTransaction();
+
+        assertEquals(BigInteger.ONE, tx.getWrapperVersion().get());
+        assertEquals(CELLS_PER_EXT_BLOB, tx.getCellProofs().get().size());
+        assertAccessListEquals(accessList, tx.getAccessList());
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.web3j
-version=5.0.3-SNAPSHOT
+version=5.0.4-SNAPSHOT
 org.gradle.caching=true
 org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn


### PR DESCRIPTION
### What does this PR do?
Fusaka update PR
adds the capability to generate Kzg cell proof within Web3j

### Where should the reviewer start?
Review all files

### Why is it needed?
In PR - https://github.com/LFDT-web3j/web3j/pull/2263 we only had the option to send EIP-7594 tx with self created kzg cell proofs. In this PR we added the ability to do this within Web3j with `RawTransaction.createEip7594Transaction()` function

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.